### PR TITLE
fix: prompt daemon restart after config set

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -2458,6 +2458,35 @@ function getNestedValue(
 }
 
 /**
+ * Prompt the user to restart the daemon if it's running.
+ * Shared by config set, add-channel, and add-plugin commands.
+ */
+async function promptDaemonRestart(): Promise<void> {
+  const status = await getDaemonStatus();
+  if (status.running) {
+    const restart = await Confirm.prompt({
+      message: "Restart daemon to apply?",
+      default: true,
+    });
+    if (restart) {
+      const stopResult = await stopDaemon();
+      if (!stopResult.ok) {
+        console.log(`✗ Failed to stop daemon: ${stopResult.message}`);
+        return;
+      }
+      const startResult = await installAndStartDaemon(Deno.execPath());
+      if (startResult.ok) {
+        console.log("✓ Daemon restarted");
+      } else {
+        console.log(`✗ ${startResult.message}`);
+      }
+    }
+  } else {
+    console.log("Daemon is not running. Start it with: triggerfish start");
+  }
+}
+
+/**
  * Set a config value in triggerfish.yaml by dotted key path.
  */
 async function runConfigSet(
@@ -2504,6 +2533,8 @@ async function runConfigSet(
       : String(value);
 
   console.log(`\n  ${key} = ${display}\n`);
+
+  await promptDaemonRestart();
 }
 
 /**
@@ -2735,29 +2766,7 @@ async function runConfigAddChannel(
 
   console.log(`\n✓ ${channelType} added to triggerfish.yaml`);
 
-  // Offer daemon restart
-  const status = await getDaemonStatus();
-  if (status.running) {
-    const restart = await Confirm.prompt({
-      message: "Restart daemon to apply?",
-      default: true,
-    });
-    if (restart) {
-      const stopResult = await stopDaemon();
-      if (!stopResult.ok) {
-        console.log(`✗ Failed to stop daemon: ${stopResult.message}`);
-        return;
-      }
-      const startResult = await installAndStartDaemon(Deno.execPath());
-      if (startResult.ok) {
-        console.log("✓ Daemon restarted");
-      } else {
-        console.log(`✗ ${startResult.message}`);
-      }
-    }
-  } else {
-    console.log("Daemon is not running. Start it with: triggerfish start");
-  }
+  await promptDaemonRestart();
 }
 
 /**
@@ -2834,29 +2843,7 @@ async function runConfigAddPlugin(
 
   console.log(`\n✓ ${pluginType} plugin added to triggerfish.yaml`);
 
-  // Offer daemon restart
-  const status = await getDaemonStatus();
-  if (status.running) {
-    const restart = await Confirm.prompt({
-      message: "Restart daemon to apply?",
-      default: true,
-    });
-    if (restart) {
-      const stopResult = await stopDaemon();
-      if (!stopResult.ok) {
-        console.log(`✗ Failed to stop daemon: ${stopResult.message}`);
-        return;
-      }
-      const startResult = await installAndStartDaemon(Deno.execPath());
-      if (startResult.ok) {
-        console.log("✓ Daemon restarted");
-      } else {
-        console.log(`✗ ${startResult.message}`);
-      }
-    }
-  } else {
-    console.log("Daemon is not running. Start it with: triggerfish start");
-  }
+  await promptDaemonRestart();
 }
 
 /**


### PR DESCRIPTION
## Summary
- Extracts duplicated daemon restart logic into shared `promptDaemonRestart()` helper
- Adds restart prompt to `triggerfish config set` command (was missing)
- Replaces inline restart code in `add-channel` and `add-plugin` with the shared helper

Closes #4

## Test plan
- [x] Run `triggerfish config set agent.name test` with daemon running — should prompt restart
- [x] Run `triggerfish config add-channel telegram` — restart prompt still works
- [x] Run `triggerfish config add-plugin obsidian` — restart prompt still works
- [x] Run `triggerfish config set` with daemon stopped — should say "Daemon is not running"

🤖 Generated with [Claude Code](https://claude.com/claude-code)