### PR TITLE
[Phase 10] feat: sliding-window rate limiter for LLM providers

### DIFF
--- a/src/agent/mod.ts
+++ b/src/agent/mod.ts
@@ -51,6 +51,42 @@ export type {
 export { loadProvidersFromConfig } from "./providers/config.ts";
 export type { ProvidersConfig, ModelsConfig, PrimaryModelRef } from "./providers/config.ts";
 
+// Rate limiting
+export { createRateLimiter, createRateLimitedProvider } from "./rate_limiter.ts";
+export type {
+  RateLimiterConfig,
+  RateLimiter,
+  RateLimiterSnapshot,
+} from "./rate_limiter.ts";
+
+// OpenAI rate limit constants
+export { getOpenAiLimits } from "./providers/openai_limits.ts";
+export type { OpenAiModelLimits, OpenAiTier } from "./providers/openai_limits.ts";
+export {
+  GPT4O_FREE,
+  GPT4O_TIER1,
+  GPT4O_TIER2,
+  GPT4O_TIER3,
+  GPT4O_TIER4,
+  GPT4O_TIER5,
+  GPT4O_MINI_FREE,
+  GPT4O_MINI_TIER1,
+  GPT4O_MINI_TIER2,
+  GPT4O_MINI_TIER3,
+  GPT4O_MINI_TIER4,
+  GPT4O_MINI_TIER5,
+  O1_TIER1,
+  O1_TIER2,
+  O1_TIER3,
+  O1_TIER4,
+  O1_TIER5,
+  O3_MINI_TIER1,
+  O3_MINI_TIER2,
+  O3_MINI_TIER3,
+  O3_MINI_TIER4,
+  O3_MINI_TIER5,
+} from "./providers/openai_limits.ts";
+
 // Plan mode
 export type {
   PlanManager,

--- a/src/agent/providers/mod.ts
+++ b/src/agent/providers/mod.ts
@@ -27,3 +27,30 @@ export type { ZenMuxConfig } from "./zenmux.ts";
 
 export { createZaiProvider } from "./zai.ts";
 export type { ZaiConfig } from "./zai.ts";
+
+export { getOpenAiLimits } from "./openai_limits.ts";
+export type { OpenAiModelLimits, OpenAiTier } from "./openai_limits.ts";
+export {
+  GPT4O_FREE,
+  GPT4O_TIER1,
+  GPT4O_TIER2,
+  GPT4O_TIER3,
+  GPT4O_TIER4,
+  GPT4O_TIER5,
+  GPT4O_MINI_FREE,
+  GPT4O_MINI_TIER1,
+  GPT4O_MINI_TIER2,
+  GPT4O_MINI_TIER3,
+  GPT4O_MINI_TIER4,
+  GPT4O_MINI_TIER5,
+  O1_TIER1,
+  O1_TIER2,
+  O1_TIER3,
+  O1_TIER4,
+  O1_TIER5,
+  O3_MINI_TIER1,
+  O3_MINI_TIER2,
+  O3_MINI_TIER3,
+  O3_MINI_TIER4,
+  O3_MINI_TIER5,
+} from "./openai_limits.ts";

--- a/src/agent/providers/openai_limits.ts
+++ b/src/agent/providers/openai_limits.ts
@@ -1,0 +1,267 @@
+/**
+ * OpenAI API rate limit constants.
+ *
+ * Values reflect OpenAI's published tier limits as of early 2026.
+ * See: https://platform.openai.com/account/rate-limits
+ *
+ * TPM = Tokens Per Minute
+ * RPM = Requests Per Minute
+ * TPD = Tokens Per Day
+ *
+ * Tier 1 is the default for new accounts with any payment method on file.
+ * Tier 5 is the highest publicly available tier.
+ *
+ * @module
+ */
+
+/** Rate limits for a single model at a specific OpenAI usage tier. */
+export interface OpenAiModelLimits {
+  /** Maximum tokens per minute (input + output combined). */
+  readonly tpm: number;
+  /** Maximum requests per minute. */
+  readonly rpm: number;
+  /** Maximum tokens per day. */
+  readonly tpd: number;
+}
+
+/** OpenAI usage tier identifier. */
+export type OpenAiTier = "free" | "tier1" | "tier2" | "tier3" | "tier4" | "tier5";
+
+// ---------------------------------------------------------------------------
+// gpt-4o limits by tier
+// ---------------------------------------------------------------------------
+
+/** gpt-4o rate limits — Free tier. */
+export const GPT4O_FREE: OpenAiModelLimits = {
+  tpm: 20_000,
+  rpm: 3,
+  tpd: 200_000,
+};
+
+/** gpt-4o rate limits — Tier 1 (default for paid accounts). */
+export const GPT4O_TIER1: OpenAiModelLimits = {
+  tpm: 30_000,
+  rpm: 500,
+  tpd: 90_000,
+};
+
+/** gpt-4o rate limits — Tier 2. */
+export const GPT4O_TIER2: OpenAiModelLimits = {
+  tpm: 450_000,
+  rpm: 5_000,
+  tpd: 1_350_000,
+};
+
+/** gpt-4o rate limits — Tier 3. */
+export const GPT4O_TIER3: OpenAiModelLimits = {
+  tpm: 800_000,
+  rpm: 5_000,
+  tpd: 40_000_000,
+};
+
+/** gpt-4o rate limits — Tier 4. */
+export const GPT4O_TIER4: OpenAiModelLimits = {
+  tpm: 2_000_000,
+  rpm: 10_000,
+  tpd: 300_000_000,
+};
+
+/** gpt-4o rate limits — Tier 5. */
+export const GPT4O_TIER5: OpenAiModelLimits = {
+  tpm: 30_000_000,
+  rpm: 10_000,
+  tpd: 5_000_000_000,
+};
+
+// ---------------------------------------------------------------------------
+// gpt-4o-mini limits by tier
+// ---------------------------------------------------------------------------
+
+/** gpt-4o-mini rate limits — Free tier. */
+export const GPT4O_MINI_FREE: OpenAiModelLimits = {
+  tpm: 200_000,
+  rpm: 3,
+  tpd: 2_000_000,
+};
+
+/** gpt-4o-mini rate limits — Tier 1. */
+export const GPT4O_MINI_TIER1: OpenAiModelLimits = {
+  tpm: 200_000,
+  rpm: 500,
+  tpd: 10_000_000,
+};
+
+/** gpt-4o-mini rate limits — Tier 2. */
+export const GPT4O_MINI_TIER2: OpenAiModelLimits = {
+  tpm: 2_000_000,
+  rpm: 5_000,
+  tpd: 50_000_000,
+};
+
+/** gpt-4o-mini rate limits — Tier 3. */
+export const GPT4O_MINI_TIER3: OpenAiModelLimits = {
+  tpm: 4_000_000,
+  rpm: 5_000,
+  tpd: 200_000_000,
+};
+
+/** gpt-4o-mini rate limits — Tier 4. */
+export const GPT4O_MINI_TIER4: OpenAiModelLimits = {
+  tpm: 10_000_000,
+  rpm: 10_000,
+  tpd: 5_000_000_000,
+};
+
+/** gpt-4o-mini rate limits — Tier 5. */
+export const GPT4O_MINI_TIER5: OpenAiModelLimits = {
+  tpm: 150_000_000,
+  rpm: 30_000,
+  tpd: 5_000_000_000,
+};
+
+// ---------------------------------------------------------------------------
+// o1 limits by tier
+// ---------------------------------------------------------------------------
+
+/** o1 rate limits — Tier 1. */
+export const O1_TIER1: OpenAiModelLimits = {
+  tpm: 30_000,
+  rpm: 500,
+  tpd: 90_000,
+};
+
+/** o1 rate limits — Tier 2. */
+export const O1_TIER2: OpenAiModelLimits = {
+  tpm: 450_000,
+  rpm: 5_000,
+  tpd: 1_350_000,
+};
+
+/** o1 rate limits — Tier 3. */
+export const O1_TIER3: OpenAiModelLimits = {
+  tpm: 800_000,
+  rpm: 5_000,
+  tpd: 40_000_000,
+};
+
+/** o1 rate limits — Tier 4. */
+export const O1_TIER4: OpenAiModelLimits = {
+  tpm: 2_000_000,
+  rpm: 10_000,
+  tpd: 300_000_000,
+};
+
+/** o1 rate limits — Tier 5. */
+export const O1_TIER5: OpenAiModelLimits = {
+  tpm: 30_000_000,
+  rpm: 10_000,
+  tpd: 5_000_000_000,
+};
+
+// ---------------------------------------------------------------------------
+// o3-mini limits by tier
+// ---------------------------------------------------------------------------
+
+/** o3-mini rate limits — Tier 1. */
+export const O3_MINI_TIER1: OpenAiModelLimits = {
+  tpm: 150_000,
+  rpm: 500,
+  tpd: 1_000_000,
+};
+
+/** o3-mini rate limits — Tier 2. */
+export const O3_MINI_TIER2: OpenAiModelLimits = {
+  tpm: 2_000_000,
+  rpm: 5_000,
+  tpd: 50_000_000,
+};
+
+/** o3-mini rate limits — Tier 3. */
+export const O3_MINI_TIER3: OpenAiModelLimits = {
+  tpm: 5_000_000,
+  rpm: 5_000,
+  tpd: 200_000_000,
+};
+
+/** o3-mini rate limits — Tier 4. */
+export const O3_MINI_TIER4: OpenAiModelLimits = {
+  tpm: 20_000_000,
+  rpm: 10_000,
+  tpd: 1_000_000_000,
+};
+
+/** o3-mini rate limits — Tier 5. */
+export const O3_MINI_TIER5: OpenAiModelLimits = {
+  tpm: 150_000_000,
+  rpm: 30_000,
+  tpd: 5_000_000_000,
+};
+
+// ---------------------------------------------------------------------------
+// Lookup helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Look up the OpenAI rate limits for a given model and tier.
+ *
+ * Returns undefined if the model/tier combination is not in the registry.
+ * Callers should fall back to a conservative default when undefined is returned.
+ *
+ * @param model - Model name (e.g. "gpt-4o", "gpt-4o-mini")
+ * @param tier  - Usage tier (default: "tier1")
+ */
+export function getOpenAiLimits(
+  model: string,
+  tier: OpenAiTier = "tier1",
+): OpenAiModelLimits | undefined {
+  if (/gpt-4o-mini/i.test(model)) {
+    return GPT4O_MINI_BY_TIER[tier];
+  }
+  if (/gpt-4o/i.test(model)) {
+    return GPT4O_BY_TIER[tier];
+  }
+  if (/o1/i.test(model)) {
+    return O1_BY_TIER[tier];
+  }
+  if (/o3-mini/i.test(model)) {
+    return O3_MINI_BY_TIER[tier];
+  }
+  return undefined;
+}
+
+const GPT4O_BY_TIER: Readonly<Record<OpenAiTier, OpenAiModelLimits>> = {
+  free: GPT4O_FREE,
+  tier1: GPT4O_TIER1,
+  tier2: GPT4O_TIER2,
+  tier3: GPT4O_TIER3,
+  tier4: GPT4O_TIER4,
+  tier5: GPT4O_TIER5,
+};
+
+const GPT4O_MINI_BY_TIER: Readonly<Record<OpenAiTier, OpenAiModelLimits>> = {
+  free: GPT4O_MINI_FREE,
+  tier1: GPT4O_MINI_TIER1,
+  tier2: GPT4O_MINI_TIER2,
+  tier3: GPT4O_MINI_TIER3,
+  tier4: GPT4O_MINI_TIER4,
+  tier5: GPT4O_MINI_TIER5,
+};
+
+// o1 and o3-mini have no free tier; map free → tier1 as a safe default.
+const O1_BY_TIER: Readonly<Record<OpenAiTier, OpenAiModelLimits>> = {
+  free: O1_TIER1,
+  tier1: O1_TIER1,
+  tier2: O1_TIER2,
+  tier3: O1_TIER3,
+  tier4: O1_TIER4,
+  tier5: O1_TIER5,
+};
+
+const O3_MINI_BY_TIER: Readonly<Record<OpenAiTier, OpenAiModelLimits>> = {
+  free: O3_MINI_TIER1,
+  tier1: O3_MINI_TIER1,
+  tier2: O3_MINI_TIER2,
+  tier3: O3_MINI_TIER3,
+  tier4: O3_MINI_TIER4,
+  tier5: O3_MINI_TIER5,
+};

--- a/src/agent/rate_limiter.ts
+++ b/src/agent/rate_limiter.ts
@@ -1,0 +1,263 @@
+/**
+ * Sliding-window rate limiter for LLM providers.
+ *
+ * Wraps any LlmProvider to enforce tokens-per-minute (TPM) and
+ * requests-per-minute (RPM) limits before each completion call.
+ * When a limit would be exceeded the call is held until the window
+ * has advanced enough to accommodate it, rather than being rejected.
+ *
+ * Design notes:
+ * - Pure sliding-window over a configurable window size (default 60 s).
+ * - State is held in a closure — immutable config, mutable counters only.
+ * - No LLM calls inside the limiter; purely deterministic token accounting.
+ * - Streaming and non-streaming completions both consume from the same budget.
+ *   Token cost for a streaming call is accounted for after the stream ends
+ *   (when actual usage figures are available).
+ *
+ * @module
+ */
+
+import type { LlmProvider, LlmMessage, LlmCompletionResult, LlmStreamChunk } from "./llm.ts";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** Configuration for a rate-limited provider. */
+export interface RateLimiterConfig {
+  /**
+   * Maximum tokens per minute (input + output combined).
+   * Set to `Infinity` to disable TPM enforcement.
+   */
+  readonly tpm: number;
+  /**
+   * Maximum requests per minute.
+   * Set to `Infinity` to disable RPM enforcement.
+   */
+  readonly rpm: number;
+  /**
+   * Sliding-window duration in milliseconds.
+   * Defaults to 60 000 ms (1 minute).
+   */
+  readonly windowMs?: number;
+  /**
+   * How frequently (in ms) to poll when waiting for the window to clear.
+   * Defaults to 500 ms.
+   */
+  readonly pollIntervalMs?: number;
+}
+
+/** Live snapshot of limiter usage within the current window. */
+export interface RateLimiterSnapshot {
+  /** Tokens consumed in the current window. */
+  readonly tokensUsed: number;
+  /** Requests made in the current window. */
+  readonly requestsUsed: number;
+  /** Configured TPM ceiling. */
+  readonly tpmLimit: number;
+  /** Configured RPM ceiling. */
+  readonly rpmLimit: number;
+  /** Window size in milliseconds. */
+  readonly windowMs: number;
+}
+
+/** A rate limiter that can be queried for its current state. */
+export interface RateLimiter {
+  /** Return the current usage snapshot (does not block). */
+  snapshot(): RateLimiterSnapshot;
+  /**
+   * Wait until there is capacity for `estimatedTokens` tokens.
+   * Resolves as soon as capacity is available.
+   */
+  waitForCapacity(estimatedTokens: number): Promise<void>;
+  /**
+   * Record actual usage after a completion.
+   * Call this with the `usage` returned by `LlmCompletionResult`.
+   */
+  recordUsage(inputTokens: number, outputTokens: number): void;
+}
+
+// ---------------------------------------------------------------------------
+// Internal record types
+// ---------------------------------------------------------------------------
+
+/** A timestamped token usage event in the sliding window. */
+interface UsageEvent {
+  readonly ts: number;
+  readonly tokens: number;
+}
+
+// ---------------------------------------------------------------------------
+// createRateLimiter
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a standalone rate limiter.
+ *
+ * The limiter maintains a sliding window of usage events and
+ * exposes `waitForCapacity` / `recordUsage` for coordination.
+ *
+ * @param config - TPM, RPM, and window settings
+ * @returns A RateLimiter instance
+ */
+export function createRateLimiter(config: RateLimiterConfig): RateLimiter {
+  const windowMs = config.windowMs ?? 60_000;
+  const pollMs = config.pollIntervalMs ?? 500;
+
+  // Mutable sliding-window event log.
+  // Events older than `windowMs` are pruned before each check.
+  const tokenEvents: UsageEvent[] = [];
+  const requestEvents: UsageEvent[] = [];
+
+  function prune(now: number): void {
+    const cutoff = now - windowMs;
+    while (tokenEvents.length > 0 && tokenEvents[0].ts < cutoff) {
+      tokenEvents.shift();
+    }
+    while (requestEvents.length > 0 && requestEvents[0].ts < cutoff) {
+      requestEvents.shift();
+    }
+  }
+
+  function windowTokens(now: number): number {
+    prune(now);
+    return tokenEvents.reduce((sum, e) => sum + e.tokens, 0);
+  }
+
+  function windowRequests(now: number): number {
+    prune(now);
+    return requestEvents.length;
+  }
+
+  function hasCapacity(estimatedTokens: number, now: number): boolean {
+    if (config.tpm !== Infinity && windowTokens(now) + estimatedTokens > config.tpm) {
+      return false;
+    }
+    if (config.rpm !== Infinity && windowRequests(now) + 1 > config.rpm) {
+      return false;
+    }
+    return true;
+  }
+
+  return {
+    snapshot(): RateLimiterSnapshot {
+      const now = Date.now();
+      return {
+        tokensUsed: windowTokens(now),
+        requestsUsed: windowRequests(now),
+        tpmLimit: config.tpm,
+        rpmLimit: config.rpm,
+        windowMs,
+      };
+    },
+
+    async waitForCapacity(estimatedTokens: number): Promise<void> {
+      // Optimistic path — no waiting needed.
+      if (hasCapacity(estimatedTokens, Date.now())) {
+        // Record the request slot immediately (token cost recorded later via recordUsage).
+        requestEvents.push({ ts: Date.now(), tokens: 0 });
+        return;
+      }
+
+      // Poll until capacity is available.
+      await new Promise<void>((resolve) => {
+        const id = setInterval(() => {
+          if (hasCapacity(estimatedTokens, Date.now())) {
+            clearInterval(id);
+            requestEvents.push({ ts: Date.now(), tokens: 0 });
+            resolve();
+          }
+        }, pollMs);
+      });
+    },
+
+    recordUsage(inputTokens: number, outputTokens: number): void {
+      const now = Date.now();
+      tokenEvents.push({ ts: now, tokens: inputTokens + outputTokens });
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// createRateLimitedProvider
+// ---------------------------------------------------------------------------
+
+/**
+ * Wrap an LlmProvider with a sliding-window rate limiter.
+ *
+ * Both `complete` and `stream` will wait for available capacity before
+ * issuing the underlying provider call. Actual token usage is recorded
+ * after each call using the usage figures returned by the provider.
+ *
+ * The estimated token cost passed to `waitForCapacity` before the call is
+ * derived from the prompt token count (input). After the call, the real
+ * total (input + output) is recorded via `recordUsage`.
+ *
+ * @param provider  - The underlying LlmProvider to wrap
+ * @param limiter   - A RateLimiter created via createRateLimiter
+ * @param estimateInputTokens - Optional callback to estimate input tokens from
+ *   messages before a call. Defaults to a character-length heuristic (÷ 4).
+ * @returns A new LlmProvider that enforces the rate limit
+ */
+export function createRateLimitedProvider(
+  provider: LlmProvider,
+  limiter: RateLimiter,
+  estimateInputTokens?: (messages: readonly LlmMessage[]) => number,
+): LlmProvider {
+  function estimateTokens(messages: readonly LlmMessage[]): number {
+    if (estimateInputTokens) return estimateInputTokens(messages);
+    // Conservative heuristic: ~4 characters per token.
+    return messages.reduce((sum, m) => {
+      const text = typeof m.content === "string" ? m.content : JSON.stringify(m.content);
+      return sum + Math.ceil(text.length / 4);
+    }, 0);
+  }
+
+  const rateLimitedProvider: LlmProvider = {
+    name: provider.name,
+    supportsStreaming: provider.supportsStreaming,
+    contextWindow: provider.contextWindow,
+
+    async complete(
+      messages: readonly LlmMessage[],
+      tools: readonly unknown[],
+      options: Record<string, unknown>,
+    ): Promise<LlmCompletionResult> {
+      const estimated = estimateTokens(messages);
+      await limiter.waitForCapacity(estimated);
+
+      const result = await provider.complete(messages, tools, options);
+      limiter.recordUsage(result.usage.inputTokens, result.usage.outputTokens);
+      return result;
+    },
+  };
+
+  // Only attach stream() if the underlying provider supports it.
+  if (provider.stream) {
+    const upstreamStream = provider.stream.bind(provider);
+
+    rateLimitedProvider.stream = async function* (
+      messages: readonly LlmMessage[],
+      tools: readonly unknown[],
+      options: Record<string, unknown>,
+    ): AsyncIterable<LlmStreamChunk> {
+      const estimated = estimateTokens(messages);
+      await limiter.waitForCapacity(estimated);
+
+      let lastUsage: { inputTokens: number; outputTokens: number } | undefined;
+
+      for await (const chunk of upstreamStream(messages, tools, options)) {
+        if (chunk.done && chunk.usage) {
+          lastUsage = chunk.usage;
+        }
+        yield chunk;
+      }
+
+      if (lastUsage) {
+        limiter.recordUsage(lastUsage.inputTokens, lastUsage.outputTokens);
+      }
+    };
+  }
+
+  return rateLimitedProvider;
+}

--- a/tests/agent/rate_limiter_test.ts
+++ b/tests/agent/rate_limiter_test.ts
@@ -1,0 +1,278 @@
+/**
+ * Tests for the sliding-window rate limiter.
+ *
+ * @module
+ */
+
+import { assertEquals, assertExists } from "@std/assert";
+import {
+  createRateLimiter,
+  createRateLimitedProvider,
+} from "../../src/agent/rate_limiter.ts";
+import type { RateLimiterConfig } from "../../src/agent/rate_limiter.ts";
+import type { LlmProvider, LlmMessage, LlmCompletionResult, LlmStreamChunk } from "../../src/agent/llm.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeMockProvider(
+  usage = { inputTokens: 10, outputTokens: 5 },
+): LlmProvider & { callCount: number } {
+  const provider = {
+    name: "mock",
+    supportsStreaming: true,
+    callCount: 0,
+
+    async complete(
+      _messages: readonly LlmMessage[],
+      _tools: readonly unknown[],
+      _options: Record<string, unknown>,
+    ): Promise<LlmCompletionResult> {
+      provider.callCount++;
+      return {
+        content: "hello",
+        toolCalls: [],
+        usage,
+      };
+    },
+
+    async *stream(
+      _messages: readonly LlmMessage[],
+      _tools: readonly unknown[],
+      _options: Record<string, unknown>,
+    ): AsyncIterable<LlmStreamChunk> {
+      provider.callCount++;
+      yield { text: "hello", done: false };
+      yield { text: "", done: true, usage, toolCalls: [] };
+    },
+  };
+  return provider;
+}
+
+const messages: readonly LlmMessage[] = [
+  { role: "user", content: "hi" },
+];
+
+// ---------------------------------------------------------------------------
+// createRateLimiter — unit tests
+// ---------------------------------------------------------------------------
+
+Deno.test("createRateLimiter — snapshot starts at zero", () => {
+  const limiter = createRateLimiter({ tpm: 1000, rpm: 10 });
+  const snap = limiter.snapshot();
+  assertEquals(snap.tokensUsed, 0);
+  assertEquals(snap.requestsUsed, 0);
+  assertEquals(snap.tpmLimit, 1000);
+  assertEquals(snap.rpmLimit, 10);
+  assertEquals(snap.windowMs, 60_000);
+});
+
+Deno.test("createRateLimiter — recordUsage accumulates tokens", () => {
+  const limiter = createRateLimiter({ tpm: 1000, rpm: 10 });
+  limiter.recordUsage(100, 50);
+  limiter.recordUsage(200, 75);
+  const snap = limiter.snapshot();
+  assertEquals(snap.tokensUsed, 425);
+});
+
+Deno.test("createRateLimiter — waitForCapacity resolves immediately under limit", async () => {
+  const limiter = createRateLimiter({ tpm: 1000, rpm: 10 });
+  await limiter.waitForCapacity(500);
+  const snap = limiter.snapshot();
+  // One request registered
+  assertEquals(snap.requestsUsed, 1);
+});
+
+Deno.test("createRateLimiter — custom window size respected in snapshot", () => {
+  const limiter = createRateLimiter({ tpm: 500, rpm: 5, windowMs: 30_000 });
+  const snap = limiter.snapshot();
+  assertEquals(snap.windowMs, 30_000);
+});
+
+Deno.test("createRateLimiter — Infinity limits never block", async () => {
+  const limiter = createRateLimiter({ tpm: Infinity, rpm: Infinity });
+  // Should resolve immediately even with huge token count
+  await limiter.waitForCapacity(1_000_000_000);
+  const snap = limiter.snapshot();
+  assertEquals(snap.requestsUsed, 1);
+});
+
+// ---------------------------------------------------------------------------
+// createRateLimitedProvider — wraps complete()
+// ---------------------------------------------------------------------------
+
+Deno.test("createRateLimitedProvider — complete() passes through result", async () => {
+  const mock = makeMockProvider();
+  const limiter = createRateLimiter({ tpm: 10_000, rpm: 100 });
+  const wrapped = createRateLimitedProvider(mock, limiter);
+
+  const result = await wrapped.complete(messages, [], {});
+  assertEquals(result.content, "hello");
+  assertEquals(result.usage.inputTokens, 10);
+  assertEquals(result.usage.outputTokens, 5);
+  assertEquals(mock.callCount, 1);
+});
+
+Deno.test("createRateLimitedProvider — complete() records usage in limiter", async () => {
+  const mock = makeMockProvider({ inputTokens: 20, outputTokens: 30 });
+  const limiter = createRateLimiter({ tpm: 10_000, rpm: 100 });
+  const wrapped = createRateLimitedProvider(mock, limiter);
+
+  await wrapped.complete(messages, [], {});
+  const snap = limiter.snapshot();
+  assertEquals(snap.tokensUsed, 50); // 20 + 30
+});
+
+Deno.test("createRateLimitedProvider — multiple completes accumulate usage", async () => {
+  const mock = makeMockProvider({ inputTokens: 10, outputTokens: 5 });
+  const limiter = createRateLimiter({ tpm: 10_000, rpm: 100 });
+  const wrapped = createRateLimitedProvider(mock, limiter);
+
+  await wrapped.complete(messages, [], {});
+  await wrapped.complete(messages, [], {});
+  await wrapped.complete(messages, [], {});
+
+  const snap = limiter.snapshot();
+  assertEquals(snap.tokensUsed, 45); // 3 × 15
+  assertEquals(snap.requestsUsed, 3);
+});
+
+Deno.test("createRateLimitedProvider — preserves provider name and streaming flag", () => {
+  const mock = makeMockProvider();
+  const limiter = createRateLimiter({ tpm: 1000, rpm: 10 });
+  const wrapped = createRateLimitedProvider(mock, limiter);
+
+  assertEquals(wrapped.name, "mock");
+  assertEquals(wrapped.supportsStreaming, true);
+});
+
+Deno.test("createRateLimitedProvider — stream() passes through chunks", async () => {
+  const mock = makeMockProvider();
+  const limiter = createRateLimiter({ tpm: 10_000, rpm: 100 });
+  const wrapped = createRateLimitedProvider(mock, limiter);
+
+  assertExists(wrapped.stream);
+  const chunks: LlmStreamChunk[] = [];
+  for await (const chunk of wrapped.stream!(messages, [], {})) {
+    chunks.push(chunk);
+  }
+
+  assertEquals(chunks.length, 2);
+  assertEquals(chunks[0].text, "hello");
+  assertEquals(chunks[1].done, true);
+  assertEquals(chunks[1].usage?.inputTokens, 10);
+});
+
+Deno.test("createRateLimitedProvider — stream() records usage in limiter", async () => {
+  const mock = makeMockProvider({ inputTokens: 40, outputTokens: 60 });
+  const limiter = createRateLimiter({ tpm: 10_000, rpm: 100 });
+  const wrapped = createRateLimitedProvider(mock, limiter);
+
+  for await (const _chunk of wrapped.stream!(messages, [], {})) {
+    // consume stream
+  }
+
+  const snap = limiter.snapshot();
+  assertEquals(snap.tokensUsed, 100); // 40 + 60
+});
+
+Deno.test("createRateLimitedProvider — provider without stream has no stream method", () => {
+  const mock: LlmProvider = {
+    name: "no-stream",
+    supportsStreaming: false,
+    async complete(): Promise<LlmCompletionResult> {
+      return { content: "", toolCalls: [], usage: { inputTokens: 1, outputTokens: 1 } };
+    },
+  };
+  const limiter = createRateLimiter({ tpm: 1000, rpm: 10 });
+  const wrapped = createRateLimitedProvider(mock, limiter);
+  assertEquals(wrapped.stream, undefined);
+});
+
+Deno.test("createRateLimitedProvider — custom token estimator is used", async () => {
+  const mock = makeMockProvider({ inputTokens: 10, outputTokens: 5 });
+  const limiter = createRateLimiter({ tpm: 10_000, rpm: 100 });
+
+  let estimatorCalled = false;
+  const wrapped = createRateLimitedProvider(mock, limiter, (_msgs) => {
+    estimatorCalled = true;
+    return 999;
+  });
+
+  await wrapped.complete(messages, [], {});
+  assertEquals(estimatorCalled, true);
+});
+
+// ---------------------------------------------------------------------------
+// OpenAI limit constants
+// ---------------------------------------------------------------------------
+
+Deno.test("openai_limits — getOpenAiLimits returns correct tier1 limits for gpt-4o", async () => {
+  const { getOpenAiLimits, GPT4O_TIER1 } = await import(
+    "../../src/agent/providers/openai_limits.ts"
+  );
+  const limits = getOpenAiLimits("gpt-4o");
+  assertExists(limits);
+  assertEquals(limits, GPT4O_TIER1);
+  assertEquals(limits!.tpm, 30_000);
+  assertEquals(limits!.rpm, 500);
+});
+
+Deno.test("openai_limits — getOpenAiLimits returns free tier for gpt-4o", async () => {
+  const { getOpenAiLimits, GPT4O_FREE } = await import(
+    "../../src/agent/providers/openai_limits.ts"
+  );
+  const limits = getOpenAiLimits("gpt-4o", "free");
+  assertExists(limits);
+  assertEquals(limits, GPT4O_FREE);
+  assertEquals(limits!.tpm, 20_000);
+});
+
+Deno.test("openai_limits — getOpenAiLimits resolves gpt-4o-mini before gpt-4o", async () => {
+  const { getOpenAiLimits, GPT4O_MINI_TIER1, GPT4O_TIER1 } = await import(
+    "../../src/agent/providers/openai_limits.ts"
+  );
+  const mini = getOpenAiLimits("gpt-4o-mini");
+  const full = getOpenAiLimits("gpt-4o");
+  assertExists(mini);
+  assertExists(full);
+  // mini and full should have different limits
+  assertEquals(mini, GPT4O_MINI_TIER1);
+  assertEquals(full, GPT4O_TIER1);
+  assertEquals(mini!.tpm, 200_000);
+  assertEquals(full!.tpm, 30_000);
+});
+
+Deno.test("openai_limits — getOpenAiLimits returns undefined for unknown model", async () => {
+  const { getOpenAiLimits } = await import(
+    "../../src/agent/providers/openai_limits.ts"
+  );
+  const result = getOpenAiLimits("unknown-model-xyz");
+  assertEquals(result, undefined);
+});
+
+Deno.test("openai_limits — o1 free maps to tier1", async () => {
+  const { getOpenAiLimits, O1_TIER1 } = await import(
+    "../../src/agent/providers/openai_limits.ts"
+  );
+  const free = getOpenAiLimits("o1", "free");
+  assertEquals(free, O1_TIER1);
+});
+
+Deno.test("openai_limits — all tier constants are readonly and non-zero", async () => {
+  const {
+    GPT4O_TIER1, GPT4O_TIER2, GPT4O_TIER3, GPT4O_TIER4, GPT4O_TIER5,
+    GPT4O_MINI_TIER1, O1_TIER1, O3_MINI_TIER1,
+  } = await import("../../src/agent/providers/openai_limits.ts");
+
+  for (const c of [GPT4O_TIER1, GPT4O_TIER2, GPT4O_TIER3, GPT4O_TIER4, GPT4O_TIER5,
+    GPT4O_MINI_TIER1, O1_TIER1, O3_MINI_TIER1]) {
+    assertEquals(typeof c.tpm, "number");
+    assertEquals(typeof c.rpm, "number");
+    assertEquals(typeof c.tpd, "number");
+    assertEquals(c.tpm > 0, true);
+    assertEquals(c.rpm > 0, true);
+    assertEquals(c.tpd > 0, true);
+  }
+});


### PR DESCRIPTION
Implements a sliding-window rate limiter for LLM providers to address OpenAI 429 rate limit errors.

## Changes

- `src/agent/rate_limiter.ts`: `RateLimiter` interface + `createRateLimiter` + `createRateLimitedProvider` decorator
- `src/agent/providers/openai_limits.ts`: Typed TPM/RPM/TPD constants for gpt-4o, gpt-4o-mini, o1, o3-mini across all tiers
- `src/agent/mod.ts`, `src/agent/providers/mod.ts`: barrel exports
- `tests/agent/rate_limiter_test.ts`: unit tests

Closes #42

Generated with [Claude Code](https://claude.ai/code)