### PR TITLE
fix: Windows secrets path mismatch between CLI and daemon

### DIFF
--- a/src/secrets/keychain.ts
+++ b/src/secrets/keychain.ts
@@ -371,10 +371,15 @@ export function createKeychain(): SecretStore {
     case "darwin":
       return createMacKeychain();
     case "windows": {
-      const localAppData = Deno.env.get("LOCALAPPDATA") ??
-        Deno.env.get("USERPROFILE") ?? ".";
-      const secretsPath = join(localAppData, "Triggerfish", "secrets.json");
-      return createFileSecretStore({ path: secretsPath });
+      // Store secrets alongside triggerfish.yaml so the Windows Service
+      // (which runs under a different account) resolves the same path
+      // as the interactive CLI user.
+      const dataDir = Deno.env.get("TRIGGERFISH_DATA_DIR") ??
+        join(
+          Deno.env.get("HOME") ?? Deno.env.get("USERPROFILE") ?? ".",
+          ".triggerfish",
+        );
+      return createFileSecretStore({ path: join(dataDir, "secrets.json") });
     }
     default:
       return createMemorySecretStore();


### PR DESCRIPTION
## Summary
- Windows Service runs under a different account than the interactive user, so `%LOCALAPPDATA%` resolves to different directories
- Move secrets storage from `%LOCALAPPDATA%\Triggerfish\secrets.json` to `~/.triggerfish/secrets.json` (the shared data dir that both CLI and daemon already agree on)
- Fixes Google OAuth token persistence AND GitHub PAT persistence on Windows

## Test plan
- [x] `triggerfish connect google` stores token in `~/.triggerfish/secrets.json`
- [x] Daemon reads from the same path
- [x] `deno task test tests/deploy/secrets_test.ts` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)