### PR TITLE
[Phase 0] feat: secure password tool with out-of-context prompt and reference substitution

### DIFF
--- a/src/agent/orchestrator.ts
+++ b/src/agent/orchestrator.ts
@@ -14,6 +14,8 @@
 
 import type { Result, ClassificationLevel } from "../core/types/classification.ts";
 import { canFlowTo } from "../core/types/classification.ts";
+import type { SecretStore } from "../secrets/keychain.ts";
+import { resolveSecretRefs } from "../secrets/resolver.ts";
 import type { PathClassifier } from "../core/security/path_classification.ts";
 import type { ToolFloorRegistry } from "../core/security/tool_floors.ts";
 import {
@@ -119,6 +121,12 @@ export interface OrchestratorConfig {
   readonly domainClassifier?: DomainClassifier;
   /** Tool floor registry for minimum classification enforcement. */
   readonly toolFloorRegistry?: ToolFloorRegistry;
+  /**
+   * Secret store for resolving `{{secret:name}}` references in tool arguments.
+   * When provided, all tool input arguments are scanned and references substituted
+   * before dispatch. The resolved values are never logged or returned to the LLM.
+   */
+  readonly secretStore?: SecretStore;
 }
 
 /** Config shape for building integration/plugin/channel classification map. */
@@ -442,7 +450,23 @@ export function createOrchestrator(config: OrchestratorConfig): Orchestrator {
           }
         }
 
-        const result = await rawToolExecutor(name, input);
+        // Resolve {{secret:name}} references in tool input before dispatch.
+        // The LLM never sees the resolved values — substitution happens here,
+        // below the LLM layer.
+        let resolvedInput = input;
+        if (config.secretStore) {
+          const resolution = await resolveSecretRefs(input, config.secretStore);
+          if (resolution.ok) {
+            if (resolution.value.missing.length > 0) {
+              return `Error: The following secrets were referenced but not found in the secret store: ${
+                resolution.value.missing.map((n) => `'${n}'`).join(", ")
+              }. Use secret_save to store them first.`;
+            }
+            resolvedInput = resolution.value.resolved;
+          }
+        }
+
+        const result = await rawToolExecutor(name, resolvedInput);
 
         // Post-call: escalate based on response-level classification
         // (e.g. GitHub per-repo classification in _classification field)

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -204,6 +204,12 @@ import {
 } from "../github/mod.ts";
 import { createKeychain } from "../secrets/keychain.ts";
 import {
+  createSecretToolExecutor,
+  getSecretToolDefinitions,
+  SECRET_TOOLS_SYSTEM_PROMPT,
+} from "../secrets/tools.ts";
+import type { SecretPromptCallback } from "../secrets/tools.ts";
+import {
   createMcpServerManager,
   createMcpExecutor,
   createMcpGateway,
@@ -1620,6 +1626,66 @@ async function runStart(): Promise<void> {
   });
   const claudeExecutor = createClaudeToolExecutor(claudeSessionManager);
 
