### PR TITLE
fix: persist Telegram bot token directly in triggerfish.yaml

### DIFF
--- a/src/dive/wizard.ts
+++ b/src/dive/wizard.ts
@@ -147,7 +147,7 @@ export function generateConfig(answers: WizardAnswers): string {
       };
     } else if (ch === "telegram" && answers.telegramBotToken.length > 0) {
       const telegramConfig: Record<string, unknown> = {
-        botToken: "${TELEGRAM_BOT_TOKEN}",
+        botToken: answers.telegramBotToken,
         classification: "INTERNAL",
       };
       if (answers.telegramOwnerId.length > 0) {
@@ -499,9 +499,7 @@ export async function runWizard(baseDir: string): Promise<DiveResult> {
         "Your Telegram user ID (numeric, message @getmyid_bot for your ID number)",
     });
     if (telegramBotToken.length > 0) {
-      console.log(
-        "  ✓ Set TELEGRAM_BOT_TOKEN in your environment before starting",
-      );
+      console.log("  ✓ Telegram bot token saved to config");
     }
   }
 
@@ -1229,16 +1227,14 @@ export async function runWizardSelective(
       });
       if (telegramBotToken.length > 0) {
         const tc: Record<string, unknown> = {
-          botToken: "${TELEGRAM_BOT_TOKEN}",
+          botToken: telegramBotToken,
           classification: "INTERNAL",
         };
         if (telegramOwnerId.length > 0) {
           tc["ownerId"] = parseInt(telegramOwnerId, 10) || 0;
         }
         channels["telegram"] = tc;
-        console.log(
-          "  ✓ Set TELEGRAM_BOT_TOKEN in your environment before starting",
-        );
+        console.log("  ✓ Telegram bot token saved to config");
       }
     }
 

--- a/tests/dive/wizard_test.ts
+++ b/tests/dive/wizard_test.ts
@@ -162,8 +162,8 @@ Deno.test("Wizard: generateConfig includes telegram channel config", () => {
   const channels = parsed.channels as Record<string, Record<string, unknown>>;
   assertEquals(channels.telegram.classification, "INTERNAL");
   assertEquals(channels.telegram.ownerId, 483291057);
-  // Token stored as env var reference, not plaintext
-  assertEquals(channels.telegram.botToken, "${TELEGRAM_BOT_TOKEN}");
+  // Token stored directly in config
+  assertEquals(channels.telegram.botToken, "123:ABC");
 });
 
 Deno.test("Wizard: generateConfig has empty channels when only CLI selected", () => {


### PR DESCRIPTION
## Summary
- `generateConfig()` was writing literal `${TELEGRAM_BOT_TOKEN}` instead of the actual token value — now stores the real token
- Same fix applied in `runWizardSelective()` for `dive --force`
- Removed stale "Set TELEGRAM_BOT_TOKEN in your environment" messaging
- Updated test to assert the actual token value is persisted

Closes #18

## Test plan
- [x] Run `triggerfish dive --force`, select Channels, enter a Telegram bot token
- [x] Check `~/.triggerfish/triggerfish.yaml` — `botToken` should contain the actual token, not `${TELEGRAM_BOT_TOKEN}`
- [ ] Start the daemon — Telegram adapter should connect successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)