### PR TITLE
[Phase 17] feat: add triggers to context with write-down enforcement

### DIFF
--- a/src/channels/telegram/adapter.ts
+++ b/src/channels/telegram/adapter.ts
@@ -86,12 +86,49 @@ export function createTelegramChannel(config: TelegramConfig): TelegramChannelAd
     });
   });
 
+  // /addtrigger command: route as a natural language message so the orchestrator
+  // calls trigger_add_to_context. Supports an optional source argument:
+  //   /addtrigger           → adds the default periodic trigger result
+  //   /addtrigger cron:job  → adds the last result for that source
+  bot.command("addtrigger", (ctx) => {
+    if (!handler) return;
+
+    const numericOwnerId = typeof ownerId === "number" ? ownerId : Number(ownerId);
+    const isOwner = ownerId !== undefined && Number.isFinite(numericOwnerId)
+      ? ctx.from.id === numericOwnerId
+      : ownerId === undefined;
+
+    if (ctx.message) {
+      trackMessage(ctx.chat.id, ctx.message.message_id);
+    }
+
+    // Extract optional source argument (e.g. "/addtrigger cron:job-id")
+    const rawArg = ctx.match?.trim() ?? "";
+    const sourceArg = rawArg.length > 0 ? ` for source "${rawArg}"` : "";
+    const content = `Add the last trigger output${sourceArg} to our conversation using the trigger_add_to_context tool.`;
+
+    handler({
+      content,
+      sessionId: `telegram-${ctx.chat.id}`,
+      senderId: String(ctx.from.id),
+      isOwner,
+      sessionTaint: isOwner ? undefined : ("PUBLIC" as ClassificationLevel),
+    });
+  });
+
   return {
     classification,
     isOwner: true, // Determined per-message via ownerId check
 
-    // deno-lint-ignore require-await
     async connect(): Promise<void> {
+      // Register bot commands with Telegram so they appear in the command menu
+      try {
+        await bot.api.setMyCommands([
+          { command: "addtrigger", description: "Add last trigger output to conversation context" },
+        ]);
+      } catch {
+        // Non-fatal: command registration failure should not prevent connection
+      }
       bot.start();
       connected = true;
     },

--- a/src/gateway/mod.ts
+++ b/src/gateway/mod.ts
@@ -56,3 +56,10 @@ export type {
   ChatSession,
   ChatSessionConfig,
 } from "./chat.ts";
+
+export {
+  getTriggerToolDefinitions,
+  createTriggerToolExecutor,
+  TRIGGER_TOOLS_SYSTEM_PROMPT,
+} from "./trigger_tools.ts";
+export type { TriggerToolContext } from "./trigger_tools.ts";

--- a/src/gateway/trigger_tools.ts
+++ b/src/gateway/trigger_tools.ts
@@ -1,0 +1,154 @@
+/**
+ * Trigger context tools for the agent orchestrator.
+ *
+ * Provides the `trigger_add_to_context` tool that allows the agent to
+ * load the most recent trigger output into the current conversation
+ * context, subject to the no-write-down rule.
+ *
+ * Classification enforcement:
+ * - The trigger result's classification must be >= the current session taint.
+ * - If the session taint is higher than the trigger classification, adding
+ *   the trigger to context would be a write-down violation and is blocked.
+ * - If the trigger classification is higher than the session taint, the
+ *   session taint escalates to match the trigger classification.
+ *
+ * @module
+ */
+
+import type { ToolDefinition } from "../agent/orchestrator.ts";
+import type { ClassificationLevel } from "../core/types/classification.ts";
+import { canFlowTo } from "../core/types/classification.ts";
+import type { TriggerResult, TriggerStore } from "../scheduler/trigger_store.ts";
+
+/** Context required by trigger tool executors. */
+export interface TriggerToolContext {
+  /** Store holding the last result for each trigger source. */
+  readonly triggerStore: TriggerStore;
+  /** Current session taint level (injected, never from LLM). */
+  readonly sessionTaint: ClassificationLevel;
+  /**
+   * Live taint getter — returns current session taint (reflects escalation).
+   * Falls back to sessionTaint if not provided.
+   */
+  readonly getSessionTaint?: () => ClassificationLevel;
+  /**
+   * Callback to escalate session taint when a trigger of higher
+   * classification is loaded into context.
+   */
+  readonly escalateTaint?: (level: ClassificationLevel) => void;
+}
+
+/** Default trigger source used when none is specified. */
+const DEFAULT_SOURCE = "trigger";
+
+/** Get the tool definitions for trigger context tools. */
+export function getTriggerToolDefinitions(): readonly ToolDefinition[] {
+  return [
+    {
+      name: "trigger_add_to_context",
+      description:
+        "Add the output of the last trigger run to the current conversation context. " +
+        "Blocked if your session taint is higher than the trigger's classification (write-down). " +
+        "If the trigger's classification is higher than your session taint, your session taint will escalate.",
+      parameters: {
+        source: {
+          type: "string",
+          description:
+            "Trigger source identifier. Defaults to 'trigger' (the periodic trigger). " +
+            "Use 'cron:<job-id>' for cron jobs or 'webhook:<source-id>' for webhooks.",
+          required: false,
+        },
+      },
+    },
+  ];
+}
+
+/** System prompt section explaining trigger tools to the LLM. */
+export const TRIGGER_TOOLS_SYSTEM_PROMPT =
+  `## Trigger Context
+
+You can retrieve recent trigger outputs and inject them into the conversation.
+
+- Use \`trigger_add_to_context\` to load the last periodic trigger result into context.
+  - The \`source\` parameter defaults to "trigger" (the periodic trigger loop).
+  - For cron jobs, use \`source="cron:<job-id>"\`. For webhooks, use \`source="webhook:<source-id>"\`.
+- Write-down enforcement applies: if your session taint is higher than the trigger's
+  classification, adding it to context is blocked.
+- When a trigger is successfully added, its content and classification are visible in context.
+- If the trigger's classification exceeds your current session taint, your session taint
+  will automatically escalate to match it.`;
+
+/**
+ * Create a tool executor for trigger context tools.
+ *
+ * Returns null for unrecognised tool names (allowing chaining with other
+ * executors). All classification checks use the injected context, never
+ * LLM-supplied values.
+ *
+ * @param ctx - Trigger tool context
+ * @returns An executor function: (name, input) => Promise<string | null>
+ */
+export function createTriggerToolExecutor(
+  ctx: TriggerToolContext | undefined,
+): (name: string, input: Record<string, unknown>) => Promise<string | null> {
+  return async (
+    name: string,
+    input: Record<string, unknown>,
+  ): Promise<string | null> => {
+    if (name !== "trigger_add_to_context") return null;
+
+    if (!ctx) {
+      return "Trigger context tools are not available in this context.";
+    }
+
+    const source =
+      typeof input.source === "string" && input.source.length > 0
+        ? input.source
+        : DEFAULT_SOURCE;
+
+    // Retrieve the last result for the requested source
+    let result: TriggerResult | null;
+    try {
+      result = await ctx.triggerStore.getLast(source);
+    } catch (err) {
+      return `Error retrieving trigger result: ${err instanceof Error ? err.message : String(err)}`;
+    }
+
+    if (result === null) {
+      return source === DEFAULT_SOURCE
+        ? "No trigger result found. The periodic trigger has not fired yet or no output was produced."
+        : `No trigger result found for source: ${source}`;
+    }
+
+    // Write-down check: session taint must be able to flow to the trigger's classification.
+    // canFlowTo(session.taint, trigger.classification) must be true.
+    // If session.taint > trigger.classification → write-down → block.
+    const currentTaint = ctx.getSessionTaint?.() ?? ctx.sessionTaint;
+    if (!canFlowTo(currentTaint, result.classification)) {
+      return (
+        `Write-down blocked: your session taint is ${currentTaint}, but this trigger result is ` +
+        `classified as ${result.classification}. ` +
+        `Data cannot flow from ${currentTaint} to ${result.classification}.`
+      );
+    }
+
+    // Escalate session taint if trigger classification is higher
+    if (!canFlowTo(result.classification, currentTaint)) {
+      // trigger.classification > currentTaint → escalate
+      ctx.escalateTaint?.(result.classification);
+    }
+
+    // Format the trigger result for injection into context
+    const firedAt = result.firedAt
+      ? new Date(result.firedAt).toLocaleString()
+      : "unknown time";
+
+    return (
+      `[Trigger output loaded into context]\n` +
+      `Source: ${result.source}\n` +
+      `Classification: ${result.classification}\n` +
+      `Fired at: ${firedAt}\n\n` +
+      result.message
+    );
+  };
+}

--- a/src/scheduler/mod.ts
+++ b/src/scheduler/mod.ts
@@ -43,3 +43,9 @@ export {
 } from "./service.ts";
 
 export { signWebhook, verifyWebhookSignature } from "./webhook_security.ts";
+
+export {
+  createTriggerStore,
+  type TriggerResult,
+  type TriggerStore,
+} from "./trigger_store.ts";

--- a/src/scheduler/service.ts
+++ b/src/scheduler/service.ts
@@ -23,6 +23,7 @@ import { createTrigger } from "./trigger.ts";
 import type { Trigger } from "./trigger.ts";
 import { createWebhookHandler, verifyHmacAsync } from "./webhooks.ts";
 import type { WebhookEvent, WebhookHandler } from "./webhooks.ts";
+import type { TriggerStore } from "./trigger_store.ts";
 
 /**
  * Factory that creates an isolated orchestrator + session per execution.
@@ -72,6 +73,8 @@ export interface SchedulerServiceConfig {
   readonly notificationService?: NotificationService;
   /** Owner user ID for notification delivery. */
   readonly ownerId?: UserId;
+  /** Optional store for persisting the last result of each trigger source. */
+  readonly triggerStore?: TriggerStore;
 }
 
 /** The scheduler service interface. */
