### PR TITLE
[Phase A3] fix: remove CONFIDENTIAL floor from browser read-only tools

### DIFF
--- a/src/core/security/constants.ts
+++ b/src/core/security/constants.ts
@@ -65,17 +65,27 @@ export const URL_WRITE_TOOLS: ReadonlySet<string> = new Set([
   "browser_type",
 ]);
 
-/** Tools with hardcoded classification floors (non-overridable minimums). */
+/**
+ * Tools with hardcoded classification floors (non-overridable minimums).
+ *
+ * Browser read-only tools (navigate, snapshot, scroll, wait) have no floor —
+ * navigating to a public website is a PUBLIC activity. The browser profile
+ * watermark system (src/browser/watermark.ts) separately prevents a lower-tainted
+ * session from reusing a profile that was previously used at a higher level.
+ *
+ * Interactive browser tools (click, type, select) require INTERNAL — they submit
+ * data into forms and carry a higher risk of unintended data disclosure.
+ *
+ * run_command requires CONFIDENTIAL — shell execution is a different risk category.
+ */
 export const HARDCODED_TOOL_FLOORS: ReadonlyMap<string, ClassificationLevel> =
   new Map<string, ClassificationLevel>([
     ["run_command", "CONFIDENTIAL"],
-    ["browser_navigate", "CONFIDENTIAL"],
-    ["browser_snapshot", "CONFIDENTIAL"],
-    ["browser_click", "CONFIDENTIAL"],
-    ["browser_type", "CONFIDENTIAL"],
-    ["browser_select", "CONFIDENTIAL"],
-    ["browser_scroll", "CONFIDENTIAL"],
-    ["browser_wait", "CONFIDENTIAL"],
+    // Interactive browser tools that submit data require INTERNAL floor
+    ["browser_click", "INTERNAL"],
+    ["browser_type", "INTERNAL"],
+    ["browser_select", "INTERNAL"],
+    // claude_* exec tools require INTERNAL (spawning sub-agents)
     ["claude_start", "INTERNAL"],
     ["claude_send", "INTERNAL"],
     ["claude_stop", "INTERNAL"],

--- a/tests/core/security/tool_floors_test.ts
+++ b/tests/core/security/tool_floors_test.ts
@@ -13,19 +13,28 @@ Deno.test("tool floor: run_command has CONFIDENTIAL floor", () => {
   assertEquals(registry.getFloor("run_command"), "CONFIDENTIAL");
 });
 
-Deno.test("tool floor: all browser tools have CONFIDENTIAL floor", () => {
+Deno.test("tool floor: interactive browser tools have INTERNAL floor", () => {
   const registry = createToolFloorRegistry();
-  const browserTools = [
-    "browser_navigate",
-    "browser_snapshot",
+  const interactiveBrowserTools = [
     "browser_click",
     "browser_type",
     "browser_select",
+  ];
+  for (const tool of interactiveBrowserTools) {
+    assertEquals(registry.getFloor(tool), "INTERNAL", `${tool} should have INTERNAL floor`);
+  }
+});
+
+Deno.test("tool floor: read-only browser tools have no floor", () => {
+  const registry = createToolFloorRegistry();
+  const readOnlyBrowserTools = [
+    "browser_navigate",
+    "browser_snapshot",
     "browser_scroll",
     "browser_wait",
   ];
-  for (const tool of browserTools) {
-    assertEquals(registry.getFloor(tool), "CONFIDENTIAL", `${tool} should have CONFIDENTIAL floor`);
+  for (const tool of readOnlyBrowserTools) {
+    assertEquals(registry.getFloor(tool), null, `${tool} should have no floor`);
   }
 });
 
@@ -70,18 +79,25 @@ Deno.test("tool floor: RESTRICTED session can invoke run_command", () => {
   assertEquals(registry.canInvoke("run_command", "RESTRICTED"), true);
 });
 
-// --- Scenario 4: INTERNAL session invokes browser_navigate → BLOCKED ---
+// --- Scenario 4: PUBLIC session invokes browser_navigate → ALLOWED (no floor) ---
 
-Deno.test("tool floor: INTERNAL session cannot invoke browser_navigate", () => {
+Deno.test("tool floor: PUBLIC session can invoke browser_navigate (no floor)", () => {
   const registry = createToolFloorRegistry();
-  assertEquals(registry.canInvoke("browser_navigate", "INTERNAL"), false);
+  assertEquals(registry.canInvoke("browser_navigate", "PUBLIC"), true);
 });
 
-// --- Scenario 5: CONFIDENTIAL session invokes browser_navigate → ALLOWED ---
+// --- Scenario 5: PUBLIC session cannot invoke browser_click (INTERNAL floor) ---
 
-Deno.test("tool floor: CONFIDENTIAL session can invoke browser_navigate", () => {
+Deno.test("tool floor: PUBLIC session cannot invoke browser_click", () => {
   const registry = createToolFloorRegistry();
-  assertEquals(registry.canInvoke("browser_navigate", "CONFIDENTIAL"), true);
+  assertEquals(registry.canInvoke("browser_click", "PUBLIC"), false);
+});
+
+// --- Scenario 5b: INTERNAL session can invoke browser_click (meets INTERNAL floor) ---
+
+Deno.test("tool floor: INTERNAL session can invoke browser_click", () => {
+  const registry = createToolFloorRegistry();
+  assertEquals(registry.canInvoke("browser_click", "INTERNAL"), true);
 });
 
 // --- Scenario 6: INTERNAL session invokes read_file → ALLOWED (no floor) ---
@@ -105,11 +121,11 @@ Deno.test("tool floor: enterprise can raise floor (run_command → RESTRICTED)",
 
 Deno.test("tool floor: enterprise CANNOT lower floor below hardcoded", () => {
   const overrides = new Map<string, ClassificationLevel>([
-    ["browser_navigate", "PUBLIC"],
+    ["run_command", "PUBLIC"],
   ]);
   const registry = createToolFloorRegistry(overrides);
   // Hardcoded is CONFIDENTIAL, enterprise tries to set PUBLIC → max = CONFIDENTIAL
-  assertEquals(registry.getFloor("browser_navigate"), "CONFIDENTIAL");
+  assertEquals(registry.getFloor("run_command"), "CONFIDENTIAL");
 });
 
 Deno.test("tool floor: enterprise can add floor to tool that had none", () => {
@@ -122,10 +138,12 @@ Deno.test("tool floor: enterprise can add floor to tool that had none", () => {
   assertEquals(registry.canInvoke("web_fetch", "CONFIDENTIAL"), true);
 });
 
-Deno.test("tool floor: PUBLIC session cannot invoke any floored tool", () => {
+Deno.test("tool floor: PUBLIC session cannot invoke floored tools", () => {
   const registry = createToolFloorRegistry();
   assertEquals(registry.canInvoke("run_command", "PUBLIC"), false);
-  assertEquals(registry.canInvoke("browser_navigate", "PUBLIC"), false);
+  assertEquals(registry.canInvoke("browser_click", "PUBLIC"), false);
+  assertEquals(registry.canInvoke("browser_type", "PUBLIC"), false);
+  assertEquals(registry.canInvoke("browser_select", "PUBLIC"), false);
 });
 
 Deno.test("tool floor: PUBLIC session can invoke unfloored tools", () => {

--- a/tests/e2e/taint_escalation_smoke_test.ts
+++ b/tests/e2e/taint_escalation_smoke_test.ts
@@ -148,17 +148,17 @@ Deno.test("SMOKE: full taint lifecycle — read → escalate → write-down bloc
   assertEquals(writeResult?.includes("blocked=true"), true, "write_file should have been blocked");
 });
 
-Deno.test("SMOKE: browser_navigate with tool floor — owner auto-escalates from PUBLIC", async () => {
+Deno.test("SMOKE: browser_navigate with no floor — PUBLIC session allowed directly", async () => {
   const log: string[] = [];
 
   let sessionTaint: ClassificationLevel = "PUBLIC";
   const order: Record<string, number> = { PUBLIC: 0, INTERNAL: 1, CONFIDENTIAL: 2, RESTRICTED: 3 };
 
-  // LLM calls browser_navigate to a CONFIDENTIAL domain from a PUBLIC session.
-  // browser_navigate has a CONFIDENTIAL tool floor. The owner pre-escalation
-  // should escalate PUBLIC → CONFIDENTIAL before the hook, so the floor passes.
+  // LLM calls browser_navigate from a PUBLIC session.
+  // browser_navigate has no floor — it should be allowed immediately without
+  // any taint escalation requirement.
   const toolSequence = [
-    { name: "browser_navigate", args: { url: "https://gmail.com/inbox" } },
+    { name: "browser_navigate", args: { url: "https://ibm.com" } },
   ];
   let toolIdx = 0;
 
@@ -187,13 +187,13 @@ Deno.test("SMOKE: browser_navigate with tool floor — owner auto-escalates from
     { name: "browser_navigate", description: "Navigate", parameters: { url: { type: "string", description: "u", required: true } } },
   ];
 
-  // Tool floor registry that returns CONFIDENTIAL for browser_navigate
+  // No hardcoded floor for browser_navigate — it has no floor in HARDCODED_TOOL_FLOORS
   const toolFloorRegistry = {
-    getFloor(toolName: string): ClassificationLevel | null {
-      const floors: Record<string, ClassificationLevel> = {
-        browser_navigate: "CONFIDENTIAL",
-      };
-      return floors[toolName] ?? null;
+    getFloor(_toolName: string): ClassificationLevel | null {
+      return null;
+    },
+    canInvoke(_toolName: string, _sessionTaint: ClassificationLevel): boolean {
+      return true;
     },
   };
 
@@ -227,11 +227,11 @@ Deno.test("SMOKE: browser_navigate with tool floor — owner auto-escalates from
   const session = createSession({ userId: "u" as UserId, channelId: "c" as ChannelId });
   const result = await orchestrator.processMessage({
     session,
-    message: "Navigate to gmail",
-    targetClassification: "CONFIDENTIAL",
+    message: "Open ibm.com",
+    targetClassification: "PUBLIC",
   });
 
-  console.log("\n── Browser Navigate + Tool Floor Log ──");
+  console.log("\n── Browser Navigate (no floor) Log ──");
   for (const entry of log) {
     console.log(`  ${entry}`);
   }
@@ -239,9 +239,8 @@ Deno.test("SMOKE: browser_navigate with tool floor — owner auto-escalates from
   console.log("────────────────────────────────────────\n");
 
   assertEquals(result.ok, true);
-  assertEquals(sessionTaint, "CONFIDENTIAL", "Owner should auto-escalate to CONFIDENTIAL");
 
-  // browser_navigate should NOT be blocked — owner pre-escalation satisfies the floor
+  // browser_navigate should NOT be blocked — no floor means PUBLIC sessions are allowed
   const navResult = log.find(l => l.includes("TOOL_RESULT: browser_navigate"));
-  assertEquals(navResult?.includes("blocked=false"), true, "browser_navigate should NOT be blocked for owner after auto-escalation");
+  assertEquals(navResult?.includes("blocked=false"), true, "browser_navigate should NOT be blocked for PUBLIC session");
 });

--- a/tests/e2e/tool_security_test.ts
+++ b/tests/e2e/tool_security_test.ts
@@ -58,7 +58,7 @@ Deno.test("e2e: tool floor allows CONFIDENTIAL session for run_command", async (
   assertEquals(result.allowed, true);
 });
 
-Deno.test("e2e: tool floor blocks PUBLIC session from browser_navigate", async () => {
+Deno.test("e2e: tool floor allows PUBLIC session to use browser_navigate (no floor)", async () => {
   const runner = makeHookRunner();
   const session = makeSession("PUBLIC");
 
@@ -66,7 +66,22 @@ Deno.test("e2e: tool floor blocks PUBLIC session from browser_navigate", async (
     session,
     input: {
       tool_call: { name: "browser_navigate", args: { url: "https://example.com" } },
-      tool_floor: "CONFIDENTIAL" as ClassificationLevel,
+      // No tool_floor set — browser_navigate no longer has a hardcoded floor
+    },
+  });
+
+  assertEquals(result.allowed, true);
+});
+
+Deno.test("e2e: tool floor blocks PUBLIC session from browser_click (INTERNAL floor)", async () => {
+  const runner = makeHookRunner();
+  const session = makeSession("PUBLIC");
+
+  const result = await runner.run("PRE_TOOL_CALL", {
+    session,
+    input: {
+      tool_call: { name: "browser_click", args: { selector: "#submit" } },
+      tool_floor: "INTERNAL" as ClassificationLevel,
     },
   });
 


### PR DESCRIPTION
Fixes #44

Browser tools had a hardcoded CONFIDENTIAL floor, blocking all browser use in fresh PUBLIC sessions. Read-only tools (navigate, snapshot, scroll, wait) now have no floor. Interactive tools (click, type, select) require INTERNAL.

Generated with [Claude Code](https://claude.ai/code)