### PR TITLE
fix: correct Google Workspace setup URL to trigger.fish

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -4591,7 +4591,7 @@ async function runConnectGoogle(): Promise<void> {
   );
   console.log('       or you\'ll get "Access blocked" when authorizing.');
   console.log(
-    "       Full walkthrough: https://triggerfish.dev/integrations/google-workspace",
+    "       Full walkthrough: https://trigger.fish/integrations/google-workspace.html#google-workspace",
   );
   console.log(
     '    6. On the Create OAuth client ID screen, select "Desktop app" from',

--- a/src/dive/wizard.ts
+++ b/src/dive/wizard.ts
@@ -600,7 +600,7 @@ export async function runWizard(baseDir: string): Promise<DiveResult> {
     );
     console.log('       or you\'ll get "Access blocked" when authorizing.');
     console.log(
-      "       Full walkthrough: https://triggerfish.dev/integrations/google-workspace",
+      "       Full walkthrough: https://trigger.fish/integrations/google-workspace.html#google-workspace",
     );
     console.log(
       '    6. On the Create OAuth client ID screen, select "Desktop app" from',


### PR DESCRIPTION
## Summary
- Updates Google Workspace walkthrough URL from `triggerfish.dev` to `trigger.fish`
- Fixed in both `src/dive/wizard.ts` and `src/cli/main.ts`

Closes #16

## Test plan
- [x] Run `triggerfish dive` — Google step should show `https://trigger.fish/integrations/google-workspace.html#google-workspace`
- [x] Run `triggerfish connect google` — same correct URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)