### PR TITLE
[Phase C2] fix: improve signal-cli reliability (all 8 recommendations)

### DIFF
--- a/src/channels/signal/adapter.ts
+++ b/src/channels/signal/adapter.ts
@@ -155,10 +155,18 @@ export function createSignalChannel(config: SignalConfig): SignalChannelAdapter 
         throw new Error(`Signal connect failed: ${result.error}`);
       }
 
-      // Verify connectivity
-      const pingResult = await client.ping();
+      // Verify connectivity — retry up to 5 times (500ms apart) to handle
+      // the TCP-ready-but-JSON-RPC-not-ready window after daemon startup.
+      let pingResult: Result<void, string> = { ok: false, error: "not attempted" };
+      for (let attempt = 0; attempt < 5; attempt++) {
+        if (attempt > 0) {
+          await new Promise((r) => setTimeout(r, 500));
+        }
+        pingResult = await client.ping();
+        if (pingResult.ok) break;
+      }
       if (!pingResult.ok) {
-        throw new Error(`Signal ping failed: ${pingResult.error}`);
+        throw new Error(`Signal ping failed after retries: ${pingResult.error}`);
       }
 
       connected = true;

--- a/src/channels/signal/client.ts
+++ b/src/channels/signal/client.ts
@@ -55,6 +55,8 @@ export function createSignalClient(options: SignalClientOptions): SignalClientIn
   let notificationHandler: ((notification: SignalNotification) => void) | null = null;
   let readLoopActive = false;
   let buffer = "";
+  let destroyed = false;
+  let reconnecting = false;
 
   /** Parse the endpoint URI into connection parameters. */
   function parseEndpoint(endpoint: string): { transport: "tcp"; hostname: string; port: number } | { transport: "unix"; path: string } {
@@ -90,7 +92,15 @@ export function createSignalClient(options: SignalClientOptions): SignalClientIn
       while (readLoopActive && conn) {
         const n = await conn.read(buf);
         if (n === null) {
+          // EOF — connection closed
           readLoopActive = false;
+          conn = null;
+          // Reject pending requests
+          for (const [id, req] of pending) {
+            req.reject(new Error("Connection closed"));
+            pending.delete(id);
+          }
+          reconnectLoop();
           break;
         }
 
@@ -115,7 +125,45 @@ export function createSignalClient(options: SignalClientOptions): SignalClientIn
     } catch {
       // Connection closed or errored
       readLoopActive = false;
+      conn = null;
+      // Reject pending requests
+      for (const [id, req] of pending) {
+        req.reject(new Error("Connection error"));
+        pending.delete(id);
+      }
+      reconnectLoop();
     }
+  }
+
+  /** Attempt to reconnect using exponential backoff. Fire-and-forget. */
+  async function reconnectLoop(): Promise<void> {
+    if (destroyed || reconnecting) return;
+    reconnecting = true;
+    let attempt = 0;
+    while (!destroyed && attempt < _maxRetries) {
+      const delay = _baseDelay * Math.pow(2, attempt);
+      await new Promise((r) => setTimeout(r, delay));
+      if (destroyed) break;
+      attempt++;
+      try {
+        const target = parseEndpoint(options.endpoint);
+        if (target.transport === "tcp") {
+          conn = await Deno.connect({ hostname: target.hostname, port: target.port });
+        } else {
+          conn = await (Deno.connect as (opts: { transport: "unix"; path: string }) => Promise<Deno.Conn>)({
+            transport: "unix",
+            path: target.path,
+          });
+        }
+        buffer = "";
+        startReadLoop();
+        reconnecting = false;
+        return;
+      } catch {
+        conn = null;
+      }
+    }
+    reconnecting = false;
   }
 
   /** Dispatch a parsed JSON message as either a response or notification. */
