### PR TITLE
[Phase 0] feat: encrypt custom secrets in Windows/Docker JSON file

### DIFF
--- a/src/secrets/encrypted_file_provider.ts
+++ b/src/secrets/encrypted_file_provider.ts
@@ -1,0 +1,325 @@
+/**
+ * AES-256-GCM encrypted file-backed secret store.
+ *
+ * Stores secrets in a JSON file where each entry's value is encrypted
+ * independently with a fresh 12-byte IV. The encryption key is loaded
+ * from a companion key file via {@link loadOrCreateMachineKey}.
+ *
+ * File format (v1):
+ * ```json
+ * {
+ *   "v": 1,
+ *   "entries": {
+ *     "MY_SECRET": { "iv": "<base64-12-bytes>", "ct": "<base64-ciphertext>" }
+ *   }
+ * }
+ * ```
+ *
+ * Secret names are stored in plaintext (keys); only values are encrypted.
+ *
+ * On first load, if the file contains a legacy flat `Record<string, string>`
+ * format, it is automatically migrated to the encrypted v1 format.
+ *
+ * @module
+ */
+
+import { dirname } from "@std/path";
+import type { Result } from "../core/types/classification.ts";
+import type { SecretStore } from "./keychain.ts";
+import { loadOrCreateMachineKey } from "./key_manager.ts";
+
+/** Options for creating an encrypted file-backed secret store. */
+export interface EncryptedFileSecretStoreOptions {
+  /** Path to the encrypted secrets JSON file. */
+  readonly secretsPath: string;
+  /** Path to the companion key file (32 raw bytes). */
+  readonly keyPath: string;
+}
+
+/** An encrypted entry in the secrets file. */
+interface EncryptedEntry {
+  /** Base64-encoded 12-byte IV. */
+  readonly iv: string;
+  /** Base64-encoded AES-GCM ciphertext + 16-byte auth tag. */
+  readonly ct: string;
+}
+
+/** The on-disk format for the encrypted secrets file (version 1). */
+interface EncryptedSecretsFile {
+  readonly v: 1;
+  readonly entries: Record<string, EncryptedEntry>;
+}
+
+/** Encode a Uint8Array to base64 string. */
+function toBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+/** Decode a base64 string to Uint8Array. */
+function fromBase64(b64: string): Uint8Array {
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+/**
+ * Create an AES-256-GCM encrypted file-backed secret store.
+ *
+ * - Each entry is encrypted with a fresh random 12-byte IV on every write.
+ * - The encryption key is derived from a machine-bound key file.
+ * - On first access, a legacy plain-text JSON file is auto-migrated.
+ * - The `SecretStore` interface is identical to other backends.
+ *
+ * @param options - Paths for the secrets file and key file
+ * @returns A SecretStore backed by an AES-256-GCM encrypted JSON file
+ */
+export function createEncryptedFileSecretStore(
+  options: EncryptedFileSecretStoreOptions,
+): SecretStore {
+  const { secretsPath, keyPath } = options;
+
+  // Cached key — loaded once per store instance
+  let cachedKey: CryptoKey | null = null;
+  // Cached parsed file — invalidated on every write
+  let cachedFile: EncryptedSecretsFile | null = null;
+
+  async function getKey(): Promise<Result<CryptoKey, string>> {
+    if (cachedKey !== null) {
+      return { ok: true, value: cachedKey };
+    }
+    const result = await loadOrCreateMachineKey({ keyPath });
+    if (result.ok) {
+      cachedKey = result.value;
+    }
+    return result;
+  }
+
+  async function loadFile(): Promise<Result<EncryptedSecretsFile, string>> {
+    if (cachedFile !== null) {
+      return { ok: true, value: cachedFile };
+    }
+
+    let raw: string;
+    try {
+      raw = await Deno.readTextFile(secretsPath);
+    } catch {
+      // File does not exist — start with empty store
+      const empty: EncryptedSecretsFile = { v: 1, entries: {} };
+      cachedFile = empty;
+      return { ok: true, value: empty };
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return { ok: false, error: `Failed to parse secrets file: ${secretsPath}` };
+    }
+
+    // Detect and migrate legacy flat format: { "KEY": "plaintext-value" }
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      !("v" in parsed) &&
+      !("entries" in parsed)
+    ) {
+      const keyResult = await getKey();
+      if (!keyResult.ok) {
+        return { ok: false, error: keyResult.error };
+      }
+      const migrated = await migrateLegacyFile(
+        parsed as Record<string, string>,
+        keyResult.value,
+      );
+      if (!migrated.ok) {
+        return migrated;
+      }
+      cachedFile = migrated.value;
+      await persistFile(migrated.value);
+      console.log("Migrating secrets.json to encrypted format");
+      return { ok: true, value: migrated.value };
+    }
+
+    // Validate v1 format
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      (parsed as Record<string, unknown>)["v"] !== 1 ||
+      typeof (parsed as Record<string, unknown>)["entries"] !== "object"
+    ) {
+      return {
+        ok: false,
+        error: `Unrecognized secrets file format: ${secretsPath}`,
+      };
+    }
+
+    cachedFile = parsed as EncryptedSecretsFile;
+    return { ok: true, value: cachedFile };
+  }
+
+  async function persistFile(file: EncryptedSecretsFile): Promise<void> {
+    await Deno.mkdir(dirname(secretsPath), { recursive: true });
+    await Deno.writeTextFile(secretsPath, JSON.stringify(file, null, 2) + "\n");
+    if (Deno.build.os !== "windows") {
+      try {
+        await Deno.chmod(secretsPath, 0o600);
+      } catch {
+        // Best-effort
+      }
+    }
+  }
+
+  async function encryptValue(
+    key: CryptoKey,
+    plaintext: string,
+  ): Promise<Result<EncryptedEntry, string>> {
+    try {
+      const iv = crypto.getRandomValues(new Uint8Array(12));
+      const encoded = new TextEncoder().encode(plaintext);
+      const ciphertext = await crypto.subtle.encrypt(
+        { name: "AES-GCM", iv },
+        key,
+        encoded,
+      );
+      return {
+        ok: true,
+        value: {
+          iv: toBase64(iv),
+          ct: toBase64(new Uint8Array(ciphertext)),
+        },
+      };
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { ok: false, error: `Encryption failed: ${message}` };
+    }
+  }
+
+  async function decryptEntry(
+    key: CryptoKey,
+    entry: EncryptedEntry,
+  ): Promise<Result<string, string>> {
+    try {
+      const iv = fromBase64(entry.iv);
+      const ct = fromBase64(entry.ct);
+      const plaintext = await crypto.subtle.decrypt(
+        { name: "AES-GCM", iv },
+        key,
+        ct,
+      );
+      return { ok: true, value: new TextDecoder().decode(plaintext) };
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { ok: false, error: `Decryption failed: ${message}` };
+    }
+  }
+
+  async function migrateLegacyFile(
+    legacy: Record<string, string>,
+    key: CryptoKey,
+  ): Promise<Result<EncryptedSecretsFile, string>> {
+    const entries: Record<string, EncryptedEntry> = {};
+    for (const [name, value] of Object.entries(legacy)) {
+      const result = await encryptValue(key, value);
+      if (!result.ok) {
+        return { ok: false, error: `Migration failed for '${name}': ${result.error}` };
+      }
+      entries[name] = result.value;
+    }
+    return { ok: true, value: { v: 1, entries } };
+  }
+
+  return {
+    async getSecret(name: string): Promise<Result<string, string>> {
+      const fileResult = await loadFile();
+      if (!fileResult.ok) {
+        return { ok: false, error: fileResult.error };
+      }
+
+      const entry = fileResult.value.entries[name];
+      if (entry === undefined) {
+        return { ok: false, error: `Secret '${name}' not found in ${secretsPath}` };
+      }
+
+      const keyResult = await getKey();
+      if (!keyResult.ok) {
+        return { ok: false, error: keyResult.error };
+      }
+
+      return decryptEntry(keyResult.value, entry);
+    },
+
+    async setSecret(name: string, value: string): Promise<Result<true, string>> {
+      const keyResult = await getKey();
+      if (!keyResult.ok) {
+        return { ok: false, error: keyResult.error };
+      }
+
+      const fileResult = await loadFile();
+      if (!fileResult.ok) {
+        return { ok: false, error: fileResult.error };
+      }
+
+      const encResult = await encryptValue(keyResult.value, value);
+      if (!encResult.ok) {
+        return { ok: false, error: encResult.error };
+      }
+
+      const updated: EncryptedSecretsFile = {
+        v: 1,
+        entries: {
+          ...fileResult.value.entries,
+          [name]: encResult.value,
+        },
+      };
+
+      try {
+        await persistFile(updated);
+        cachedFile = updated;
+        return { ok: true, value: true };
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { ok: false, error: `Failed to write secrets file: ${message}` };
+      }
+    },
+
+    async deleteSecret(name: string): Promise<Result<true, string>> {
+      const fileResult = await loadFile();
+      if (!fileResult.ok) {
+        return { ok: false, error: fileResult.error };
+      }
+
+      if (!(name in fileResult.value.entries)) {
+        return { ok: false, error: `Secret '${name}' not found in ${secretsPath}` };
+      }
+
+      const newEntries = { ...fileResult.value.entries };
+      delete newEntries[name];
+
+      const updated: EncryptedSecretsFile = { v: 1, entries: newEntries };
+
+      try {
+        await persistFile(updated);
+        cachedFile = updated;
+        return { ok: true, value: true };
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { ok: false, error: `Failed to write secrets file: ${message}` };
+      }
+    },
+
+    async listSecrets(): Promise<Result<string[], string>> {
+      const fileResult = await loadFile();
+      if (!fileResult.ok) {
+        return { ok: false, error: fileResult.error };
+      }
+      return { ok: true, value: Object.keys(fileResult.value.entries) };
+    },
+  };
+}

