### PR TITLE
refactor: move integration docs from system prompt to skills

### DIFF
--- a/skills/bundled/healthcheck/SKILL.md
+++ b/skills/bundled/healthcheck/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: healthcheck
+description: >
+  Inspect Triggerfish runtime health. Reports status of LLM providers, storage,
+  skills, and configuration. Use when diagnosing issues or confirming the
+  platform is working correctly.
+classification_ceiling: INTERNAL
+requires_tools:
+  - healthcheck
+network_domains: []
+---
+
+# Healthcheck
+
+Inspect the health of Triggerfish's own runtime components.
+
+## Tool
+
+| Tool | Purpose |
+|------|---------|
+| `healthcheck` | Check status of one or more components |
+
+## Components
+
+| Component | What It Checks |
+|-----------|---------------|
+| `providers` | LLM provider registry — is a default provider configured and reachable? |
+| `storage` | SQLite storage — can it read/write? |
+| `skills` | Skill loader — how many skills were discovered? |
+| `config` | Configuration — is triggerfish.yaml valid and loaded? |
+| `all` | Run all checks (default) |
+
+## Usage
+
+When the user asks "is everything working?", "check status", "what's broken?",
+or is diagnosing issues, call `healthcheck` with the relevant components:
+
+```
+healthcheck(components: ["all"])
+healthcheck(components: ["providers", "storage"])
+```
+
+## Status Levels
+
+- **healthy** — component is fully operational
+- **degraded** — component is partially working (e.g. no default provider set)
+- **error** — component is unavailable or misconfigured
+
+## Classification
+
+Healthcheck output reveals system internals (provider names, storage paths,
+skill counts). Minimum classification is INTERNAL — never share healthcheck
+results on PUBLIC channels.