+  // Secret store and CLI prompt callback for secure out-of-context secret input.
+  // The prompt writes directly to the terminal TTY to keep the value off-screen
+  // and out of any pipe or log. The LLM never sees the entered value.
+  const mainKeychain = createKeychain();
+  const cliSecretPrompt: SecretPromptCallback = async (
+    name: string,
+    hint?: string,
+  ): Promise<string | null> => {
+    const promptText = hint
+      ? `Enter value for '${name}' (${hint}): `
+      : `Enter value for '${name}': `;
+    // Write prompt to stderr so it shows on terminal even when stdout is piped.
+    Deno.stderr.writeSync(new TextEncoder().encode(promptText));
+    // Read from stdin with raw mode to suppress echo.
+    try {
+      Deno.stdin.setRaw(true);
+    } catch {
+      // setRaw may fail in non-TTY environments; proceed without it.
+    }
+    const chars: number[] = [];
+    const buf = new Uint8Array(1);
+    try {
+      while (true) {
+        const n = await Deno.stdin.read(buf);
+        if (n === null) break;
+        const byte = buf[0];
+        // Enter key
+        if (byte === 13 || byte === 10) break;
+        // Ctrl-C
+        if (byte === 3) {
+          Deno.stderr.writeSync(new TextEncoder().encode("\n"));
+          return null;
+        }
+        // Backspace
+        if (byte === 127 || byte === 8) {
+          if (chars.length > 0) chars.pop();
+        } else {
+          chars.push(byte);
+        }
+      }
+    } finally {
+      try {
+        Deno.stdin.setRaw(false);
+      } catch {
+        // Ignore
+      }
+      Deno.stderr.writeSync(new TextEncoder().encode("\n"));
+    }
+    return new TextDecoder().decode(new Uint8Array(chars));
+  };
+  // Mutable prompt callback ref — defaults to CLI terminal input.
+  // Tidepool path swaps this to the browser WebSocket callback once the
+  // chatSession is available. Access is safe because the mutex serializes
+  // processMessage calls and ensures no concurrent secret_save invocations.
+  let activeSecretPrompt: SecretPromptCallback = cliSecretPrompt;
+  const secretExecutor = createSecretToolExecutor(
+    mainKeychain,
+    (name, hint) => activeSecretPrompt(name, hint),
+  );
+
   const toolExecutor = createToolExecutor({
     execTools,
     cronManager,
@@ -1648,6 +1714,7 @@ async function runStart(): Promise<void> {
     claudeExecutor,
     mcpExecutor,
     subagentFactory,
+    secretExecutor,
     providerRegistry: registry,
   });
 
@@ -1681,8 +1748,10 @@ async function runStart(): Promise<void> {
       SUMMARIZE_SYSTEM_PROMPT,
       HEALTHCHECK_SYSTEM_PROMPT,
       CLAUDE_SESSION_SYSTEM_PROMPT,
+      SECRET_TOOLS_SYSTEM_PROMPT,
       mcpSystemPrompt,
     ],
+    secretStore: mainKeychain,
     session,
     ...(streamingPref !== undefined
       ? { enableStreaming: streamingPref === true }
@@ -1712,9 +1781,27 @@ async function runStart(): Promise<void> {
 
   console.log("  Main session created");
 
+  // Wrap the chatSession processMessage for Tidepool so that each WebSocket
+  // message sets the active secret prompt callback to the Tidepool variant
+  // (which sends a `secret_prompt` event over the browser WebSocket).
+  // CLI path leaves activeSecretPrompt as the terminal hidden-input callback.
+  const tidepoolChatSession = {
+    ...chatSession,
+    processMessage: (
+      content: Parameters<typeof chatSession.processMessage>[0],
+      sendEvent: Parameters<typeof chatSession.processMessage>[1],
+      signal?: Parameters<typeof chatSession.processMessage>[2],
+    ) => {
+      activeSecretPrompt = chatSession.createTidepoolSecretPrompt(sendEvent);
+      return chatSession.processMessage(content, sendEvent, signal).finally(() => {
+        activeSecretPrompt = cliSecretPrompt;
+      });
+    },
+  };
+
   // Start Tidepool + Gateway EARLY so `triggerfish chat` can connect
   // while channels and MCP servers finish wiring in the background.
-  const tidepoolHost = createA2UIHost({ chatSession });
+  const tidepoolHost = createA2UIHost({ chatSession: tidepoolChatSession });
   const tidepoolPort = 18790;
   await tidepoolHost.start(tidepoolPort);
   tidepoolTools = createTidePoolTools(tidepoolHost);
@@ -3130,6 +3217,7 @@ function getToolDefinitions(
   return [
     ...getTodoToolDefinitions(),
     ...getMemoryToolDefinitions(),
+    ...getSecretToolDefinitions(),
     ...getWebToolDefinitions(),
     ...getPlanToolDefinitions(),
     ...getBrowserToolDefinitions(),
@@ -3386,6 +3474,10 @@ interface ToolExecutorOptions {
     input: Record<string, unknown>,
   ) => Promise<string | null>;
   readonly subagentFactory?: (task: string, tools?: string) => Promise<string>;
+  readonly secretExecutor?: (
+    name: string,
+    input: Record<string, unknown>,
+  ) => Promise<string | null>;
 }
 
 /**
@@ -3502,6 +3594,12 @@ function createToolExecutor(opts: ToolExecutorOptions): ToolExecutor {
     if (opts.mcpExecutor) {
       const mcpResult = await opts.mcpExecutor(name, input);
       if (mcpResult !== null) return mcpResult;
+    }
+
+    // Try secret tools (returns null if not a secret tool)
+    if (opts.secretExecutor) {
+      const secretResult = await opts.secretExecutor(name, input);
+      if (secretResult !== null) return secretResult;
     }
 
     // Try web tools (returns null if not a web tool)

--- a/src/gateway/chat.ts
+++ b/src/gateway/chat.ts
@@ -23,6 +23,7 @@ import type {
   ToolDefinition,
   ToolExecutor,
 } from "../agent/orchestrator.ts";
+import type { SecretStore } from "../secrets/keychain.ts";
 import type { LlmProviderRegistry, LlmProvider } from "../agent/llm.ts";
 import type { PlanManager } from "../agent/plan.ts";
 import type { HookRunner } from "../core/policy/hooks.ts";
@@ -75,14 +76,39 @@ export type ChatEvent =
     readonly tokensBefore: number;
     readonly tokensAfter: number;
   }
-  | { readonly type: "taint_changed"; readonly level: ClassificationLevel };
+  | { readonly type: "taint_changed"; readonly level: ClassificationLevel }
+  | {
+    /**
+     * Server → browser: request the user to securely enter a secret value.
+     * The browser must show a password input form and respond with
+     * `secret_prompt_response`.
+     */
+    readonly type: "secret_prompt";
+    /** Unique nonce correlating this request with the response. */
+    readonly nonce: string;
+    /** The secret name being collected. */
+    readonly name: string;
+    /** Optional human-readable hint for the user. */
+    readonly hint?: string;
+  };
 
 /** Messages the client can send. */
 export type ChatClientMessage =
   | { readonly type: "message"; readonly content: MessageContent }
   | { readonly type: "cancel" }
   | { readonly type: "clear" }
-  | { readonly type: "compact" };
+  | { readonly type: "compact" }
+  | {
+    /**
+     * Browser → server: the user has entered a secret value in the password
+     * form triggered by a `secret_prompt` event.
+     */
+    readonly type: "secret_prompt_response";
+    /** The nonce from the originating `secret_prompt` event. */
+    readonly nonce: string;
+    /** The secret value entered by the user, or null if cancelled. */
+    readonly value: string | null;
+  };
 
 /** Callback to send a chat event to a specific client. */
 export type ChatEventSender = (event: ChatEvent) => void;
@@ -158,6 +184,17 @@ export interface ChatSessionConfig {
   readonly toolFloorRegistry?: ToolFloorRegistry;
   /** Primary model identifier (e.g. "gpt-5.2-codex") for display. */
   readonly primaryModelName?: string;
+  /**
+   * Secret store for resolving `{{secret:name}}` references in tool arguments.
+   * Passed through to the orchestrator for substitution below the LLM layer.
+   */
+  readonly secretStore?: SecretStore;
+  /**
+   * Callback invoked when a `secret_prompt` response arrives from the browser.
+   * Used by the Tidepool WebSocket handler to route browser responses to the
+   * waiting `secret_save` tool executor.
+   */
+  readonly onSecretPromptResponse?: (nonce: string, value: string | null) => void;
 }
 
 /** Internal per-channel state tracked by ChatSession. */
@@ -211,6 +248,26 @@ export interface ChatSession {
   readonly modelName: string;
   /** Read the current owner session taint. */
   readonly sessionTaint: ClassificationLevel;
+  /**
+   * Route a `secret_prompt_response` from the Tidepool browser client to the
+   * waiting `secret_save` tool executor.
+   *
+   * @param nonce - The nonce from the originating `secret_prompt` event.
+   * @param value - The entered secret value, or null if the user cancelled.
+   */
+  handleSecretPromptResponse(nonce: string, value: string | null): void;
+  /**
+   * Create a `SecretPromptCallback` suitable for use with `createSecretToolExecutor`
+   * in Tidepool mode.
+   *
+   * When called, the callback sends a `secret_prompt` WebSocket event to the
+   * currently-active Tidepool client (via `sendEvent`) and awaits the
+   * corresponding `secret_prompt_response` from the browser.
+   *
+   * @param sendEvent - The function that sends events to the active WebSocket client.
+   * @returns A SecretPromptCallback that resolves when the browser responds.
+   */
+  createTidepoolSecretPrompt(sendEvent: ChatEventSender): (name: string, hint?: string) => Promise<string | null>;
 }
 
 /**
@@ -343,6 +400,7 @@ export function createChatSession(config: ChatSessionConfig): ChatSession {
     pathClassifier: config.pathClassifier,
     domainClassifier: config.domainClassifier,
     toolFloorRegistry: config.toolFloorRegistry,
+    secretStore: config.secretStore,
   });
 
   const initialSession = config.session;
@@ -352,6 +410,10 @@ export function createChatSession(config: ChatSessionConfig): ChatSession {
 
   const providerName = config.providerRegistry.getDefault()?.name ?? "unknown";
   const modelName = config.primaryModelName ?? config.providerRegistry.getDefault()?.name ?? "unknown";
+
+  // Registry of pending secret prompt requests from the Tidepool browser client.
+  // Keyed by nonce; values are resolve functions from awaited Promises.
+  const pendingSecretPrompts = new Map<string, (value: string | null) => void>();
 
   // Promise-chain mutex: each processMessage waits for the previous to finish
   let mutex: Promise<void> = Promise.resolve();
@@ -547,12 +609,37 @@ export function createChatSession(config: ChatSessionConfig): ChatSession {
     }
   }
 
+  function handleSecretPromptResponse(nonce: string, value: string | null): void {
+    const resolve = pendingSecretPrompts.get(nonce);
+    if (resolve) {
+      pendingSecretPrompts.delete(nonce);
+      resolve(value);
+    }
+  }
+
+  function createTidepoolSecretPrompt(
+    sendEvent: ChatEventSender,
+  ): (name: string, hint?: string) => Promise<string | null> {
+    return (name: string, hint?: string): Promise<string | null> => {
+      const nonce = crypto.randomUUID();
+      return new Promise<string | null>((resolve) => {
+        pendingSecretPrompts.set(nonce, resolve);
+        const promptEvent: ChatEvent = hint !== undefined
+          ? { type: "secret_prompt", nonce, name, hint }
+          : { type: "secret_prompt", nonce, name };
+        sendEvent(promptEvent);
+      });
+    };
+  }
+
   return {
     processMessage,
     registerChannel,
     handleChannelMessage,
     clear,
     compact,
+    handleSecretPromptResponse,
+    createTidepoolSecretPrompt,
     get providerName() {
       return providerName;
     },

--- a/src/secrets/mod.ts
+++ b/src/secrets/mod.ts
@@ -17,3 +17,11 @@ export { createEncryptedFileSecretStore } from "./encrypted_file_provider.ts";
 export type { EncryptedFileSecretStoreOptions } from "./encrypted_file_provider.ts";
 export { loadOrCreateMachineKey } from "./key_manager.ts";
 export type { MachineKeyOptions } from "./key_manager.ts";
+export { resolveSecretRefs } from "./resolver.ts";
+export type { ResolveResult } from "./resolver.ts";
+export {
+  createSecretToolExecutor,
+  getSecretToolDefinitions,
+  SECRET_TOOLS_SYSTEM_PROMPT,
+} from "./tools.ts";
+export type { SecretPromptCallback } from "./tools.ts";

--- a/src/secrets/resolver.ts
+++ b/src/secrets/resolver.ts
@@ -1,0 +1,145 @@
+/**
+ * Secret reference resolver.
+ *
+ * Scans tool input arguments for `{{secret:name}}` tokens and replaces
+ * them with the actual secret values from the SecretStore. The resolved
+ * values are never logged or returned to the LLM — they flow directly into
+ * tool arguments below the LLM layer.
+ *
+ * @module
+ */
+
+import type { SecretStore } from "./keychain.ts";
+import type { Result } from "../core/types/classification.ts";
+
+/** Pattern matching `{{secret:name}}` tokens anywhere in a string. */
+const SECRET_REF_PATTERN = /\{\{secret:([^}]+)\}\}/g;
+
+/** Result of a resolution pass — the resolved input and any errors encountered. */
+export interface ResolveResult {
+  /** The input with all `{{secret:name}}` tokens replaced by their values. */
+  readonly resolved: Record<string, unknown>;
+  /**
+   * Names of secrets that were referenced but could not be found in the store.
+   * Empty array if all references resolved successfully.
+   */
+  readonly missing: readonly string[];
+}
+
+/**
+ * Recursively walk a value and collect all `{{secret:name}}` tokens.
+ *
+ * @param value - Any JSON-compatible value
+ * @returns Array of secret names referenced (may contain duplicates)
+ */
+function collectSecretRefs(value: unknown): string[] {
+  if (typeof value === "string") {
+    const refs: string[] = [];
+    let match: RegExpExecArray | null;
+    const re = new RegExp(SECRET_REF_PATTERN.source, "g");
+    while ((match = re.exec(value)) !== null) {
+      refs.push(match[1].trim());
+    }
+    return refs;
+  }
+  if (Array.isArray(value)) {
+    return value.flatMap(collectSecretRefs);
+  }
+  if (value !== null && typeof value === "object") {
+    return Object.values(value as Record<string, unknown>).flatMap(
+      collectSecretRefs,
+    );
+  }
+  return [];
+}
+
+/**
+ * Substitute all `{{secret:name}}` tokens in a string using the provided
+ * name→value map. Names not in the map are left as-is (their absence was
+ * already reported in the missing list).
+ */
+function substituteInString(
+  str: string,
+  secrets: ReadonlyMap<string, string>,
+): string {
+  return str.replace(
+    new RegExp(SECRET_REF_PATTERN.source, "g"),
+    (_match, name: string) => {
+      const trimmed = name.trim();
+      return secrets.get(trimmed) ?? `{{secret:${trimmed}}}`;
+    },
+  );
+}
+
+/**
+ * Recursively substitute `{{secret:name}}` tokens in any JSON-compatible value.
+ */
+function substituteValue(
+  value: unknown,
+  secrets: ReadonlyMap<string, string>,
+): unknown {
+  if (typeof value === "string") {
+    return substituteInString(value, secrets);
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => substituteValue(item, secrets));
+  }
+  if (value !== null && typeof value === "object") {
+    const result: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      result[k] = substituteValue(v, secrets);
+    }
+    return result;
+  }
+  return value;
+}
+
+/**
+ * Resolve all `{{secret:name}}` references in tool input arguments.
+ *
+ * Fetches required secrets from the store in parallel. Returns the resolved
+ * input and a list of any names that could not be found. The LLM never sees
+ * the resolved values — they are substituted at the tool executor layer.
+ *
+ * @param input - Raw tool input from the LLM
+ * @param store - SecretStore to retrieve values from
+ * @returns ResolveResult with substituted input and missing secret names
+ */
+export async function resolveSecretRefs(
+  input: Record<string, unknown>,
+  store: SecretStore,
+): Promise<Result<ResolveResult, string>> {
+  // Collect all unique secret names referenced in the input.
+  const allRefs = collectSecretRefs(input);
+  const uniqueNames = [...new Set(allRefs)];
+
+  if (uniqueNames.length === 0) {
+    return {
+      ok: true,
+      value: { resolved: input, missing: [] },
+    };
+  }
+
+  // Fetch all secrets in parallel.
+  const results = await Promise.all(
+    uniqueNames.map((name) => store.getSecret(name).then((r) => ({ name, r }))),
+  );
+
+  const secrets = new Map<string, string>();
+  const missing: string[] = [];
+
+  for (const { name, r } of results) {
+    if (r.ok) {
+      secrets.set(name, r.value);
+    } else {
+      missing.push(name);
+    }
+  }
+
+  const resolved = substituteValue(input, secrets) as Record<string, unknown>;
+
+  return {
+    ok: true,
+    value: { resolved, missing },
+  };
+}