--- a/src/secrets/key_manager.ts
+++ b/src/secrets/key_manager.ts
@@ -1,0 +1,87 @@
+/**
+ * Machine-bound encryption key management.
+ *
+ * Generates or loads a 256-bit AES-GCM key stored as raw bytes in a
+ * dedicated key file. The key file is the machine secret: it is placed
+ * in a user-owned directory and chmod 0600 on Unix systems.
+ *
+ * @module
+ */
+
+import { dirname } from "@std/path";
+import type { Result } from "../core/types/classification.ts";
+
+/** Options for loading or creating the machine key. */
+export interface MachineKeyOptions {
+  /** Absolute path to the key file (e.g. `~/.triggerfish/secrets.key`). */
+  readonly keyPath: string;
+}
+
+/**
+ * Load the machine encryption key from disk, or generate a new one if
+ * the key file does not exist.
+ *
+ * - If the key file exists: reads 32 raw bytes and imports as AES-256-GCM.
+ * - If absent: generates a new random 256-bit key, writes raw bytes to disk,
+ *   and sets file permissions to 0600 on Unix.
+ *
+ * @param options - Key file path configuration
+ * @returns The CryptoKey on success, or an error string on failure
+ */
+export async function loadOrCreateMachineKey(
+  options: MachineKeyOptions,
+): Promise<Result<CryptoKey, string>> {
+  const { keyPath } = options;
+
+  try {
+    // Attempt to read existing key file
+    let rawBytes: Uint8Array;
+    try {
+      const fileBytes = await Deno.readFile(keyPath);
+      if (fileBytes.byteLength !== 32) {
+        return {
+          ok: false,
+          error: `Key file '${keyPath}' is corrupt: expected 32 bytes, got ${fileBytes.byteLength}`,
+        };
+      }
+      rawBytes = fileBytes;
+    } catch {
+      // Key file does not exist — generate a new key
+      const key = await crypto.subtle.generateKey(
+        { name: "AES-GCM", length: 256 },
+        true,
+        ["encrypt", "decrypt"],
+      );
+      const exported = await crypto.subtle.exportKey("raw", key);
+      rawBytes = new Uint8Array(exported);
+
+      // Write key file with restrictive permissions
+      await Deno.mkdir(dirname(keyPath), { recursive: true });
+      await Deno.writeFile(keyPath, rawBytes, { mode: 0o600 });
+
+      // Explicitly chmod on Unix (writeFile mode may be masked by umask)
+      if (Deno.build.os !== "windows") {
+        try {
+          await Deno.chmod(keyPath, 0o600);
+        } catch {
+          // Best-effort; chmod may fail in restricted containers
+        }
+      }
+
+      return { ok: true, value: key };
+    }
+
+    // Import the existing raw bytes as AES-GCM key
+    const key = await crypto.subtle.importKey(
+      "raw",
+      rawBytes,
+      { name: "AES-GCM" },
+      false,
+      ["encrypt", "decrypt"],
+    );
+    return { ok: true, value: key };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: `Failed to load machine key: ${message}` };
+  }
+}