--- a/skills/bundled/signal/SKILL.md
+++ b/skills/bundled/signal/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: signal
+description: >
+  Signal messaging integration. Send and receive messages as the owner's phone
+  number, list groups and contacts, manage pairing authorization. Requires
+  signal-cli linked to the owner's account via 'triggerfish connect signal'.
+classification_ceiling: CONFIDENTIAL
+requires_tools:
+  - signal_list_groups
+  - signal_list_contacts
+  - signal_generate_pairing
+  - message
+  - channels_list
+network_domains:
+  - "signal.org"
+  - "*.signal.org"
+---
+
+# Signal
+
+You operate as the owner's assistant on their Signal phone number. People who message the owner on Signal are routed to you. Each Signal contact gets their own session with independent taint tracking.
+
+## Tools
+
+| Tool | Purpose |
+|------|---------|
+| `signal_list_groups` | List all Signal groups (names, IDs, member counts) |
+| `signal_list_contacts` | List known Signal contacts (names, phone numbers) |
+| `signal_generate_pairing` | Generate a 6-digit pairing code for authorization |
+| `message` | Send a message to a contact or group (channel="signal") |
+| `channels_list` | Discover connected channels and classification levels |
+
+## Sending Messages
+
+Use `message` with `channel="signal"`:
+
+- **Contact**: `recipient="+15551234567"` (E.164 format)
+- **Group**: `recipient="group-<groupId>"` (get IDs from `signal_list_groups`)
+
+Write-down enforcement applies: you cannot send data to a channel whose
+classification is lower than your current session taint.
+
+## Pairing (Authorization)
+
+When Signal DM policy is "pairing", ALL senders must be paired before they get
+any response — DMs and group messages alike. This is enforced at the code level.
+You will never see messages from unpaired senders.
+
+### Pairing Flow
+
+1. The owner asks you to generate a pairing code → use `signal_generate_pairing`.
+2. The owner gives the code to the person (verbally, via another channel, etc.).
+3. The person sends the 6-digit code as a DM to the owner's Signal number.
+4. If valid, they're paired and can chat (DMs and groups). On success they get a confirmation message.
+5. ALL unpaired messages are silently ignored — no response, no indication of the agent's presence. The owner is also a linked device on this Signal account, so unpaired people are just having normal conversations with the owner. Triggerfish stays invisible until someone pairs.
+
+## Session Management
+
+Each Signal contact gets an independent session. The owner can:
+
+- Use `sessions_list` to see all Signal sessions
+- Use `sessions_history` to read a contact's conversation
+- Instruct you on how to respond to specific contacts

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -116,7 +116,6 @@ import {
   getLlmTaskToolDefinitions,
   getSummarizeToolDefinitions,
   getTodoToolDefinitions,
-  HEALTHCHECK_SYSTEM_PROMPT,
   LLM_TASK_SYSTEM_PROMPT,
   SUMMARIZE_SYSTEM_PROMPT,
   TODO_SYSTEM_PROMPT,
@@ -151,7 +150,6 @@ import {
   PLAN_SYSTEM_PROMPT,
 } from "../agent/plan_tools.ts";
 import {
-  BROWSER_TOOLS_SYSTEM_PROMPT,
   createAutoLaunchBrowserExecutor,
   createBrowserManager,
   createDomainPolicy as createBrowserDomainPolicy,
@@ -164,7 +162,6 @@ import {
   createObsidianToolExecutor,
   createVaultContext,
   getObsidianToolDefinitions,
-  OBSIDIAN_SYSTEM_PROMPT,
 } from "../obsidian/mod.ts";
 import {
   createImageToolExecutor,
@@ -192,14 +189,12 @@ import {
   createSheetsService,
   createTasksService,
   getGoogleToolDefinitions,
-  GOOGLE_TOOLS_SYSTEM_PROMPT,
 } from "../google/mod.ts";
 import type { GoogleAuthConfig } from "../google/mod.ts";
 import {
   createGitHubClient,
   createGitHubToolExecutor,
   getGitHubToolDefinitions,
-  GITHUB_TOOLS_SYSTEM_PROMPT,
   resolveGitHubToken,
 } from "../github/mod.ts";
 import { createKeychain } from "../secrets/keychain.ts";
@@ -1098,11 +1093,8 @@ function createOrchestratorFactory(
           WEB_TOOLS_SYSTEM_PROMPT,
           MEMORY_SYSTEM_PROMPT,
           PLAN_SYSTEM_PROMPT,
-          GOOGLE_TOOLS_SYSTEM_PROMPT,
-          GITHUB_TOOLS_SYSTEM_PROMPT,
           LLM_TASK_SYSTEM_PROMPT,
           SUMMARIZE_SYSTEM_PROMPT,
-          HEALTHCHECK_SYSTEM_PROMPT,
           factorySkillsPrompt,
         ],
         visionProvider: schedulerVisionProvider,
@@ -1761,19 +1753,14 @@ async function runStart(): Promise<void> {
       WEB_TOOLS_SYSTEM_PROMPT,
       MEMORY_SYSTEM_PROMPT,
       PLAN_SYSTEM_PROMPT,
-      BROWSER_TOOLS_SYSTEM_PROMPT,
       TIDEPOOL_SYSTEM_PROMPT,
       SESSION_TOOLS_SYSTEM_PROMPT,
       IMAGE_TOOLS_SYSTEM_PROMPT,
       EXPLORE_SYSTEM_PROMPT,
-      GOOGLE_TOOLS_SYSTEM_PROMPT,
-      GITHUB_TOOLS_SYSTEM_PROMPT,
-      OBSIDIAN_SYSTEM_PROMPT,
       SKILLS_SYSTEM_PROMPT,
       TRIGGERS_SYSTEM_PROMPT,
       LLM_TASK_SYSTEM_PROMPT,
       SUMMARIZE_SYSTEM_PROMPT,
-      HEALTHCHECK_SYSTEM_PROMPT,
       CLAUDE_SESSION_SYSTEM_PROMPT,
       SECRET_TOOLS_SYSTEM_PROMPT,
       mcpSystemPrompt,

--- a/src/gateway/tools.ts
+++ b/src/gateway/tools.ts
@@ -163,14 +163,12 @@ export function getSessionToolDefinitions(): readonly ToolDefinition[] {
 /** System prompt section explaining session tools to the LLM. */
 export const SESSION_TOOLS_SYSTEM_PROMPT = `## Session & Channel Management
 
-You have access to messaging channels (Signal, Telegram, etc.) and can manage sessions across them.
+You have access to messaging channels and can manage sessions across them.
 
 ### Channels
 - Use channels_list to discover connected channels and their classification levels.
 - Use message to send a message to a recipient on a connected channel.
-  - For Signal: you ARE the owner's phone number. Recipients are phone numbers in E.164 format (e.g. "+15551234567") or group IDs prefixed with "group-".
-  - For Telegram: recipients are chat IDs.
-- Write-down enforcement applies: you cannot send data to a channel whose classification is lower than your current session taint. If your taint is CONFIDENTIAL and the channel is INTERNAL, the message will be blocked.
+- Write-down enforcement applies: you cannot send data to a channel whose classification is lower than your current session taint.
 
 ### Sessions
 - Use sessions_list to see active sessions across all channels (filtered by your taint level).
@@ -179,23 +177,7 @@ You have access to messaging channels (Signal, Telegram, etc.) and can manage se
 - Use sessions_spawn to create a new background session for autonomous tasks.
 - Use session_status to check a session's metadata (taint, channel, user).
 
-### Signal
-When Signal is connected, you operate as the owner's assistant on their phone number. People who message the owner on Signal are routed to you. Each Signal contact gets their own session with independent taint tracking. The owner can see these sessions and instruct you on how to respond.
-
-- Use signal_list_groups to see all Signal groups the account belongs to (names, IDs, member counts).
-- Use signal_list_contacts to see known Signal contacts (names, phone numbers).
-- To message a group, use: message with channel="signal" and recipient="group-<groupId>".
-- To message a contact, use: message with channel="signal" and recipient="+15551234567".
-
-### Signal Pairing (Authorization)
-When Signal DM policy is "pairing", ALL senders must be paired before they get any response — DMs and group messages alike. This is enforced at the code level. You will never see messages from unpaired senders.
-
-The pairing flow:
-1. The owner asks you to generate a pairing code → use signal_generate_pairing.
-2. The owner gives the code to the person (verbally, via another channel, etc.).
-3. The person sends the 6-digit code as a DM to the owner's Signal number.
-4. If valid, they're paired and can chat (DMs and groups). On success they get a confirmation message.
-5. ALL unpaired messages are silently ignored — no response, no indication of the agent's presence. The owner is also a linked device on this Signal account, so unpaired people are just having normal conversations with the owner. Triggerfish stays invisible until someone pairs.`;
+For Signal-specific usage (messaging contacts, groups, pairing), read the "signal" skill.`;
 
 /**
  * Create a tool executor for session management tools.

--- a/src/secrets/encrypted_file_provider.ts
+++ b/src/secrets/encrypted_file_provider.ts
@@ -209,9 +209,9 @@ export function createEncryptedFileSecretStore(
       const iv = fromBase64(entry.iv);
       const ct = fromBase64(entry.ct);
       const plaintext = await crypto.subtle.decrypt(
-        { name: "AES-GCM", iv },
+        { name: "AES-GCM", iv: iv.buffer as ArrayBuffer },
         key,
-        ct,
+        ct.buffer as ArrayBuffer,
       );
       return { ok: true, value: new TextDecoder().decode(plaintext) };
     } catch (err: unknown) {

--- a/src/secrets/key_manager.ts
+++ b/src/secrets/key_manager.ts
@@ -74,7 +74,7 @@ export async function loadOrCreateMachineKey(
     // Import the existing raw bytes as AES-GCM key
     const key = await crypto.subtle.importKey(
       "raw",
-      rawBytes,
+      rawBytes.buffer as ArrayBuffer,
       { name: "AES-GCM" },
       false,
       ["encrypt", "decrypt"],

--- a/tests/skills/skills_test.ts
+++ b/tests/skills/skills_test.ts
@@ -58,8 +58,8 @@ Deno.test("SkillLoader: discovers all bundled skills", async () => {
   });
   const skills = await loader.discover();
 
-  // Should find all 16 bundled skills
-  assertEquals(skills.length, 16);
+  // Should find all 18 bundled skills
+  assertEquals(skills.length, 18);
 
   const names = skills.map((s) => s.name).sort();
   assertEquals(names, [
@@ -68,6 +68,7 @@ Deno.test("SkillLoader: discovers all bundled skills", async () => {
     "git-branch-management",
     "github",
     "google-workspace",
+    "healthcheck",
     "integration-builder",
     "log-analyst",
     "maps",
@@ -75,6 +76,7 @@ Deno.test("SkillLoader: discovers all bundled skills", async () => {
     "mastering-typescript",
     "obsidian",
     "pdf",
+    "signal",
     "skill-builder",
     "tdd",
     "triggers",


### PR DESCRIPTION
## Summary
- Remove inlined `*_SYSTEM_PROMPT` constants from `systemPromptSections` for integrations that already have bundled skills (Google Workspace, GitHub, Browser Automation, Obsidian)
- Create new bundled skills for **Signal** and **Healthcheck**, removing their documentation from the system prompt
- Trim `SESSION_TOOLS_SYSTEM_PROMPT` to generic session/channel management with a pointer to the signal skill
- Fix two Deno 2.x type errors in `secrets/encrypted_file_provider.ts` and `secrets/key_manager.ts` (`Uint8Array.buffer` → `ArrayBuffer` cast)

## Motivation
Integration tool documentation was being injected into every LLM call via `systemPromptSections`, duplicating what the skills system already provides. The agent discovers skills via the auto-generated skills table and reads SKILL.md on demand — no need to carry all integration docs in the system prompt.

## Changes
| File | Change |
|------|--------|
| `src/cli/main.ts` | Remove 5 system prompt constants from both chat and scheduler `systemPromptSections` |
| `src/gateway/tools.ts` | Trim `SESSION_TOOLS_SYSTEM_PROMPT` — remove Signal sections, add skill pointer |
| `skills/bundled/signal/SKILL.md` | New skill: Signal messaging, contacts, groups, pairing flow |
| `skills/bundled/healthcheck/SKILL.md` | New skill: runtime health inspection tool |
| `tests/skills/skills_test.ts` | Update bundled skill count 16 → 18, add signal + healthcheck to name list |
| `src/secrets/encrypted_file_provider.ts` | Fix `Uint8Array.buffer` type error |
| `src/secrets/key_manager.ts` | Fix `Uint8Array.buffer` type error |

## Test plan
- [x] `deno task check` — builds clean
- [x] `deno task test` — 1507 passed, 0 failed
- [x] Skills test validates 18 bundled skills discovered

🤖 Generated with [Claude Code](https://claude.com/claude-code)