--- a/src/secrets/tools.ts
+++ b/src/secrets/tools.ts
@@ -1,0 +1,177 @@
+/**
+ * LLM tool definitions and executor for secret management.
+ *
+ * Provides three LLM-callable tools:
+ * - `secret_save`  — prompt the user for a secret value outside LLM context, store it
+ * - `secret_list`  — list stored secret names (never values)
+ * - `secret_delete` — delete a stored secret by name
+ *
+ * The secret value is NEVER accepted from the LLM. The `secret_save` tool
+ * triggers an out-of-band input mechanism (terminal prompt or browser form)
+ * via a platform-supplied `PromptCallback`. The actual value flows directly
+ * into the SecretStore without passing through the LLM context.
+ *
+ * @module
+ */
+
+import type { ToolDefinition } from "../agent/orchestrator.ts";
+import type { SecretStore } from "./keychain.ts";
+
+/**
+ * Platform-supplied callback to collect a secret value from the user
+ * through a secure, out-of-LLM-context channel.
+ *
+ * For CLI: shows a hidden terminal prompt (input not echoed).
+ * For Tidepool: sends a `secret_prompt` WebSocket event and awaits browser response.
+ *
+ * @param name - The secret name (shown to the user as a hint)
+ * @param hint - Optional descriptive hint about what the secret is for
+ * @returns The entered secret value, or null if the user cancelled
+ */
+export type SecretPromptCallback = (
+  name: string,
+  hint?: string,
+) => Promise<string | null>;
+
+/** System prompt section explaining secret tool usage to the LLM. */
+export const SECRET_TOOLS_SYSTEM_PROMPT = `## Secret Management
+
+You have access to secure secret storage tools for managing passwords, API keys, and tokens.
+
+### How to save a secret
+Call \`secret_save\` with a descriptive name and an optional hint. The user will be prompted
+to enter the value through a secure input channel — the actual value is NEVER passed through
+your context and you will NEVER see it.
+
+### How to reference a secret
+Use the reference syntax \`{{secret:name}}\` anywhere in a tool argument where a password,
+API key, or token is required. The Triggerfish runtime resolves these references to the real
+values before executing the tool — the values are never visible to you.
+
+Example: to use a stored API key named "openai_key" in a tool argument:
+  \`{"api_key": "{{secret:openai_key}}"}\`
+
+### Rules
+- You MUST use the reference syntax. Never ask the user to type secrets in chat.
+- Call \`secret_list\` to see which secrets are already stored before asking to save a new one.
+- Do not log, repeat, or reveal secret values. They are never in your context.
+- Secret names should be lowercase with underscores (e.g. "github_token", "smtp_password").`;
+
+/** Tool definitions for the secret management tools. */
+export function getSecretToolDefinitions(): readonly ToolDefinition[] {
+  return [
+    {
+      name: "secret_save",
+      description:
+        "Prompt the user to securely enter a secret value (password, API key, token) " +
+        "through a private input channel and store it under the given name. " +
+        "The value is NEVER passed through LLM context. " +
+        "Use secret_list first to check if the secret already exists.",
+      parameters: {
+        name: {
+          type: "string",
+          description:
+            "Unique name for this secret (lowercase, underscores). " +
+            "Example: 'github_token', 'smtp_password', 'openai_key'.",
+          required: true,
+        },
+        hint: {
+          type: "string",
+          description:
+            "Optional human-readable description shown to the user when prompting " +
+            "for the value. Example: 'GitHub personal access token with repo scope'.",
+        },
+      },
+    },
+    {
+      name: "secret_list",
+      description:
+        "List the names of all stored secrets. " +
+        "Returns names only — secret values are never returned.",
+      parameters: {},
+    },
+    {
+      name: "secret_delete",
+      description: "Delete a stored secret by name.",
+      parameters: {
+        name: {
+          type: "string",
+          description: "The name of the secret to delete.",
+          required: true,
+        },
+      },
+    },
+  ];
+}
+
+/**
+ * Create a tool executor for secret management tools.
+ *
+ * @param store - The SecretStore backend to read/write secrets.
+ * @param prompt - Platform-supplied callback to collect the secret value from the user.
+ * @returns An executor function returning null for non-secret tools (standard pattern).
+ */
+export function createSecretToolExecutor(
+  store: SecretStore,
+  prompt: SecretPromptCallback,
+): (name: string, input: Record<string, unknown>) => Promise<string | null> {
+  return async (
+    name: string,
+    input: Record<string, unknown>,
+  ): Promise<string | null> => {
+    switch (name) {
+      case "secret_save": {
+        const secretName = input.name;
+        if (typeof secretName !== "string" || secretName.trim().length === 0) {
+          return "Error: secret_save requires a 'name' argument (string).";
+        }
+        const trimmedName = secretName.trim();
+        const hint =
+          typeof input.hint === "string" ? input.hint.trim() : undefined;
+
+        // Collect the value through the out-of-band channel — never from LLM args.
+        const value = await prompt(trimmedName, hint);
+        if (value === null) {
+          return `Secret '${trimmedName}' was not saved — input was cancelled.`;
+        }
+        if (value.length === 0) {
+          return `Error: Secret value cannot be empty. Secret '${trimmedName}' was not saved.`;
+        }
+
+        const result = await store.setSecret(trimmedName, value);
+        if (!result.ok) {
+          return `Error saving secret '${trimmedName}': ${result.error}`;
+        }
+        return `Secret '${trimmedName}' saved successfully. Reference it in tool arguments as {{secret:${trimmedName}}}.`;
+      }
+
+      case "secret_list": {
+        const result = await store.listSecrets();
+        if (!result.ok) {
+          return `Error listing secrets: ${result.error}`;
+        }
+        if (result.value.length === 0) {
+          return "No secrets stored. Use secret_save to store a secret.";
+        }
+        const names = result.value.map((n) => `  - ${n}`).join("\n");
+        return `Stored secrets (${result.value.length}):\n${names}\n\nReference them as {{secret:name}} in tool arguments.`;
+      }
+
+      case "secret_delete": {
+        const secretName = input.name;
+        if (typeof secretName !== "string" || secretName.trim().length === 0) {
+          return "Error: secret_delete requires a 'name' argument (string).";
+        }
+        const trimmedName = secretName.trim();
+        const result = await store.deleteSecret(trimmedName);
+        if (!result.ok) {
+          return `Error deleting secret '${trimmedName}': ${result.error}`;
+        }
+        return `Secret '${trimmedName}' deleted successfully.`;
+      }
+
+      default:
+        return null;
+    }
+  };
+}

