### PR TITLE
[Phase A3] fix: add Brave browser support and fix browser-scheme URL confusion

### DIFF
--- a/skills/bundled/browser-automation/SKILL.md
+++ b/skills/bundled/browser-automation/SKILL.md
@@ -73,6 +73,7 @@ When a page loads content asynchronously:
 
 - The browser auto-launches when you call any browser tool. You do not need to start it manually.
 - Only http and https URLs are allowed. Private/reserved IPs are blocked (SSRF prevention).
+- When the user says "open Brave", "open Chrome", or "open a browser tab", use `browser_navigate` with an http/https URL. Do not use browser-scheme URLs like `brave://` or `chrome://` — they are not supported.
 - Some domains may be blocked by policy. If navigation fails, tell the user.
 - The browser profile is classification-aware — visiting classified domains escalates the watermark.
 - Always use `browser_snapshot` after navigation to see what loaded.

--- a/src/browser/manager.ts
+++ b/src/browser/manager.ts
@@ -126,6 +126,7 @@ const FLATPAK_APP_IDS = [
   "com.google.Chrome",
   "com.google.ChromeDev",
   "org.chromium.Chromium",
+  "com.brave.Browser",
 ] as const;
 
 // ---------------------------------------------------------------------------
@@ -147,12 +148,16 @@ export async function detectChrome(): Promise<ChromeDetection | undefined> {
     "/usr/bin/google-chrome-stable",
     "/snap/bin/chromium",
     "/usr/bin/microsoft-edge",
+    "/usr/bin/brave-browser",
+    "/usr/bin/brave",
+    "/snap/bin/brave",
   ];
 
   const darwinPaths = [
     "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
     "/Applications/Chromium.app/Contents/MacOS/Chromium",
     "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+    "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
   ];
 
   const candidates = Deno.build.os === "darwin" ? darwinPaths : linuxPaths;
@@ -167,7 +172,7 @@ export async function detectChrome(): Promise<ChromeDetection | undefined> {
   }
 
   // Fallback: try 'which' for common browser names
-  const names = ["chromium-browser", "chromium", "google-chrome"];
+  const names = ["chromium-browser", "chromium", "google-chrome", "brave-browser", "brave"];
   for (const name of names) {
     try {
       const cmd = new Deno.Command("which", {

--- a/src/browser/tools.ts
+++ b/src/browser/tools.ts
@@ -108,7 +108,8 @@ export function createBrowserTools(config: BrowserToolsConfig): BrowserTools {
       if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
         return {
           ok: false,
-          error: `Only http/https URLs are allowed, got: ${parsed.protocol}`,
+          error:
+            `Only http/https URLs are allowed. Got: ${parsed.protocol} — if the user asked to open a browser or a browser tab, navigate to a URL like https://example.com instead.`,
         };
       }
 
@@ -410,7 +411,9 @@ export const BROWSER_TOOLS_SYSTEM_PROMPT = `## Browser Automation
 
 You have browser automation tools (browser_navigate, browser_snapshot, browser_click, browser_type, browser_select, browser_scroll, browser_wait, browser_describe). The browser auto-launches on first use — just call the tools directly.
 
-When the user asks to open or go to a website, call browser_navigate immediately. Use browser_snapshot after navigating to see the page. Use browser_describe if you need a visual description of the screenshot. Read the browser-automation skill for detailed usage patterns.`;
+When the user asks to open or go to a website, call browser_navigate immediately. Use browser_snapshot after navigating to see the page. Use browser_describe if you need a visual description of the screenshot. Read the browser-automation skill for detailed usage patterns.
+
+When the user says "open Brave", "open Chrome", or "open a browser tab", use browser_navigate with an http/https URL — never use browser-scheme URLs like brave:// or chrome://. Only http and https are supported.`;
 
 // ─── Executor ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Fixes #issue-44

Adds Brave browser detection (Chromium-based, CDP-compatible) and fixes the LLM hallucinating an auth error when a user says "open Brave".

Generated with [Claude Code](https://claude.ai/code)