### PR TITLE
feat: create default TRIGGER.md during dive wizard setup

### DIFF
--- a/src/dive/mod.ts
+++ b/src/dive/mod.ts
@@ -23,6 +23,7 @@ export {
   type DiveResult,
   generateConfig,
   generateSpine,
+  generateTrigger,
   type ProviderChoice,
   runWizard,
   type ToneChoice,

--- a/src/dive/wizard.ts
+++ b/src/dive/wizard.ts
@@ -257,6 +257,16 @@ function getToneGuidelines(tone: ToneChoice, customTone: string): string {
   }
 }
 
+/** Generate a default TRIGGER.md with a minimal starting template. */
+export function generateTrigger(): string {
+  return `# Check on each wakeup
+
+- Any unread messages older than 1 hour
+- Calendar events in the next 4 hours
+- Anything urgent in email
+`;
+}
+
 // ─── Directory setup (side-effectful) ────────────────────────────────────────
 
 /** Create the ~/.triggerfish directory tree. */
@@ -829,6 +839,17 @@ export async function runWizard(baseDir: string): Promise<DiveResult> {
   const spineContent = generateSpine(answers);
   await Deno.writeTextFile(spinePath, spineContent);
   console.log(`  ✓ Created: ${spinePath}`);
+
+  // Write TRIGGER.md (only if it doesn't already exist)
+  const triggerPath = join(baseDir, "TRIGGER.md");
+  try {
+    await Deno.stat(triggerPath);
+    // Already exists — don't overwrite
+  } catch {
+    const triggerContent = generateTrigger();
+    await Deno.writeTextFile(triggerPath, triggerContent);
+    console.log(`  ✓ Created: ${triggerPath}`);
+  }
 
   if (apiKey.length > 0) {
     console.log(`  ✓ API key saved to triggerfish.yaml`);


### PR DESCRIPTION
## Summary
- Adds `generateTrigger()` that creates a minimal starter TRIGGER.md
- Dive wizard now writes TRIGGER.md alongside SPINE.md and triggerfish.yaml
- Skips creation if TRIGGER.md already exists (safe for `--force` reruns)
- Template matches the minimal example from the documentation

Closes #19

## Test plan
- [x] Run `triggerfish dive` on a fresh install — verify TRIGGER.md is created
- [x] Run `triggerfish dive --force` with existing TRIGGER.md — verify it's not overwritten
- [x] Verify TRIGGER.md content matches the minimal template

🤖 Generated with [Claude Code](https://claude.com/claude-code)