--- a/src/tidepool/host.ts
+++ b/src/tidepool/host.ts
@@ -186,6 +186,12 @@ export function createA2UIHost(options?: A2UIHostOptions): A2UIHost {
                   return;
                 }
 
+                // Route secret prompt responses to the waiting secret_save executor.
+                if (msg.type === "secret_prompt_response") {
+                  chatSession.handleSecretPromptResponse(msg.nonce, msg.value);
+                  return;
+                }
+
                 if (msg.type === "message" && (typeof msg.content === "string" || (Array.isArray(msg.content) && msg.content.length > 0))) {
                   abortController = new AbortController();
                   const signal = abortController.signal;

--- a/src/tidepool/tmpl_chat.html
+++ b/src/tidepool/tmpl_chat.html
@@ -14,3 +14,17 @@
     <button id="send" disabled>Send</button>
   </div>
 </div>
+
+<!-- Secret prompt overlay: shown when the agent needs a password/key/token -->
+<div id="secret-prompt-overlay" style="display:none;position:fixed;inset:0;background:rgba(0,0,0,0.6);z-index:1000;align-items:center;justify-content:center;">
+  <div style="background:var(--bg,#1a1a1a);border:1px solid var(--border,#333);border-radius:8px;padding:24px;width:min(400px,90vw);display:flex;flex-direction:column;gap:12px;">
+    <div id="secret-prompt-title" style="font-weight:600;font-size:14px;color:var(--fg,#e0e0e0);">Enter secret</div>
+    <div id="secret-prompt-hint" style="font-size:12px;color:var(--muted,#888);min-height:16px;"></div>
+    <input id="secret-prompt-value" type="password" placeholder="Enter value..." autocomplete="off"
+      style="background:var(--input-bg,#111);border:1px solid var(--border,#333);border-radius:4px;padding:8px 10px;color:var(--fg,#e0e0e0);font-size:13px;outline:none;width:100%;box-sizing:border-box;" />
+    <div style="display:flex;gap:8px;justify-content:flex-end;">
+      <button id="secret-prompt-cancel" style="background:transparent;border:1px solid var(--border,#333);border-radius:4px;padding:6px 14px;color:var(--muted,#888);cursor:pointer;font-size:13px;">Cancel</button>
+      <button id="secret-prompt-submit" style="background:var(--accent,#4a9eff);border:none;border-radius:4px;padding:6px 14px;color:#fff;cursor:pointer;font-size:13px;font-weight:600;">Save</button>
+    </div>
+  </div>
+</div>

--- a/src/tidepool/tmpl_chat_script.html
+++ b/src/tidepool/tmpl_chat_script.html
@@ -147,7 +147,60 @@
           window.tidepoolCanvas.clear();
         }
         break;