--- a/src/secrets/keychain.ts
+++ b/src/secrets/keychain.ts
@@ -11,7 +11,7 @@
 import { join } from "@std/path";
 import type { Result } from "../core/types/classification.ts";
 import { isDockerEnvironment } from "../core/env.ts";
-import { createFileSecretStore } from "./file_provider.ts";
+import { createEncryptedFileSecretStore } from "./encrypted_file_provider.ts";
 
 /** Service name used for all keychain entries. */
 const SERVICE_NAME = "triggerfish";
@@ -360,7 +360,10 @@ export function createMemorySecretStore(): SecretStore {
  */
 export function createKeychain(): SecretStore {
   if (isDockerEnvironment()) {
-    return createFileSecretStore({ path: "/data/secrets.json" });
+    return createEncryptedFileSecretStore({
+      secretsPath: "/data/secrets.json",
+      keyPath: "/data/secrets.key",
+    });
   }
 
   const os = Deno.build.os;
@@ -379,7 +382,10 @@ export function createKeychain(): SecretStore {
           Deno.env.get("HOME") ?? Deno.env.get("USERPROFILE") ?? ".",
           ".triggerfish",
         );
-      return createFileSecretStore({ path: join(dataDir, "secrets.json") });
+      return createEncryptedFileSecretStore({
+        secretsPath: join(dataDir, "secrets.json"),
+        keyPath: join(dataDir, "secrets.key"),
+      });
     }
     default:
       return createMemorySecretStore();

--- a/src/secrets/mod.ts
+++ b/src/secrets/mod.ts
@@ -13,3 +13,7 @@ export { createKeychain, createMemorySecretStore } from "./keychain.ts";
 export type { SecretStore } from "./keychain.ts";
 export { createFileSecretStore } from "./file_provider.ts";
 export type { FileSecretStoreOptions } from "./file_provider.ts";
+export { createEncryptedFileSecretStore } from "./encrypted_file_provider.ts";
+export type { EncryptedFileSecretStoreOptions } from "./encrypted_file_provider.ts";
+export { loadOrCreateMachineKey } from "./key_manager.ts";
+export type { MachineKeyOptions } from "./key_manager.ts";

--- a/tests/secrets/encrypted_file_provider_test.ts
+++ b/tests/secrets/encrypted_file_provider_test.ts
@@ -1,0 +1,273 @@
+/**
+ * Unit tests for the AES-256-GCM encrypted file secret store.
+ *
+ * All tests use temporary directories and clean up after themselves.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
+import { createEncryptedFileSecretStore } from "../../src/secrets/encrypted_file_provider.ts";
+
+// Helper: create a temp dir and return its path + a cleanup function
+async function withTempDir(
+  fn: (dir: string) => Promise<void>,
+): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "triggerfish_enc_test_" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+// Helper: build store options from a temp dir
+function storeOpts(dir: string) {
+  return {
+    secretsPath: join(dir, "secrets.json"),
+    keyPath: join(dir, "secrets.key"),
+  };
+}
+
+// --- Basic CRUD ---
+
+Deno.test("setSecret and getSecret round-trip correctly", async () => {
+  await withTempDir(async (dir) => {
+    const store = createEncryptedFileSecretStore(storeOpts(dir));
+
+    const setResult = await store.setSecret("MY_KEY", "super-secret-value");
+    assertEquals(setResult.ok, true);
+
+    const getResult = await store.getSecret("MY_KEY");
+    assertEquals(getResult.ok, true);
+    if (getResult.ok) {
+      assertEquals(getResult.value, "super-secret-value");
+    }
+  });
+});
+
+Deno.test("setSecret overwrites an existing secret", async () => {
+  await withTempDir(async (dir) => {
+    const store = createEncryptedFileSecretStore(storeOpts(dir));
+
+    await store.setSecret("TOKEN", "old-token");
+    await store.setSecret("TOKEN", "new-token");
+
+    const result = await store.getSecret("TOKEN");
+    assertEquals(result.ok, true);
+    if (result.ok) {
+      assertEquals(result.value, "new-token");
+    }
+  });
+});
+
+Deno.test("deleteSecret removes entry; subsequent getSecret returns error", async () => {
+  await withTempDir(async (dir) => {
+    const store = createEncryptedFileSecretStore(storeOpts(dir));
+
+    await store.setSecret("TEMP", "temporary-value");
+
+    const deleteResult = await store.deleteSecret("TEMP");
+    assertEquals(deleteResult.ok, true);
+
+    const getResult = await store.getSecret("TEMP");
+    assertEquals(getResult.ok, false);
+    if (!getResult.ok) {
+      assertStringIncludes(getResult.error, "not found");
+    }
+  });
+});
+
+Deno.test("listSecrets returns all stored secret names without decrypting", async () => {
+  await withTempDir(async (dir) => {
+    const store = createEncryptedFileSecretStore(storeOpts(dir));
+
+    await store.setSecret("KEY_A", "val-a");
+    await store.setSecret("KEY_B", "val-b");
+    await store.setSecret("KEY_C", "val-c");
+
+    const result = await store.listSecrets();
+    assertEquals(result.ok, true);
+    if (result.ok) {
+      assertEquals(result.value.length, 3);
+      assertEquals(result.value.includes("KEY_A"), true);
+      assertEquals(result.value.includes("KEY_B"), true);
+      assertEquals(result.value.includes("KEY_C"), true);
+    }
+  });
+});
+
+Deno.test("listSecrets returns empty array when no secrets stored", async () => {
+  await withTempDir(async (dir) => {
+    const store = createEncryptedFileSecretStore(storeOpts(dir));
+
+    const result = await store.listSecrets();
+    assertEquals(result.ok, true);
+    if (result.ok) {
+      assertEquals(result.value, []);
+    }
+  });
+});
+
+Deno.test("getSecret returns error for nonexistent key", async () => {
+  await withTempDir(async (dir) => {
+    const store = createEncryptedFileSecretStore(storeOpts(dir));
+
+    const result = await store.getSecret("DOES_NOT_EXIST");
+    assertEquals(result.ok, false);
+    if (!result.ok) {
+      assertStringIncludes(result.error, "not found");
+    }
+  });
+});
+
+Deno.test("deleteSecret returns error for nonexistent key", async () => {
+  await withTempDir(async (dir) => {
+    const store = createEncryptedFileSecretStore(storeOpts(dir));
+
+    const result = await store.deleteSecret("DOES_NOT_EXIST");
+    assertEquals(result.ok, false);
+    if (!result.ok) {
+      assertStringIncludes(result.error, "not found");
+    }
+  });
+});
+
+// --- Encryption sanity ---
+
+Deno.test("encrypted file is not plain-text (raw file content differs from value)", async () => {
+  await withTempDir(async (dir) => {
+    const opts = storeOpts(dir);
+    const store = createEncryptedFileSecretStore(opts);
+
+    await store.setSecret("API_KEY", "very-secret-api-key-1234");
+
+    const raw = await Deno.readTextFile(opts.secretsPath);
+    // The plaintext value must not appear verbatim in the file
+    assertEquals(raw.includes("very-secret-api-key-1234"), false);
+    // The file must be valid JSON with v=1 format
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    assertEquals(parsed["v"], 1);
+  });
+});
+
+Deno.test("two different setSecret calls produce different ciphertexts (IV freshness)", async () => {
+  await withTempDir(async (dir) => {
+    const store = createEncryptedFileSecretStore(storeOpts(dir));
+
+    // Write the same value twice (to same key — overwrite)
+    await store.setSecret("KEY", "same-value");
+    const rawFirst = JSON.parse(await Deno.readTextFile(storeOpts(dir).secretsPath));
+
+    await store.setSecret("KEY", "same-value");
+    const rawSecond = JSON.parse(await Deno.readTextFile(storeOpts(dir).secretsPath));
+
+    // The IV should differ on each write
+    const ivFirst = (rawFirst as { entries: Record<string, { iv: string }> }).entries["KEY"].iv;
+    const ivSecond = (rawSecond as { entries: Record<string, { iv: string }> }).entries["KEY"].iv;
+    assertEquals(ivFirst !== ivSecond, true);
+  });
+});
+
+// --- Migration from legacy plain-text format ---
+
+Deno.test("auto-migrates legacy plain-text JSON to encrypted format on first load", async () => {
+  await withTempDir(async (dir) => {
+    const opts = storeOpts(dir);
+
+    // Write a legacy flat JSON file
+    await Deno.mkdir(dir, { recursive: true });
+    await Deno.writeTextFile(
+      opts.secretsPath,
+      JSON.stringify({ OLD_KEY: "old-plain-value", ANOTHER: "another-value" }),
+    );
+
+    // Open the encrypted store — should auto-migrate
+    const store = createEncryptedFileSecretStore(opts);
+
+    const result1 = await store.getSecret("OLD_KEY");
+    assertEquals(result1.ok, true);
+    if (result1.ok) {
+      assertEquals(result1.value, "old-plain-value");
+    }
+
+    const result2 = await store.getSecret("ANOTHER");
+    assertEquals(result2.ok, true);
+    if (result2.ok) {
+      assertEquals(result2.value, "another-value");
+    }
+
+    // File must now be in v1 encrypted format
+    const raw = await Deno.readTextFile(opts.secretsPath);
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    assertEquals(parsed["v"], 1);
+    // Values must not be in plaintext
+    assertEquals(raw.includes("old-plain-value"), false);
+    assertEquals(raw.includes("another-value"), false);
+  });
+});
+
+// --- Edge cases ---
+
+Deno.test("secrets with empty string values are stored and retrieved correctly", async () => {
+  await withTempDir(async (dir) => {
+    const store = createEncryptedFileSecretStore(storeOpts(dir));
+
+    const setResult = await store.setSecret("EMPTY", "");
+    assertEquals(setResult.ok, true);
+
+    const getResult = await store.getSecret("EMPTY");
+    assertEquals(getResult.ok, true);
+    if (getResult.ok) {
+      assertEquals(getResult.value, "");
+    }
+  });
+});
+
+Deno.test("secrets with special characters in name and value round-trip correctly", async () => {
+  await withTempDir(async (dir) => {
+    const store = createEncryptedFileSecretStore(storeOpts(dir));
+
+    await store.setSecret("my/secret.key-1", "p@$$w0rd!#%^&*()");
+
+    const result = await store.getSecret("my/secret.key-1");
+    assertEquals(result.ok, true);
+    if (result.ok) {
+      assertEquals(result.value, "p@$$w0rd!#%^&*()");
+    }
+  });
+});
+
+Deno.test("listSecrets reflects deletions correctly", async () => {
+  await withTempDir(async (dir) => {
+    const store = createEncryptedFileSecretStore(storeOpts(dir));
+
+    await store.setSecret("KEEP", "keep-value");
+    await store.setSecret("REMOVE", "remove-value");
+    await store.deleteSecret("REMOVE");
+
+    const result = await store.listSecrets();
+    assertEquals(result.ok, true);
+    if (result.ok) {
+      assertEquals(result.value.includes("KEEP"), true);
+      assertEquals(result.value.includes("REMOVE"), false);
+    }
+  });
+});
+
+Deno.test("store persists data across separate store instances (same files)", async () => {
+  await withTempDir(async (dir) => {
+    const opts = storeOpts(dir);
+
+    // Write with first store instance
+    const store1 = createEncryptedFileSecretStore(opts);
+    await store1.setSecret("PERSISTENT", "cross-instance-value");
+
+    // Read with second store instance (new in-memory cache)
+    const store2 = createEncryptedFileSecretStore(opts);
+    const result = await store2.getSecret("PERSISTENT");
+    assertEquals(result.ok, true);
+    if (result.ok) {
+      assertEquals(result.value, "cross-instance-value");
+    }
+  });
+});

--- a/tests/secrets/key_manager_test.ts
+++ b/tests/secrets/key_manager_test.ts
@@ -1,0 +1,162 @@
+/**
+ * Unit tests for the machine key manager.
+ *
+ * Tests key generation, loading, and error handling using
+ * temporary directories so no filesystem state is left behind.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
+import { loadOrCreateMachineKey } from "../../src/secrets/key_manager.ts";
+
+// Helper: create a temp dir and return its path + a cleanup function
+async function withTempDir(
+  fn: (dir: string) => Promise<void>,
+): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "triggerfish_key_test_" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+// --- Key generation ---
+
+Deno.test(
+  "loadOrCreateMachineKey generates a valid CryptoKey when no key file exists",
+  async () => {
+    await withTempDir(async (dir) => {
+      const keyPath = join(dir, "secrets.key");
+      const result = await loadOrCreateMachineKey({ keyPath });
+
+      assertEquals(result.ok, true);
+      if (result.ok) {
+        assertEquals(result.value.type, "secret");
+        assertEquals(result.value.algorithm.name, "AES-GCM");
+        assertEquals((result.value.algorithm as AesKeyAlgorithm).length, 256);
+        assertEquals(result.value.usages.includes("encrypt"), true);
+        assertEquals(result.value.usages.includes("decrypt"), true);
+      }
+    });
+  },
+);
+
+Deno.test(
+  "loadOrCreateMachineKey writes a 32-byte key file on first call",
+  async () => {
+    await withTempDir(async (dir) => {
+      const keyPath = join(dir, "secrets.key");
+      const result = await loadOrCreateMachineKey({ keyPath });
+      assertEquals(result.ok, true);
+
+      const fileBytes = await Deno.readFile(keyPath);
+      assertEquals(fileBytes.byteLength, 32);
+    });
+  },
+);
+
+// --- Key persistence / determinism ---
+
+Deno.test(
+  "loadOrCreateMachineKey loads the same key on subsequent calls",
+  async () => {
+    await withTempDir(async (dir) => {
+      const keyPath = join(dir, "secrets.key");
+
+      // Generate key (first call)
+      const result1 = await loadOrCreateMachineKey({ keyPath });
+      assertEquals(result1.ok, true);
+
+      // Read the raw bytes of the generated key file
+      const rawBytes = await Deno.readFile(keyPath);
+
+      // Load key (second call)
+      const result2 = await loadOrCreateMachineKey({ keyPath });
+      assertEquals(result2.ok, true);
+
+      // Both keys should decrypt data encrypted by the other.
+      // Verify by encrypting with key1 and decrypting with key2.
+      if (result1.ok && result2.ok) {
+        const iv = crypto.getRandomValues(new Uint8Array(12));
+        const plaintext = new TextEncoder().encode("test-value");
+        const ct = await crypto.subtle.encrypt(
+          { name: "AES-GCM", iv },
+          result1.value,
+          plaintext,
+        );
+        const decrypted = await crypto.subtle.decrypt(
+          { name: "AES-GCM", iv },
+          result2.value,
+          ct,
+        );
+        assertEquals(
+          new TextDecoder().decode(decrypted),
+          "test-value",
+        );
+      }
+
+      // Suppress unused variable warning
+      assertEquals(rawBytes.byteLength, 32);
+    });
+  },
+);
+
+// --- Key file in nested directory ---
+
+Deno.test(
+  "loadOrCreateMachineKey creates intermediate directories as needed",
+  async () => {
+    await withTempDir(async (dir) => {
+      const keyPath = join(dir, "nested", "deep", "secrets.key");
+      const result = await loadOrCreateMachineKey({ keyPath });
+      assertEquals(result.ok, true);
+
+      const fileBytes = await Deno.readFile(keyPath);
+      assertEquals(fileBytes.byteLength, 32);
+    });
+  },
+);
+
+// --- Corrupt key file ---
+
+Deno.test(
+  "loadOrCreateMachineKey returns error when key file has wrong byte count",
+  async () => {
+    await withTempDir(async (dir) => {
+      const keyPath = join(dir, "secrets.key");
+      // Write a corrupt key file (16 bytes instead of 32)
+      await Deno.writeFile(keyPath, new Uint8Array(16));
+
+      const result = await loadOrCreateMachineKey({ keyPath });
+      assertEquals(result.ok, false);
+      if (!result.ok) {
+        assertStringIncludes(result.error, "corrupt");
+      }
+    });
+  },
+);
+
+// --- Two calls return interoperable keys ---
+
+Deno.test(
+  "loadOrCreateMachineKey produces a key that is usable for AES-GCM encryption",
+  async () => {
+    await withTempDir(async (dir) => {
+      const keyPath = join(dir, "secrets.key");
+      const result = await loadOrCreateMachineKey({ keyPath });
+      assertEquals(result.ok, true);
+
+      if (result.ok) {
+        const key = result.value;
+        const iv = crypto.getRandomValues(new Uint8Array(12));
+        const data = new TextEncoder().encode("hello secrets");
+
+        const ct = await crypto.subtle.encrypt({ name: "AES-GCM", iv }, key, data);
+        const pt = await crypto.subtle.decrypt({ name: "AES-GCM", iv }, key, ct);
+
+        assertEquals(new TextDecoder().decode(pt), "hello secrets");
+      }
+    });
+  },
+);


### PR DESCRIPTION
Implements AES-256-GCM encryption for secrets stored in the file-backed secret store used on Windows and Docker. Secrets were previously stored in plain-text JSON at `~\.triggerfish\secrets.json`.

Closes #45

Generated with [Claude Code](https://claude.ai/code)