@@ -190,6 +238,7 @@ export function createSignalClient(options: SignalClientOptions): SignalClientIn
     },
 
     disconnect(): Promise<void> {
+      destroyed = true;
       readLoopActive = false;
       if (conn) {
         try {

--- a/src/channels/signal/setup.ts
+++ b/src/channels/signal/setup.ts
@@ -10,6 +10,13 @@
 import type { Result } from "../../core/types/classification.ts";
 import { resolveBaseDir } from "../../cli/paths.ts";
 
+/**
+ * Minimum known-good signal-cli version. Warn (but don't block) if the
+ * installed version is older. Update this constant when a newer release
+ * has been validated.
+ */
+export const SIGNAL_CLI_KNOWN_GOOD_VERSION = "0.13.0";
+
 /** Result of the guided Signal setup flow. */
 export interface SignalSetupResult {
   readonly account: string;
@@ -30,6 +37,29 @@ export function resolveSignalCliBinDir(): string {
 }
 
 /**
+ * Log a warning if the installed signal-cli version is older than the known-good version.
+ *
+ * @param versionOutput - Output from `signal-cli --version` (e.g. "signal-cli 0.13.24").
+ */
+export function warnIfOldVersion(versionOutput: string): void {
+  const match = versionOutput.match(/(\d+\.\d+\.\d+)/);
+  if (!match) return;
+  const installed = match[1].split(".").map(Number);
+  const known = SIGNAL_CLI_KNOWN_GOOD_VERSION.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    const inst = installed[i] ?? 0;
+    const know = known[i] ?? 0;
+    if (inst < know) {
+      console.warn(
+        `⚠ signal-cli ${match[1]} is older than known-good ${SIGNAL_CLI_KNOWN_GOOD_VERSION}. Consider upgrading.`,
+      );
+      return;
+    }
+    if (inst > know) return;
+  }
+}
+
+/**
  * Find signal-cli binary — check PATH first, then Triggerfish's managed bin dir.
  *
  * Returns the version string, resolved binary path, and optional JAVA_HOME
@@ -42,7 +72,10 @@ export async function checkSignalCli(): Promise<Result<{ version: string; path: 
 
   // 1. Check PATH (system-installed signal-cli, uses system java)
   const pathResult = await trySignalCli(`signal-cli${ext}`);
-  if (pathResult.ok) return pathResult;
+  if (pathResult.ok) {
+    warnIfOldVersion(pathResult.value.version);
+    return pathResult;
+  }
 
   // 2. Check managed install dir
   const binDir = resolveSignalCliBinDir();
@@ -656,6 +689,8 @@ export interface DaemonHandle {
   readonly child: Deno.ChildProcess;
   /** Collect any stderr output (for diagnostics on failure). */
   readonly stderrText: () => Promise<string>;
+  /** Resolves with the first stderr output received within 5s of start (for fast error surfacing). */
+  readonly earlyStderr: Promise<string>;
 }
 
 /**
@@ -692,36 +727,71 @@ export function startDaemon(
     });
     const child = cmd.spawn();
 
-    // Collect stderr lazily — only read when caller needs diagnostics
-    let stderrPromise: Promise<string> | null = null;
-    const stderrText = (): Promise<string> => {
-      if (!stderrPromise) {
-        stderrPromise = (async () => {
-          try {
-            const reader = child.stderr.getReader();
-            const chunks: Uint8Array[] = [];
-            while (true) {
-              const { value, done } = await reader.read();
-              if (done) break;
-              chunks.push(value);
-            }
-            const total = chunks.reduce((n, c) => n + c.length, 0);
-            const merged = new Uint8Array(total);
-            let offset = 0;
-            for (const c of chunks) {
-              merged.set(c, offset);
-              offset += c.length;
-            }
-            return new TextDecoder().decode(merged).trim();
-          } catch {
-            return "";
-          }
-        })();
-      }
-      return stderrPromise;
-    };
+    // Read all stderr into a shared buffer for diagnostics.
+    // earlyStderr resolves with the first line (within 5s); stderrText() resolves when the process ends.
+    const stderrChunks: Uint8Array[] = [];
+    let earlyResolve: ((s: string) => void) | null = null;
+    let fullResolve: ((s: string) => void) | null = null;
+    const earlyStderr: Promise<string> = new Promise((r) => { earlyResolve = r; });
+    const _fullStderrPromise: Promise<string> = new Promise((r) => { fullResolve = r; });
 
-    return { ok: true, value: { child, stderrText } };
+    // Background reader — collects all stderr, resolves both promises
+    (async () => {
+      const decoder = new TextDecoder();
+      const earlyDeadline = Date.now() + 5000;
+      // Auto-resolve earlyStderr after 5s if not already done
+      const earlyTimer = setTimeout(() => {
+        if (earlyResolve) {
+          const soFar = stderrChunks.map((c) => decoder.decode(c)).join("");
+          earlyResolve(soFar.split("\n")[0].trim());
+          earlyResolve = null;
+        }
+      }, 5000);
+      try {
+        const reader = child.stderr.getReader();
+        try {
+          while (true) {
+            const { value, done } = await reader.read();
+            if (done || !value) {
+              // Process ended — resolve early if not yet done
+              if (earlyResolve) {
+                const soFar = stderrChunks.map((c) => decoder.decode(c)).join("");
+                earlyResolve(soFar.split("\n")[0].trim());
+                earlyResolve = null;
+              }
+              break;
+            }
+            stderrChunks.push(value);
+            // Resolve earlyStderr once we have the first complete line (before 5s deadline)
+            if (earlyResolve && Date.now() < earlyDeadline) {
+              const soFar = stderrChunks.map((c) => decoder.decode(c)).join("");
+              if (soFar.includes("\n")) {
+                earlyResolve(soFar.split("\n")[0].trim());
+                earlyResolve = null;
+              }
+            }
+          }
+        } finally {
+          reader.releaseLock();
+        }
+      } catch {
+        if (earlyResolve) { earlyResolve(""); earlyResolve = null; }
+      }
+      clearTimeout(earlyTimer);
+      // Resolve the full stderr promise
+      const total = stderrChunks.reduce((n, c) => n + c.length, 0);
+      const merged = new Uint8Array(total);
+      let offset = 0;
+      for (const c of stderrChunks) {
+        merged.set(c, offset);
+        offset += c.length;
+      }
+      if (fullResolve) { fullResolve(new TextDecoder().decode(merged).trim()); fullResolve = null; }
+    })();
+
+    const stderrText = (): Promise<string> => _fullStderrPromise;
+
+    return { ok: true, value: { child, stderrText, earlyStderr } };
   } catch (err) {
     return { ok: false, error: `Failed to start signal-cli daemon: ${err instanceof Error ? err.message : String(err)}` };
   }
@@ -734,6 +804,152 @@ export async function waitForDaemon(host: string, port: number, timeoutMs: numbe
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
     if (await isDaemonRunning(host, port)) return true;
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  return false;
+}
+
+/**
+ * Check if a running TCP daemon actually responds to JSON-RPC (not just accepts TCP).
+ *
+ * Returns true if healthy (JSON-RPC responds), false if port is occupied but
+ * the daemon is broken or not yet initialized.
+ */
+export async function isDaemonHealthy(host: string, port: number): Promise<boolean> {
+  try {
+    const conn = await Deno.connect({ hostname: normalizeHost(host), port });
+    const encoder = new TextEncoder();
+    const decoder = new TextDecoder();
+    const req = JSON.stringify({ jsonrpc: "2.0", method: "version", params: {}, id: "health-1" }) + "\n";
+    await conn.write(encoder.encode(req));
+    const buf = new Uint8Array(1024);
+    const readResult = await Promise.race<number | null>([
+      conn.read(buf),
+      new Promise<null>((r) => setTimeout(() => r(null), 3000)),
+    ]);
+    conn.close();
+    if (readResult === null || readResult === 0) return false;
+    const resp = JSON.parse(decoder.decode(buf.subarray(0, readResult))) as Record<string, unknown>;
+    return resp?.result !== undefined || resp?.error !== undefined;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check if signal-cli daemon is already running on a Unix socket.
+ */
+export async function isDaemonRunningUnix(socketPath: string): Promise<boolean> {
+  try {
+    const conn = await (Deno.connect as (opts: { transport: "unix"; path: string }) => Promise<Deno.Conn>)({
+      transport: "unix",
+      path: socketPath,
+    });
+    conn.close();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Start signal-cli daemon on a Unix socket.
+ *
+ * @param account - Phone number (E.164).
+ * @param socketPath - Path to the Unix socket file.
+ * @param signalCliPath - Path to signal-cli binary.
+ * @param javaHome - Optional JAVA_HOME for managed JRE.
+ * @returns A handle with the child process and stderr accessor.
+ */
+export function startDaemonUnix(
+  account: string,
+  socketPath: string,
+  signalCliPath: string = "signal-cli",
+  javaHome?: string,
+): Result<DaemonHandle, string> {
+  try {
+    const env = javaHome
+      ? { ...Deno.env.toObject(), JAVA_HOME: javaHome }
+      : undefined;
+    const cmd = new Deno.Command(signalCliPath, {
+      args: ["-a", account, "daemon", "--socket", socketPath],
+      stdout: "null",
+      stderr: "piped",
+      env,
+    });
+    const child = cmd.spawn();
+
+    // Read all stderr into a shared buffer — earlyStderr resolves with the first line within 5s
+    const stderrChunksUnix: Uint8Array[] = [];
+    let earlyResolveUnix: ((s: string) => void) | null = null;
+    let fullResolveUnix: ((s: string) => void) | null = null;
+    const earlyStderr: Promise<string> = new Promise((r) => { earlyResolveUnix = r; });
+    const _fullStderrPromiseUnix: Promise<string> = new Promise((r) => { fullResolveUnix = r; });
+
+    (async () => {
+      const decoder = new TextDecoder();
+      const earlyDeadlineUnix = Date.now() + 5000;
+      const earlyTimerUnix = setTimeout(() => {
+        if (earlyResolveUnix) {
+          const soFar = stderrChunksUnix.map((c) => decoder.decode(c)).join("");
+          earlyResolveUnix(soFar.split("\n")[0].trim());
+          earlyResolveUnix = null;
+        }
+      }, 5000);
+      try {
+        const reader = child.stderr.getReader();
+        try {
+          while (true) {
+            const { value, done } = await reader.read();
+            if (done || !value) {
+              if (earlyResolveUnix) {
+                const soFar = stderrChunksUnix.map((c) => decoder.decode(c)).join("");
+                earlyResolveUnix(soFar.split("\n")[0].trim());
+                earlyResolveUnix = null;
+              }
+              break;
+            }
+            stderrChunksUnix.push(value);
+            if (earlyResolveUnix && Date.now() < earlyDeadlineUnix) {
+              const soFar = stderrChunksUnix.map((c) => decoder.decode(c)).join("");
+              if (soFar.includes("\n")) {
+                earlyResolveUnix(soFar.split("\n")[0].trim());
+                earlyResolveUnix = null;
+              }
+            }
+          }
+        } finally {
+          reader.releaseLock();
+        }
+      } catch {
+        if (earlyResolveUnix) { earlyResolveUnix(""); earlyResolveUnix = null; }
+      }
+      clearTimeout(earlyTimerUnix);
+      const total = stderrChunksUnix.reduce((n, c) => n + c.length, 0);
+      const merged = new Uint8Array(total);
+      let offset = 0;
+      for (const c of stderrChunksUnix) {
+        merged.set(c, offset);
+        offset += c.length;
+      }
+      if (fullResolveUnix) { fullResolveUnix(new TextDecoder().decode(merged).trim()); fullResolveUnix = null; }
+    })();
+
+    const stderrText = (): Promise<string> => _fullStderrPromiseUnix;
+
+    return { ok: true, value: { child, stderrText, earlyStderr } };
+  } catch (err) {
+    return { ok: false, error: `Failed to start signal-cli daemon: ${err instanceof Error ? err.message : String(err)}` };
+  }
+}
+
+/**
+ * Wait for daemon to become reachable on a Unix socket.
+ */
+export async function waitForDaemonUnix(socketPath: string, timeoutMs: number = 60000): Promise<boolean> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (await isDaemonRunningUnix(socketPath)) return true;
     await new Promise((r) => setTimeout(r, 500));
   }
   return false;

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -221,12 +221,17 @@ import {
   checkSignalCli,
   downloadSignalCli,
   fetchLatestVersion,
+  isDaemonHealthy,
   isDaemonRunning,
+  isDaemonRunningUnix,
   renderQrCode,
   startDaemon,
+  startDaemonUnix,
   startLinkProcess,
   waitForDaemon,
+  waitForDaemonUnix,
 } from "../channels/signal/setup.ts";
+import type { DaemonHandle } from "../channels/signal/setup.ts";
 import { createNotificationService } from "../gateway/notifications.ts";
 import { parseClassification } from "../core/types/classification.ts";
 import { createSkillLoader } from "../skills/loader.ts";
@@ -1979,16 +1984,31 @@ async function runStart(): Promise<void> {
     groups?: Record<string, { mode: string; classification?: string }>;
   } | undefined;
 
+  // Track the spawned signal-cli daemon child so we can gracefully stop it on exit.
+  let signalDaemonHandle: DaemonHandle | null = null;
+
   if (signalConfig?.endpoint && signalConfig?.account) {
-    // Parse endpoint to check if signal-cli daemon is running
-    const endpointMatch = signalConfig.endpoint.match(
-      /^tcp:\/\/([^:]+):(\d+)$/,
-    );
-    if (endpointMatch) {
-      const [, tcpHost, tcpPortStr] = endpointMatch;
+    // Parse endpoint — handle both TCP and Unix socket auto-start
+    const tcpMatch = signalConfig.endpoint.match(/^tcp:\/\/([^:]+):(\d+)$/);
+    const unixMatch = signalConfig.endpoint.match(/^unix:\/\/(.+)$/);
+
+    if (tcpMatch) {
+      const [, tcpHost, tcpPortStr] = tcpMatch;
       const tcpPort = parseInt(tcpPortStr, 10);
       const running = await isDaemonRunning(tcpHost, tcpPort);
-      if (!running) {
+      const healthy = running ? await isDaemonHealthy(tcpHost, tcpPort) : false;
+
+      if (!running || !healthy) {
+        if (running && !healthy) {
+          log.warn("signal-cli daemon is occupying the port but not responding to JSON-RPC");
+          // If we own the process, kill it and wait briefly before restarting
+          if (signalDaemonHandle) {
+            try { signalDaemonHandle.child.kill("SIGTERM"); } catch { /* already dead */ }
+            signalDaemonHandle = null;
+            await new Promise((r) => setTimeout(r, 1000));
+          }
+        }
+
         // Auto-start signal-cli daemon
         log.info("signal-cli daemon not running, starting...");
         const cliCheck = await checkSignalCli();
@@ -2001,13 +2021,69 @@ async function runStart(): Promise<void> {
             cliCheck.value.javaHome,
           );
           if (daemonResult.ok) {
+            signalDaemonHandle = daemonResult.value;
             const ready = await waitForDaemon(tcpHost, tcpPort);
             if (ready) {
               log.info("signal-cli daemon started");
+              // Log version for diagnostics (rec 7)
+              const versionCheck = await checkSignalCli();
+              if (versionCheck.ok) {
+                log.info(`signal-cli version: ${versionCheck.value.version}`);
+              }
             } else {
+              const earlyErr = await daemonResult.value.earlyStderr;
+              if (earlyErr) {
+                log.error(`signal-cli early stderr: ${earlyErr}`);
+              }
               const stderr = await daemonResult.value.stderrText();
               log.error(
                 "signal-cli daemon started but not reachable within 60s",
+              );
+              if (stderr) {
+                log.error(`signal-cli stderr: ${stderr}`);
+              }
+            }
+          } else {
+            log.error(
+              `Failed to start signal-cli daemon: ${daemonResult.error}`,
+            );
+          }
+        } else {
+          log.error("signal-cli not found — cannot auto-start daemon");
+        }
+      }
+    } else if (unixMatch) {
+      const socketPath = unixMatch[1];
+      const running = await isDaemonRunningUnix(socketPath);
+      if (!running) {
+        // Auto-start signal-cli daemon on Unix socket
+        log.info("signal-cli daemon not running (Unix socket), starting...");
+        const cliCheck = await checkSignalCli();
+        if (cliCheck.ok) {
+          const daemonResult = startDaemonUnix(
+            signalConfig.account,
+            socketPath,
+            cliCheck.value.path,
+            cliCheck.value.javaHome,
+          );
+          if (daemonResult.ok) {
+            signalDaemonHandle = daemonResult.value;
+            const ready = await waitForDaemonUnix(socketPath);
+            if (ready) {
+              log.info("signal-cli daemon started (Unix socket)");
+              // Log version for diagnostics (rec 7)
+              const versionCheck = await checkSignalCli();
+              if (versionCheck.ok) {
+                log.info(`signal-cli version: ${versionCheck.value.version}`);
+              }
+            } else {
+              const earlyErr = await daemonResult.value.earlyStderr;
+              if (earlyErr) {
+                log.error(`signal-cli early stderr: ${earlyErr}`);
+              }
+              const stderr = await daemonResult.value.stderrText();
+              log.error(
+                "signal-cli daemon (Unix socket) not reachable within 60s",
               );
               if (stderr) {
                 log.error(`signal-cli stderr: ${stderr}`);
@@ -2103,6 +2179,20 @@ async function runStart(): Promise<void> {
     log.info(`Trigger: every ${schedulerConfig.trigger.intervalMinutes}m`);
   }
   log.info("Triggerfish is running!");
+
+  // Graceful shutdown handler — stop signal-cli daemon if we spawned it
+  const handleShutdown = () => {
+    if (signalDaemonHandle) {
+      try { signalDaemonHandle.child.kill("SIGTERM"); } catch { /* already dead */ }
+      signalDaemonHandle = null;
+    }
+  };
+  try {
+    Deno.addSignalListener("SIGTERM", handleShutdown);
+  } catch { /* not supported on all platforms */ }
+  try {
+    Deno.addSignalListener("SIGINT", handleShutdown);
+  } catch { /* not supported on all platforms */ }
 
   // Keep running until interrupted
   await new Promise(() => {}); // Never resolves

--- a/tests/channels/signal/client_test.ts
+++ b/tests/channels/signal/client_test.ts
@@ -310,3 +310,64 @@ Deno.test("SignalClient: sendTypingStop sends stop flag", async () => {
 
   await client.disconnect();
 });
+
+Deno.test("SignalClient: disconnect sets destroyed flag, prevents reconnect", async () => {
+  const { conn } = createMockConn();
+  const client = createSignalClient({
+    endpoint: "tcp://localhost:7583",
+    _conn: conn,
+    maxRetries: 3,
+    baseDelay: 10,
+  });
+
+  await client.connect();
+  // Disconnect immediately — should prevent any reconnection attempt
+  await client.disconnect();
+
+  // After disconnect, sendMessage should fail (not connected)
+  const result = await client.sendMessage("+15551234567", "test after disconnect");
+  assertEquals(result.ok, false);
+});
+
+Deno.test("SignalClient: reconnection triggers after EOF on read loop", async () => {
+  // Create a conn that immediately signals EOF on first read
+  let readCount = 0;
+  const eofConn = {
+    read(_buf: Uint8Array): Promise<number | null> {
+      readCount++;
+      // Signal EOF on first read
+      return Promise.resolve(null);
+    },
+    write(data: Uint8Array): Promise<number> {
+      return Promise.resolve(data.length);
+    },
+    close(): void {},
+    localAddr: { transport: "tcp", hostname: "127.0.0.1", port: 12345 } as Deno.Addr,
+    remoteAddr: { transport: "tcp", hostname: "127.0.0.1", port: 7583 } as Deno.Addr,
+    rid: 0,
+    readable: new ReadableStream(),
+    writable: new WritableStream(),
+    ref(): void {},
+    unref(): void {},
+    [Symbol.dispose](): void {},
+    closeWrite(): Promise<void> { return Promise.resolve(); },
+  } as unknown as Deno.Conn;
+
+  const client = createSignalClient({
+    endpoint: "tcp://127.0.0.1:7583",
+    _conn: eofConn,
+    maxRetries: 1,
+    baseDelay: 50,
+  });
+
+  await client.connect();
+
+  // Wait briefly for the EOF to be processed and reconnect attempt to fire
+  await new Promise((r) => setTimeout(r, 200));
+
+  // readCount should be >= 1 (initial read triggered reconnect)
+  assert(readCount >= 1, `Expected at least 1 read attempt, got ${readCount}`);
+
+  // Clean up — destroy prevents further reconnect attempts
+  await client.disconnect();
+});

--- a/tests/channels/signal/setup_test.ts
+++ b/tests/channels/signal/setup_test.ts
@@ -1,0 +1,111 @@
+/**
+ * Signal CLI setup tests.
+ *
+ * Tests version checking, daemon health probing, and daemon utility functions.
+ */
+import { assertEquals, assert } from "@std/assert";
+import {
+  warnIfOldVersion,
+  SIGNAL_CLI_KNOWN_GOOD_VERSION,
+} from "../../../src/channels/signal/setup.ts";
+
+// ─── warnIfOldVersion ────────────────────────────────────────────────────────
+
+Deno.test("warnIfOldVersion: older version logs a warning", () => {
+  // Parse version "0.0.1" which is older than known-good
+  const warnings: string[] = [];
+  const origWarn = console.warn;
+  console.warn = (...args: unknown[]) => { warnings.push(args.join(" ")); };
+  try {
+    warnIfOldVersion("signal-cli 0.0.1");
+    assert(warnings.length > 0, "Expected a warning for old version");
+    assert(warnings[0].includes("older"), `Expected 'older' in warning: ${warnings[0]}`);
+  } finally {
+    console.warn = origWarn;
+  }
+});
+
+Deno.test("warnIfOldVersion: same version is silent", () => {
+  const warnings: string[] = [];
+  const origWarn = console.warn;
+  console.warn = (...args: unknown[]) => { warnings.push(args.join(" ")); };
+  try {
+    warnIfOldVersion(`signal-cli ${SIGNAL_CLI_KNOWN_GOOD_VERSION}`);
+    assertEquals(warnings.length, 0, "Expected no warning for known-good version");
+  } finally {
+    console.warn = origWarn;
+  }
+});
+
+Deno.test("warnIfOldVersion: newer version is silent", () => {
+  const warnings: string[] = [];
+  const origWarn = console.warn;
+  console.warn = (...args: unknown[]) => { warnings.push(args.join(" ")); };
+  try {
+    warnIfOldVersion("signal-cli 99.0.0");
+    assertEquals(warnings.length, 0, "Expected no warning for newer version");
+  } finally {
+    console.warn = origWarn;
+  }
+});
+
+Deno.test("warnIfOldVersion: version string with only numbers is parsed", () => {
+  const warnings: string[] = [];
+  const origWarn = console.warn;
+  console.warn = (...args: unknown[]) => { warnings.push(args.join(" ")); };
+  try {
+    warnIfOldVersion("0.0.1");
+    assert(warnings.length > 0, "Expected a warning for bare old version string");
+  } finally {
+    console.warn = origWarn;
+  }
+});
+
+Deno.test("warnIfOldVersion: unparseable string is silent", () => {
+  const warnings: string[] = [];
+  const origWarn = console.warn;
+  console.warn = (...args: unknown[]) => { warnings.push(args.join(" ")); };
+  try {
+    warnIfOldVersion("not a version");
+    assertEquals(warnings.length, 0, "Expected no warning for unparseable version");
+  } finally {
+    console.warn = origWarn;
+  }
+});
+
+Deno.test("warnIfOldVersion: patch version comparison works", () => {
+  // Only the patch component is older than known-good (0.13.0)
+  // 0.12.99 is older (minor component)
+  const warnings: string[] = [];
+  const origWarn = console.warn;
+  console.warn = (...args: unknown[]) => { warnings.push(args.join(" ")); };
+  try {
+    warnIfOldVersion("signal-cli 0.12.99");
+    assert(warnings.length > 0, "Expected warning for 0.12.99 < 0.13.0");
+  } finally {
+    console.warn = origWarn;
+  }
+});
+
+Deno.test("warnIfOldVersion: higher minor version is not flagged", () => {
+  // 0.14.0 > 0.13.0
+  const warnings: string[] = [];
+  const origWarn = console.warn;
+  console.warn = (...args: unknown[]) => { warnings.push(args.join(" ")); };
+  try {
+    warnIfOldVersion("signal-cli 0.14.0");
+    assertEquals(warnings.length, 0, "Expected no warning for 0.14.0 > 0.13.0");
+  } finally {
+    console.warn = origWarn;
+  }
+});
+
+// ─── SIGNAL_CLI_KNOWN_GOOD_VERSION constant ───────────────────────────────────
+
+Deno.test("SIGNAL_CLI_KNOWN_GOOD_VERSION is a valid semver string", () => {
+  const parts = SIGNAL_CLI_KNOWN_GOOD_VERSION.split(".");
+  assertEquals(parts.length, 3, "Known-good version should have 3 components");
+  for (const part of parts) {
+    assert(!isNaN(Number(part)), `Each component should be numeric, got: ${part}`);
+  }
+});


### PR DESCRIPTION
Implements all 8 reliability improvements from issue #55:

- Track daemon child + graceful SIGTERM shutdown
- Reconnection loop in client with exponential backoff
- Retry JSON-RPC ping up to 5x on connect
- Pin known-good version constant + warn if older
- Progressive stderr (earlyStderr in 5s, full on process end)
- Unix socket auto-start support
- isDaemonHealthy() to detect broken zombie processes
- Log signal-cli version at startup

Closes #55

Generated with [Claude Code](https://claude.ai/code)