+
+      case "secret_prompt":
+        handleSecretPrompt(evt.nonce, evt.name, evt.hint);
+        break;
     }
+  }
+
+  function handleSecretPrompt(nonce, name, hint) {
+    var overlay = document.getElementById("secret-prompt-overlay");
+    var title = document.getElementById("secret-prompt-title");
+    var desc = document.getElementById("secret-prompt-hint");
+    var valueInput = document.getElementById("secret-prompt-value");
+    var submitBtn = document.getElementById("secret-prompt-submit");
+    var cancelBtn = document.getElementById("secret-prompt-cancel");
+
+    if (!overlay || !title || !valueInput || !submitBtn || !cancelBtn) return;
+
+    title.textContent = "Enter secret: " + name;
+    if (desc) desc.textContent = hint || "";
+    valueInput.value = "";
+    overlay.style.display = "flex";
+    setTimeout(function() { valueInput.focus(); }, 50);
+
+    function cleanup() {
+      overlay.style.display = "none";
+      valueInput.value = "";
+      submitBtn.removeEventListener("click", onSubmit);
+      cancelBtn.removeEventListener("click", onCancel);
+      valueInput.removeEventListener("keydown", onKeydown);
+    }
+
+    function onSubmit() {
+      var val = valueInput.value;
+      cleanup();
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ type: "secret_prompt_response", nonce: nonce, value: val || null }));
+      }
+    }
+
+    function onCancel() {
+      cleanup();
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ type: "secret_prompt_response", nonce: nonce, value: null }));
+      }
+    }
+
+    function onKeydown(e) {
+      if (e.key === "Enter") { e.preventDefault(); onSubmit(); }
+      if (e.key === "Escape") { e.preventDefault(); onCancel(); }
+    }
+
+    submitBtn.addEventListener("click", onSubmit);
+    cancelBtn.addEventListener("click", onCancel);
+    valueInput.addEventListener("keydown", onKeydown);
   }
 
   function addRenderLabel(evt) {

--- a/tests/secrets/resolver_test.ts
+++ b/tests/secrets/resolver_test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for the secret reference resolver.
+ *
+ * @module
+ */
+
+import { assertEquals } from "@std/assert";
+import { createMemorySecretStore } from "../../src/secrets/keychain.ts";
+import { resolveSecretRefs } from "../../src/secrets/resolver.ts";
+
+Deno.test("resolveSecretRefs — no references returns input unchanged", async () => {
+  const store = createMemorySecretStore();
+  const input = { url: "https://example.com", method: "GET" };
+  const result = await resolveSecretRefs(input, store);
+  assertEquals(result.ok, true);
+  if (!result.ok) return;
+  assertEquals(result.value.resolved, input);
+  assertEquals(result.value.missing, []);
+});
+
+Deno.test("resolveSecretRefs — substitutes a known secret", async () => {
+  const store = createMemorySecretStore();
+  await store.setSecret("api_key", "secret-value-xyz");
+
+  const input = { authorization: "Bearer {{secret:api_key}}" };
+  const result = await resolveSecretRefs(input, store);
+  assertEquals(result.ok, true);
+  if (!result.ok) return;
+  assertEquals(result.value.resolved, {
+    authorization: "Bearer secret-value-xyz",
+  });
+  assertEquals(result.value.missing, []);
+});
+
+Deno.test("resolveSecretRefs — reports missing secrets", async () => {
+  const store = createMemorySecretStore();
+
+  const input = { token: "{{secret:missing_secret}}" };
+  const result = await resolveSecretRefs(input, store);
+  assertEquals(result.ok, true);
+  if (!result.ok) return;
+  // Missing secrets leave the placeholder in place
+  assertEquals(result.value.resolved, { token: "{{secret:missing_secret}}" });
+  assertEquals(result.value.missing, ["missing_secret"]);
+});
+
+Deno.test("resolveSecretRefs — substitutes multiple secrets", async () => {
+  const store = createMemorySecretStore();
+  await store.setSecret("user", "admin");
+  await store.setSecret("pass", "hunter2");
+
+  const input = { username: "{{secret:user}}", password: "{{secret:pass}}" };
+  const result = await resolveSecretRefs(input, store);
+  assertEquals(result.ok, true);
+  if (!result.ok) return;
+  assertEquals(result.value.resolved, { username: "admin", password: "hunter2" });
+  assertEquals(result.value.missing, []);
+});
+
+Deno.test("resolveSecretRefs — handles nested objects", async () => {
+  const store = createMemorySecretStore();
+  await store.setSecret("db_pass", "s3cr3t");
+
+  const input = {
+    database: {
+      host: "localhost",
+      password: "{{secret:db_pass}}",
+    },
+  };
+  const result = await resolveSecretRefs(input, store);
+  assertEquals(result.ok, true);
+  if (!result.ok) return;
+  const resolved = result.value.resolved as { database: { host: string; password: string } };
+  assertEquals(resolved.database.password, "s3cr3t");
+  assertEquals(resolved.database.host, "localhost");
+});
+
+Deno.test("resolveSecretRefs — handles arrays", async () => {
+  const store = createMemorySecretStore();
+  await store.setSecret("token", "tok123");
+
+  const input = { headers: ["Content-Type: application/json", "Authorization: Bearer {{secret:token}}"] };
+  const result = await resolveSecretRefs(input, store);
+  assertEquals(result.ok, true);
+  if (!result.ok) return;
+  const resolved = result.value.resolved as { headers: string[] };
+  assertEquals(resolved.headers[1], "Authorization: Bearer tok123");
+});
+
+Deno.test("resolveSecretRefs — deduplicated lookup for repeated references", async () => {
+  const store = createMemorySecretStore();
+  await store.setSecret("key", "value");
+
+  const input = { a: "{{secret:key}}", b: "{{secret:key}}", c: "prefix-{{secret:key}}-suffix" };
+  const result = await resolveSecretRefs(input, store);
+  assertEquals(result.ok, true);
+  if (!result.ok) return;
+  const resolved = result.value.resolved as Record<string, string>;
+  assertEquals(resolved.a, "value");
+  assertEquals(resolved.b, "value");
+  assertEquals(resolved.c, "prefix-value-suffix");
+});
+
+Deno.test("resolveSecretRefs — non-string values pass through unchanged", async () => {
+  const store = createMemorySecretStore();
+
+  const input = { count: 42, enabled: true, tags: null };
+  const result = await resolveSecretRefs(input, store);
+  assertEquals(result.ok, true);
+  if (!result.ok) return;
+  assertEquals(result.value.resolved, input);
+});
+
+Deno.test("resolveSecretRefs — mixed found and missing secrets", async () => {
+  const store = createMemorySecretStore();
+  await store.setSecret("found", "found-value");
+
+  const input = { a: "{{secret:found}}", b: "{{secret:not_found}}" };
+  const result = await resolveSecretRefs(input, store);
+  assertEquals(result.ok, true);
+  if (!result.ok) return;
+  const resolved = result.value.resolved as Record<string, string>;
+  assertEquals(resolved.a, "found-value");
+  // Placeholder left in place for missing secret
+  assertEquals(resolved.b, "{{secret:not_found}}");
+  assertEquals(result.value.missing, ["not_found"]);
+});

--- a/tests/secrets/tools_test.ts
+++ b/tests/secrets/tools_test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests for the secret management LLM tool executor.
+ *
+ * @module
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { createMemorySecretStore } from "../../src/secrets/keychain.ts";
+import { createSecretToolExecutor, getSecretToolDefinitions, SECRET_TOOLS_SYSTEM_PROMPT } from "../../src/secrets/tools.ts";
+
+/** Create a test prompt callback that always returns the given value. */
+function makePrompt(value: string | null) {
+  return (_name: string, _hint?: string): Promise<string | null> =>
+    Promise.resolve(value);
+}
+
+Deno.test("getSecretToolDefinitions — returns 3 tool definitions", () => {
+  const defs = getSecretToolDefinitions();
+  assertEquals(defs.length, 3);
+  assertEquals(defs[0].name, "secret_save");
+  assertEquals(defs[1].name, "secret_list");
+  assertEquals(defs[2].name, "secret_delete");
+});
+
+Deno.test("SECRET_TOOLS_SYSTEM_PROMPT — contains reference syntax", () => {
+  assertStringIncludes(SECRET_TOOLS_SYSTEM_PROMPT, "{{secret:name}}");
+  assertStringIncludes(SECRET_TOOLS_SYSTEM_PROMPT, "secret_save");
+  assertStringIncludes(SECRET_TOOLS_SYSTEM_PROMPT, "secret_list");
+});
+
+Deno.test("createSecretToolExecutor — secret_save stores value and returns confirmation", async () => {
+  const store = createMemorySecretStore();
+  const executor = createSecretToolExecutor(store, makePrompt("my-secret-value"));
+
+  const result = await executor("secret_save", { name: "my_key" });
+  assertEquals(typeof result, "string");
+  assertStringIncludes(result!, "my_key");
+  assertStringIncludes(result!, "saved successfully");
+  assertStringIncludes(result!, "{{secret:my_key}}");
+
+  // Value should be stored
+  const stored = await store.getSecret("my_key");
+  assertEquals(stored.ok, true);
+  if (!stored.ok) return;
+  assertEquals(stored.value, "my-secret-value");
+});
+
+Deno.test("createSecretToolExecutor — secret_save does NOT accept value from LLM args", async () => {
+  const store = createMemorySecretStore();
+  // Prompt returns "from-prompt", not anything from the LLM input
+  const executor = createSecretToolExecutor(store, makePrompt("from-prompt"));
+
+  // Even if LLM passes a value, it is ignored
+  await executor("secret_save", { name: "test_key", value: "from-llm" });
+
+  const stored = await store.getSecret("test_key");
+  assertEquals(stored.ok, true);
+  if (!stored.ok) return;
+  assertEquals(stored.value, "from-prompt");
+});
+
+Deno.test("createSecretToolExecutor — secret_save with cancelled prompt", async () => {
+  const store = createMemorySecretStore();
+  const executor = createSecretToolExecutor(store, makePrompt(null));
+
+  const result = await executor("secret_save", { name: "cancelled_key" });
+  assertStringIncludes(result!, "cancelled");
+
+  // Should not be stored
+  const stored = await store.getSecret("cancelled_key");
+  assertEquals(stored.ok, false);
+});
+
+Deno.test("createSecretToolExecutor — secret_save with empty name returns error", async () => {
+  const store = createMemorySecretStore();
+  const executor = createSecretToolExecutor(store, makePrompt("value"));
+
+  const result = await executor("secret_save", { name: "" });
+  assertStringIncludes(result!, "Error");
+});
+
+Deno.test("createSecretToolExecutor — secret_save with empty value returns error", async () => {
+  const store = createMemorySecretStore();
+  const executor = createSecretToolExecutor(store, makePrompt(""));
+
+  const result = await executor("secret_save", { name: "test" });
+  assertStringIncludes(result!, "Error");
+  assertStringIncludes(result!, "empty");
+});
+
+Deno.test("createSecretToolExecutor — secret_list returns names only", async () => {
+  const store = createMemorySecretStore();
+  await store.setSecret("key_one", "value1");
+  await store.setSecret("key_two", "value2");
+  const executor = createSecretToolExecutor(store, makePrompt("x"));
+
+  const result = await executor("secret_list", {});
+  assertStringIncludes(result!, "key_one");
+  assertStringIncludes(result!, "key_two");
+  // Should NOT contain the actual values
+  assertEquals(result!.includes("value1"), false);
+  assertEquals(result!.includes("value2"), false);
+});
+
+Deno.test("createSecretToolExecutor — secret_list when empty", async () => {
+  const store = createMemorySecretStore();
+  const executor = createSecretToolExecutor(store, makePrompt("x"));
+
+  const result = await executor("secret_list", {});
+  assertStringIncludes(result!, "No secrets");
+});
+
+Deno.test("createSecretToolExecutor — secret_delete removes a secret", async () => {
+  const store = createMemorySecretStore();
+  await store.setSecret("to_delete", "secret");
+  const executor = createSecretToolExecutor(store, makePrompt("x"));
+
+  const result = await executor("secret_delete", { name: "to_delete" });
+  assertStringIncludes(result!, "deleted");
+
+  const stored = await store.getSecret("to_delete");
+  assertEquals(stored.ok, false);
+});
+
+Deno.test("createSecretToolExecutor — secret_delete non-existent secret returns error", async () => {
+  const store = createMemorySecretStore();
+  const executor = createSecretToolExecutor(store, makePrompt("x"));
+
+  const result = await executor("secret_delete", { name: "nonexistent" });
+  assertStringIncludes(result!, "Error");
+});
+
+Deno.test("createSecretToolExecutor — returns null for unknown tools", async () => {
+  const store = createMemorySecretStore();
+  const executor = createSecretToolExecutor(store, makePrompt("x"));
+
+  const result = await executor("some_other_tool", {});
+  assertEquals(result, null);
+});
+
+Deno.test("createSecretToolExecutor — secret_save trims whitespace from name", async () => {
+  const store = createMemorySecretStore();
+  const executor = createSecretToolExecutor(store, makePrompt("trimmed-value"));
+
+  await executor("secret_save", { name: "  trimmed_key  " });
+
+  const stored = await store.getSecret("trimmed_key");
+  assertEquals(stored.ok, true);
+  if (!stored.ok) return;
+  assertEquals(stored.value, "trimmed-value");
+});


### PR DESCRIPTION
Implements the secure password tool described in issue #36.

Adds LLM-callable secret management tools (secret_save, secret_list, secret_delete) where the secret value is never passed through LLM context, and a `{{secret:name}}` reference syntax that is resolved to real values in the tool executor layer below the LLM.

Works in both CLI (terminal hidden-input) and Tidepool (browser password form via WebSocket round-trip).

Closes #36

Generated with [Claude Code](https://claude.ai/code)