### PR TITLE
fix: force Deno.exit(0) after main() to prevent Windows hang after daemon restart

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -5004,7 +5004,11 @@ async function main(): Promise<void> {
 
 // Execute main if this is the entry point
 if (import.meta.main) {
-  main().catch((err) => {
+  // Force-exit after completion to prevent Deno from hanging on Windows due to
+  // stdin raw-mode handles left open by interactive prompts (Cliffy). Without
+  // Deno.exit(0), the process lingers for minutes after "Daemon restarted" is
+  // printed on Windows because the TTY handle is never fully released.
+  main().then(() => Deno.exit(0)).catch((err) => {
     console.error("Fatal error:", err);
     Deno.exit(1);
   });


### PR DESCRIPTION
Fixes #41

On Windows, Cliffy interactive prompts (`Confirm.prompt`, `Select.prompt`) leave the TTY stdin handle in raw mode after completion. Deno's event loop cannot drain cleanly with this handle open, causing the process to hang for multiple minutes after commands like `add-channel` complete (including after printing "Daemon Restarted").

Adding `.then(() => Deno.exit(0))` ensures the process always exits immediately after any command finishes, regardless of lingering async handles.

Generated with [Claude Code](https://claude.ai/code)