### PR TITLE
fix: add delay after Windows service stop/start for reliable restart

### DIFF
--- a/src/cli/daemon.ts
+++ b/src/cli/daemon.ts
@@ -334,8 +334,11 @@ export async function installAndStartDaemon(
       return { ok: true, message: `Daemon is already running (Windows Service: ${WINDOWS_SERVICE_NAME})` };
     }
 
-    // Start the service (needs elevation)
-    const startScript = `Start-Service -Name '${WINDOWS_SERVICE_NAME}' -ErrorAction Stop`;
+    // Start the service (needs elevation) and wait briefly for it to settle
+    const startScript = [
+      `Start-Service -Name '${WINDOWS_SERVICE_NAME}' -ErrorAction Stop`,
+      `Start-Sleep -Seconds 2`,
+    ].join("; ");
     const encoded = encodeUtf16Base64(startScript);
     await runElevatedCommand(encoded);
 
@@ -374,7 +377,12 @@ export async function stopDaemon(): Promise<DaemonResult> {
   }
 
   if (manager === "windows-service") {
-    const stopScript = `Stop-Service -Name '${WINDOWS_SERVICE_NAME}' -Force -ErrorAction Stop`;
+    // Include a 2-second delay after stopping to let the service release
+    // file locks before any subsequent binary replacement or restart.
+    const stopScript = [
+      `Stop-Service -Name '${WINDOWS_SERVICE_NAME}' -Force -ErrorAction Stop`,
+      `Start-Sleep -Seconds 2`,
+    ].join("; ");
     const encoded = encodeUtf16Base64(stopScript);
 
     await runElevatedCommand(encoded);


### PR DESCRIPTION
## Summary
- Adds `Start-Sleep -Seconds 2` after `Stop-Service` in `stopDaemon()` to let file locks release before binary replacement
- Adds `Start-Sleep -Seconds 2` after `Start-Service` in `installAndStartDaemon()` for reliable status verification
- Matches the pattern already used in `uninstallDaemon()` and install scripts

Closes #10

## Test plan
- [ ] On Windows: run `triggerfish update` — daemon should auto-restart after update
- [ ] On Windows: run `triggerfish stop && triggerfish start` — verify clean stop/start cycle
- [ ] On Linux/macOS: verify no behavioral change (systemd/launchd paths unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)