### PR TITLE
fix: signal-cli daemon unreachable on Windows (IPv6 localhost)

### DIFF
--- a/src/channels/signal/mod.ts
+++ b/src/channels/signal/mod.ts
@@ -18,7 +18,7 @@ export type {
 export { createSignalClient } from "./client.ts";
 export type { SignalChannelAdapter } from "./adapter.ts";
 export { createSignalChannel } from "./adapter.ts";
-export type { SignalCliInstall } from "./setup.ts";
+export type { SignalCliInstall, DaemonHandle } from "./setup.ts";
 export {
   checkSignalCli,
   fetchLatestVersion,

--- a/src/channels/signal/setup.ts
+++ b/src/channels/signal/setup.ts
@@ -650,15 +650,27 @@ export async function isDaemonRunning(host: string, port: number): Promise<boole
   }
 }
 
+/** Result of starting the signal-cli daemon. */
+export interface DaemonHandle {
+  /** The child process. */
+  readonly child: Deno.ChildProcess;
+  /** Collect any stderr output (for diagnostics on failure). */
+  readonly stderrText: () => Promise<string>;
+}
+
 /**
  * Start signal-cli daemon on a TCP socket.
+ *
+ * Normalizes "localhost" to "127.0.0.1" so signal-cli binds IPv4 — on
+ * Windows dual-stack systems Java resolves "localhost" to `::1` (IPv6),
+ * causing connection refused when Triggerfish probes `127.0.0.1`.
  *
  * @param account - Phone number (E.164).
  * @param host - TCP hostname. Default: localhost.
  * @param port - TCP port. Default: 7583.
  * @param signalCliPath - Path to signal-cli binary.
  * @param javaHome - Optional JAVA_HOME for managed JRE.
- * @returns The child process handle.
+ * @returns A handle with the child process and stderr accessor.
  */
 export function startDaemon(
   account: string,
@@ -666,19 +678,50 @@ export function startDaemon(
   port: number = 7583,
   signalCliPath: string = "signal-cli",
   javaHome?: string,
-): Result<Deno.ChildProcess, string> {
+): Result<DaemonHandle, string> {
   try {
     const env = javaHome
       ? { ...Deno.env.toObject(), JAVA_HOME: javaHome }
       : undefined;
+    const normalizedHost = normalizeHost(host);
     const cmd = new Deno.Command(signalCliPath, {
-      args: ["-a", account, "daemon", "--tcp", `${host}:${port}`],
+      args: ["-a", account, "daemon", "--tcp", `${normalizedHost}:${port}`],
       stdout: "null",
-      stderr: "null",
+      stderr: "piped",
       env,
     });
     const child = cmd.spawn();
-    return { ok: true, value: child };
+
+    // Collect stderr lazily — only read when caller needs diagnostics
+    let stderrPromise: Promise<string> | null = null;
+    const stderrText = (): Promise<string> => {
+      if (!stderrPromise) {
+        stderrPromise = (async () => {
+          try {
+            const reader = child.stderr.getReader();
+            const chunks: Uint8Array[] = [];
+            while (true) {
+              const { value, done } = await reader.read();
+              if (done) break;
+              chunks.push(value);
+            }
+            const total = chunks.reduce((n, c) => n + c.length, 0);
+            const merged = new Uint8Array(total);
+            let offset = 0;
+            for (const c of chunks) {
+              merged.set(c, offset);
+              offset += c.length;
+            }
+            return new TextDecoder().decode(merged).trim();
+          } catch {
+            return "";
+          }
+        })();
+      }
+      return stderrPromise;
+    };
+
+    return { ok: true, value: { child, stderrText } };
   } catch (err) {
     return { ok: false, error: `Failed to start signal-cli daemon: ${err instanceof Error ? err.message : String(err)}` };
   }

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1865,9 +1865,13 @@ async function runStart(): Promise<void> {
             if (ready) {
               console.log("  signal-cli daemon started");
             } else {
+              const stderr = await daemonResult.value.stderrText();
               console.error(
                 "  signal-cli daemon started but not reachable within 60s",
               );
+              if (stderr) {
+                console.error(`  signal-cli stderr: ${stderr}`);
+              }
             }
           } else {
             console.error(
@@ -2326,9 +2330,13 @@ async function promptChannelConfig(
             if (ready) {
               console.log("  Daemon is running.");
             } else {
+              const stderr = await daemonResult.value.stderrText();
               console.error(
                 "  Daemon started but not reachable yet. It may still be initializing.",
               );
+              if (stderr) {
+                console.error(`  signal-cli stderr: ${stderr}`);
+              }
               console.error(
                 `  Check: ${signalCliPath} -a ${config.account} daemon --tcp localhost:7583`,
               );


### PR DESCRIPTION
## Summary
- Normalizes `localhost` to `127.0.0.1` in `startDaemon()` before passing to signal-cli's `--tcp` argument — on Windows dual-stack systems, Java resolves "localhost" to `::1` (IPv6), so signal-cli binds on `[::1]:7583` while Triggerfish probes `127.0.0.1:7583` and gets connection refused (OS error 10061)
- Captures daemon `stderr` output and surfaces it when the 60s reachability check fails, making startup failures diagnosable instead of silently timing out
- Exports `DaemonHandle` type from signal module for the new return shape

## Root cause
The `normalizeHost()` function was already applied in `isDaemonRunning()` and `waitForDaemon()`, but **not** in `startDaemon()` where the `--tcp` bind address is constructed. This IPv4/IPv6 mismatch only manifests on Windows where Java prefers IPv6.

## Test plan
- [x] All 26 CLI tests pass
- [ ] Manual: verify on Windows that `triggerfish start` with Signal configured connects successfully
- [ ] Manual: verify daemon stderr is printed when signal-cli fails to start

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)