@@ -110,15 +113,31 @@ export function createSchedulerService(
   let cronTickId: number | undefined;
   let trigger: Trigger | undefined;
 
-  /** Deliver orchestrator output as a notification. */
+  /** Deliver orchestrator output as a notification and persist to trigger store. */
   async function deliverOutput(
     result: Result<{ readonly response: string }, string>,
     sessionTaint: ClassificationLevel,
     source: string,
   ): Promise<void> {
-    if (!config.notificationService || !config.ownerId) return;
     const text = result.ok ? result.value.response : result.error;
     if (!text || text.trim().length === 0) return;
+
+    // Persist result to trigger store (if configured) regardless of notification delivery
+    if (config.triggerStore) {
+      try {
+        await config.triggerStore.save({
+          id: crypto.randomUUID(),
+          source,
+          message: text,
+          classification: sessionTaint,
+          firedAt: new Date().toISOString(),
+        });
+      } catch {
+        // Store failures never crash the scheduler
+      }
+    }
+
+    if (!config.notificationService || !config.ownerId) return;
     try {
       await config.notificationService.deliver({
         userId: config.ownerId,

--- a/src/scheduler/trigger_store.ts
+++ b/src/scheduler/trigger_store.ts
@@ -1,0 +1,93 @@
+/**
+ * TriggerStore — persists the most recent trigger result per source.
+ *
+ * Stores one entry per trigger source keyed as `trigger:last:<source>`.
+ * Each new result for a source overwrites the previous one, keeping
+ * storage bounded. Results carry the classification level at which the
+ * trigger executed.
+ *
+ * @module
+ */
+
+import type { ClassificationLevel } from "../core/types/classification.ts";
+import type { StorageProvider } from "../core/storage/provider.ts";
+
+/** A persisted trigger execution result. */
+export interface TriggerResult {
+  /** Unique identifier for this result (random UUID). */
+  readonly id: string;
+  /**
+   * Trigger source identifier.
+   * Examples: "trigger" (periodic), "cron:job-id", "webhook:src".
+   */
+  readonly source: string;
+  /** The orchestrator response text. */
+  readonly message: string;
+  /** Classification level at which the trigger ran. */
+  readonly classification: ClassificationLevel;
+  /** When the trigger fired. */
+  readonly firedAt: string; // ISO-8601 string for serialisation round-trips
+}
+
+/** Interface for storing and retrieving trigger results. */
+export interface TriggerStore {
+  /**
+   * Save the latest result for a source.
+   * Overwrites any previous result for the same source.
+   */
+  save(result: TriggerResult): Promise<void>;
+  /**
+   * Get the most recent result for a source.
+   * Returns null if no result has been stored for that source.
+   */
+  getLast(source: string): Promise<TriggerResult | null>;
+  /** List all stored results (one per source). */
+  listAll(): Promise<TriggerResult[]>;
+}
+
+/** Storage key prefix for trigger results. */
+const KEY_PREFIX = "trigger:last:";
+
+/**
+ * Create a TriggerStore backed by the given StorageProvider.
+ *
+ * Results are serialised as JSON strings. One entry per source;
+ * each call to `save` overwrites the previous entry for that source.
+ *
+ * @param storage - The underlying storage provider
+ * @returns A TriggerStore instance
+ */
+export function createTriggerStore(storage: StorageProvider): TriggerStore {
+  return {
+    async save(result: TriggerResult): Promise<void> {
+      const key = `${KEY_PREFIX}${result.source}`;
+      await storage.set(key, JSON.stringify(result));
+    },
+
+    async getLast(source: string): Promise<TriggerResult | null> {
+      const key = `${KEY_PREFIX}${source}`;
+      const raw = await storage.get(key);
+      if (raw === null) return null;
+      try {
+        return JSON.parse(raw) as TriggerResult;
+      } catch {
+        return null;
+      }
+    },
+
+    async listAll(): Promise<TriggerResult[]> {
+      const keys = await storage.list(KEY_PREFIX);
+      const results: TriggerResult[] = [];
+      for (const key of keys) {
+        const raw = await storage.get(key);
+        if (raw === null) continue;
+        try {
+          results.push(JSON.parse(raw) as TriggerResult);
+        } catch {
+          // Skip corrupted entries
+        }
+      }
+      return results;
+    },
+  };
+}

--- a/tests/gateway/trigger_tools_test.ts
+++ b/tests/gateway/trigger_tools_test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for trigger context tools — trigger_add_to_context.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { createMemoryStorage } from "../../src/core/storage/memory.ts";
+import { createTriggerStore } from "../../src/scheduler/trigger_store.ts";
+import type { TriggerResult } from "../../src/scheduler/trigger_store.ts";
+import {
+  createTriggerToolExecutor,
+  getTriggerToolDefinitions,
+} from "../../src/gateway/trigger_tools.ts";
+import type { TriggerToolContext } from "../../src/gateway/trigger_tools.ts";
+
+function makeResult(
+  overrides: Partial<TriggerResult> = {},
+): TriggerResult {
+  return {
+    id: crypto.randomUUID(),
+    source: "trigger",
+    message: "Nothing to report.",
+    classification: "PUBLIC",
+    firedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeCtx(
+  overrides: Partial<TriggerToolContext> = {},
+): TriggerToolContext {
+  const store = createTriggerStore(createMemoryStorage());
+  return {
+    triggerStore: store,
+    sessionTaint: "PUBLIC",
+    ...overrides,
+  };
+}
+
+// ── Tool definitions ──────────────────────────────────────────────────
+
+Deno.test("getTriggerToolDefinitions: returns trigger_add_to_context", () => {
+  const defs = getTriggerToolDefinitions();
+  assertEquals(defs.length, 1);
+  assertEquals(defs[0].name, "trigger_add_to_context");
+});
+
+// ── No result found ───────────────────────────────────────────────────
+
+Deno.test("trigger_add_to_context: returns error when no trigger result exists", async () => {
+  const ctx = makeCtx();
+  const exec = createTriggerToolExecutor(ctx);
+  const result = await exec("trigger_add_to_context", {});
+  assertEquals(typeof result, "string");
+  assertStringIncludes(result as string, "No trigger result found");
+});
+
+Deno.test("trigger_add_to_context: returns error for unknown source", async () => {
+  const ctx = makeCtx();
+  const exec = createTriggerToolExecutor(ctx);
+  const result = await exec("trigger_add_to_context", { source: "cron:nonexistent" });
+  assertStringIncludes(result as string, "No trigger result found for source: cron:nonexistent");
+});
+
+// ── Classification allowed ────────────────────────────────────────────
+
+Deno.test("trigger_add_to_context: returns trigger content when classification allows", async () => {
+  const storage = createMemoryStorage();
+  const store = createTriggerStore(storage);
+  const triggerResult = makeResult({ message: "Everything is fine.", classification: "PUBLIC" });
+  await store.save(triggerResult);
+
+  const ctx = makeCtx({ triggerStore: store, sessionTaint: "PUBLIC" });
+  const exec = createTriggerToolExecutor(ctx);
+  const result = await exec("trigger_add_to_context", {});
+  assertStringIncludes(result as string, "Everything is fine.");
+  assertStringIncludes(result as string, "PUBLIC");
+  assertStringIncludes(result as string, "Trigger output loaded into context");
+});
+
+Deno.test("trigger_add_to_context: session taint < trigger classification (write-up) is allowed", async () => {
+  const storage = createMemoryStorage();
+  const store = createTriggerStore(storage);
+  const triggerResult = makeResult({ message: "Internal info.", classification: "INTERNAL" });
+  await store.save(triggerResult);
+
+  const ctx = makeCtx({ triggerStore: store, sessionTaint: "PUBLIC" });
+  const exec = createTriggerToolExecutor(ctx);
+  const result = await exec("trigger_add_to_context", {});
+  assertStringIncludes(result as string, "Internal info.");
+});
+
+// ── Write-down enforcement ────────────────────────────────────────────
+
+Deno.test("trigger_add_to_context: blocks when session taint > trigger classification (write-down)", async () => {
+  const storage = createMemoryStorage();
+  const store = createTriggerStore(storage);
+  const triggerResult = makeResult({ message: "Public news.", classification: "PUBLIC" });
+  await store.save(triggerResult);
+
+  const ctx = makeCtx({ triggerStore: store, sessionTaint: "CONFIDENTIAL" });
+  const exec = createTriggerToolExecutor(ctx);
+  const result = await exec("trigger_add_to_context", {});
+  assertStringIncludes(result as string, "Write-down blocked");
+  assertStringIncludes(result as string, "CONFIDENTIAL");
+  assertStringIncludes(result as string, "PUBLIC");
+});
+
+Deno.test("trigger_add_to_context: RESTRICTED session blocked from PUBLIC trigger", async () => {
+  const storage = createMemoryStorage();
+  const store = createTriggerStore(storage);
+  await store.save(makeResult({ classification: "PUBLIC" }));
+
+  const ctx = makeCtx({ triggerStore: store, sessionTaint: "RESTRICTED" });
+  const exec = createTriggerToolExecutor(ctx);
+  const result = await exec("trigger_add_to_context", {});
+  assertStringIncludes(result as string, "Write-down blocked");
+});
+
+// ── Taint escalation ──────────────────────────────────────────────────
+
+Deno.test("trigger_add_to_context: escalates session taint when trigger classification is higher", async () => {
+  const storage = createMemoryStorage();
+  const store = createTriggerStore(storage);
+  await store.save(makeResult({ message: "Confidential info.", classification: "CONFIDENTIAL" }));
+
+  let escalatedTo: string | undefined;
+  const ctx = makeCtx({
+    triggerStore: store,
+    sessionTaint: "PUBLIC",
+    escalateTaint: (level) => { escalatedTo = level; },
+  });
+  const exec = createTriggerToolExecutor(ctx);
+  await exec("trigger_add_to_context", {});
+  assertEquals(escalatedTo, "CONFIDENTIAL");
+});
+
+Deno.test("trigger_add_to_context: does not escalate when trigger classification equals session taint", async () => {
+  const storage = createMemoryStorage();
+  const store = createTriggerStore(storage);
+  await store.save(makeResult({ classification: "INTERNAL" }));
+
+  let escalated = false;
+  const ctx = makeCtx({
+    triggerStore: store,
+    sessionTaint: "INTERNAL",
+    escalateTaint: () => { escalated = true; },
+  });
+  const exec = createTriggerToolExecutor(ctx);
+  await exec("trigger_add_to_context", {});
+  assertEquals(escalated, false);
+});
+
+// ── Source parameter ──────────────────────────────────────────────────
+
+Deno.test("trigger_add_to_context: defaults to 'trigger' source when not specified", async () => {
+  const storage = createMemoryStorage();
+  const store = createTriggerStore(storage);
+  await store.save(makeResult({ source: "trigger", message: "default source result" }));
+  await store.save(makeResult({ source: "cron:job-1", message: "cron result" }));
+
+  const ctx = makeCtx({ triggerStore: store, sessionTaint: "PUBLIC" });
+  const exec = createTriggerToolExecutor(ctx);
+  const result = await exec("trigger_add_to_context", {});
+  assertStringIncludes(result as string, "default source result");
+});
+
+Deno.test("trigger_add_to_context: source parameter selects the correct stored result", async () => {
+  const storage = createMemoryStorage();
+  const store = createTriggerStore(storage);
+  await store.save(makeResult({ source: "trigger", message: "periodic result" }));
+  await store.save(makeResult({ source: "cron:job-1", message: "cron job result" }));
+
+  const ctx = makeCtx({ triggerStore: store, sessionTaint: "PUBLIC" });
+  const exec = createTriggerToolExecutor(ctx);
+  const result = await exec("trigger_add_to_context", { source: "cron:job-1" });
+  assertStringIncludes(result as string, "cron job result");
+});
+
+// ── Non-trigger tool names ────────────────────────────────────────────
+
+Deno.test("trigger executor: returns null for unknown tool names", async () => {
+  const ctx = makeCtx();
+  const exec = createTriggerToolExecutor(ctx);
+  const result = await exec("some_other_tool", {});
+  assertEquals(result, null);
+});
+
+Deno.test("trigger executor: returns null for sessions_list", async () => {
+  const ctx = makeCtx();
+  const exec = createTriggerToolExecutor(ctx);
+  const result = await exec("sessions_list", {});
+  assertEquals(result, null);
+});
+
+// ── No context available ──────────────────────────────────────────────
+
+Deno.test("trigger executor: returns error when context is undefined", async () => {
+  const exec = createTriggerToolExecutor(undefined);
+  const result = await exec("trigger_add_to_context", {});
+  assertStringIncludes(result as string, "not available");
+});

--- a/tests/scheduler/trigger_store_test.ts
+++ b/tests/scheduler/trigger_store_test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests for TriggerStore — persists last trigger result per source.
+ */
+
+import { assertEquals, assertExists } from "@std/assert";
+import { createMemoryStorage } from "../../src/core/storage/memory.ts";
+import {
+  createTriggerStore,
+} from "../../src/scheduler/trigger_store.ts";
+import type { TriggerResult } from "../../src/scheduler/trigger_store.ts";
+
+function makeResult(
+  overrides: Partial<TriggerResult> = {},
+): TriggerResult {
+  return {
+    id: crypto.randomUUID(),
+    source: "trigger",
+    message: "All clear — nothing to report.",
+    classification: "PUBLIC",
+    firedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+Deno.test("TriggerStore: save and getLast round-trip", async () => {
+  const store = createTriggerStore(createMemoryStorage());
+  const result = makeResult();
+  await store.save(result);
+  const retrieved = await store.getLast("trigger");
+  assertExists(retrieved);
+  assertEquals(retrieved.id, result.id);
+  assertEquals(retrieved.source, result.source);
+  assertEquals(retrieved.message, result.message);
+  assertEquals(retrieved.classification, result.classification);
+  assertEquals(retrieved.firedAt, result.firedAt);
+});
+
+Deno.test("TriggerStore: getLast returns null when source has no stored result", async () => {
+  const store = createTriggerStore(createMemoryStorage());
+  const retrieved = await store.getLast("trigger");
+  assertEquals(retrieved, null);
+});
+
+Deno.test("TriggerStore: saving a second result for the same source overwrites the first", async () => {
+  const store = createTriggerStore(createMemoryStorage());
+  const first = makeResult({ message: "first message", id: "id-1" });
+  const second = makeResult({ message: "second message", id: "id-2" });
+  await store.save(first);
+  await store.save(second);
+  const retrieved = await store.getLast("trigger");
+  assertExists(retrieved);
+  assertEquals(retrieved.id, "id-2");
+  assertEquals(retrieved.message, "second message");
+});
+
+Deno.test("TriggerStore: listAll returns one entry per source", async () => {
+  const store = createTriggerStore(createMemoryStorage());
+  await store.save(makeResult({ source: "trigger" }));
+  await store.save(makeResult({ source: "cron:job-1" }));
+  await store.save(makeResult({ source: "webhook:src-a" }));
+  const all = await store.listAll();
+  assertEquals(all.length, 3);
+  const sources = new Set(all.map((r) => r.source));
+  assertEquals(sources.has("trigger"), true);
+  assertEquals(sources.has("cron:job-1"), true);
+  assertEquals(sources.has("webhook:src-a"), true);
+});
+
+Deno.test("TriggerStore: listAll returns only the latest result per source after overwrite", async () => {
+  const store = createTriggerStore(createMemoryStorage());
+  await store.save(makeResult({ source: "trigger", message: "old" }));
+  await store.save(makeResult({ source: "trigger", message: "new" }));
+  const all = await store.listAll();
+  assertEquals(all.length, 1);
+  assertEquals(all[0].message, "new");
+});
+
+Deno.test("TriggerStore: preserves classification level", async () => {
+  const store = createTriggerStore(createMemoryStorage());
+  await store.save(makeResult({ classification: "CONFIDENTIAL" }));
+  const retrieved = await store.getLast("trigger");
+  assertExists(retrieved);
+  assertEquals(retrieved.classification, "CONFIDENTIAL");
+});
+
+Deno.test("TriggerStore: different sources are stored independently", async () => {
+  const store = createTriggerStore(createMemoryStorage());
+  await store.save(makeResult({ source: "trigger", message: "periodic result" }));
+  await store.save(makeResult({ source: "cron:job-1", message: "cron result" }));
+
+  const periodic = await store.getLast("trigger");
+  const cron = await store.getLast("cron:job-1");
+
+  assertExists(periodic);
+  assertExists(cron);
+  assertEquals(periodic.message, "periodic result");
+  assertEquals(cron.message, "cron result");
+});
+
+Deno.test("TriggerStore: listAll returns empty array when no results stored", async () => {
+  const store = createTriggerStore(createMemoryStorage());
+  const all = await store.listAll();
+  assertEquals(all.length, 0);
+});


### PR DESCRIPTION
Implements trigger result persistence and the `trigger_add_to_context` agent tool to resolve #37.

Closes #37

Generated with [Claude Code](https://claude.ai/code)