### PR TITLE
feat: context length progress bar in CLI and Tidepool

### DIFF
--- a/src/agent/orchestrator.ts
+++ b/src/agent/orchestrator.ts
@@ -213,6 +213,11 @@ export interface Orchestrator {
   clearHistory(sessionId: SessionId): void;
   /** Force LLM-based summarization of a session's history. */
   compactHistory(sessionId: SessionId): Promise<CompactResult>;
+  /**
+   * Get current context window usage for a session.
+   * Returns token counts suitable for emitting a `context_usage` event.
+   */
+  getContextUsage(sessionId: SessionId): { current: number; max: number; compactAt: number };
 }
 
 /** Events emitted by the orchestrator during message processing. */
@@ -988,5 +993,13 @@ export function createOrchestrator(config: OrchestratorConfig): Orchestrator {
     return { messagesBefore, messagesAfter: history.length, tokensBefore, tokensAfter };
   }
 
-  return { processMessage, getHistory, clearHistory, compactHistory };
+  function getContextUsage(sessionId: SessionId): { current: number; max: number; compactAt: number } {
+    const history = histories.get(sessionId as string) ?? [];
+    const current = compactor.getTokenEstimate(history);
+    const max = effectiveBudget;
+    const compactAt = Math.floor(max * 0.7);
+    return { current, max, compactAt };
+  }
+
+  return { processMessage, getHistory, clearHistory, compactHistory, getContextUsage };
 }

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -4364,6 +4364,12 @@ async function runChat(): Promise<void> {
         return;
       }
 
+      if (evt.type === "context_usage") {
+        screen.setContextUsage(evt.current, evt.max, evt.compactAt);
+        if (isTty) screen.redrawInput(editor);
+        return;
+      }
+
       if (evt.type === "response_chunk") {
         eventHandler(evt as OrchestratorEvent);
         if (isTty) screen.redrawInput(editor);

--- a/src/cli/screen.ts
+++ b/src/cli/screen.ts
@@ -50,6 +50,39 @@ const GREEN = "\x1b[32m";
 const YELLOW = "\x1b[33m";
 const RED = "\x1b[31m";
 const ORANGE = "\x1b[38;5;208m";
+const WHITE = "\x1b[37m";
+const BLUE = "\x1b[34m";
+
+/**
+ * Build context bar segment counts for a given token state.
+ *
+ * Pure function exported for unit testing. Returns the number of filled,
+ * overflow, and empty characters, plus the compact marker position —
+ * all in bar-character units, not pixels.
+ *
+ * @param current - Current token count
+ * @param max - Full context window in tokens
+ * @param compactAt - Token threshold for auto-compact
+ * @param barWidth - Width of the bar in characters (default 20)
+ */
+export function buildContextBarSegments(
+  current: number,
+  max: number,
+  compactAt: number,
+  barWidth = 20,
+): { readonly filled: number; readonly overflow: number; readonly empty: number; readonly markerPos: number } {
+  if (max === 0) {
+    return { filled: 0, overflow: 0, empty: barWidth, markerPos: 0 };
+  }
+  const markerPos = Math.round(Math.min(compactAt, max) / max * barWidth);
+  const filledEnd = Math.round(Math.min(current, compactAt) / max * barWidth);
+  const filled = filledEnd;
+  const overflow = current > compactAt
+    ? Math.round(Math.min((current - compactAt) / max * barWidth, barWidth - filled))
+    : 0;
+  const empty = Math.max(barWidth - filled - overflow, 0);
+  return { filled, overflow, empty, markerPos };
+}
 
 /** ANSI color code for a classification level. */
 export function taintColor(level: ClassificationLevel): string {
@@ -105,6 +138,13 @@ export interface ScreenManager {
    * @param configured - Total number of configured (non-disabled) MCP servers
    */
   setMcpStatus(connected: number, configured: number): void;
+  /**
+   * Update the context usage progress bar in the bottom separator.
+   * @param current - Current estimated token count (history only)
+   * @param max - Full model context window in tokens
+   * @param compactAt - Token threshold at which auto-compact fires
+   */
+  setContextUsage(current: number, max: number, compactAt: number): void;
   /** Handle terminal resize. */
   handleResize(): void;
   /**
@@ -191,6 +231,10 @@ function createTtyScreenManager(): ScreenManager {
   // MCP server connection indicator
   let mcpConnected = -1; // -1 = not configured (hidden)
   let mcpConfigured = 0;
+  // Context usage progress bar (0 = hidden until first update)
+  let ctxCurrent = 0;
+  let ctxMax = 0;
+  let ctxCompactAt = 0;
 
   // Track the last known cursor position so we never rely on
   // the terminal's single-slot SAVE_CURSOR / RESTORE_CURSOR,
@@ -294,8 +338,34 @@ function createTtyScreenManager(): ScreenManager {
       rawWrite(`${DIM}${editor.suggestion}${RESET}`);
     }
 
-    // ── Bottom separator with taint label inline and optional MCP indicator ──
+    // ── Bottom separator with taint label, optional context bar, and optional MCP indicator ──
     const label = currentTaint;
+    // Build optional context usage progress bar (center region)
+    let ctxBarStr = "";
+    let ctxBarVisLen = 0;
+    if (ctxMax > 0) {
+      const BAR_WIDTH = 20;
+      const filled = Math.round(Math.min(ctxCurrent, ctxCompactAt) / ctxMax * BAR_WIDTH);
+      const overflow = ctxCurrent > ctxCompactAt
+        ? Math.round(Math.min((ctxCurrent - ctxCompactAt) / ctxMax * BAR_WIDTH, BAR_WIDTH - filled))
+        : 0;
+      const markerPos = Math.round(ctxCompactAt / ctxMax * BAR_WIDTH);
+      // Build bar character by character
+      let bar = "";
+      for (let i = 0; i < BAR_WIDTH; i++) {
+        if (i < filled) {
+          bar += `${WHITE}█`;
+        } else if (i === markerPos && overflow === 0) {
+          bar += `${BLUE}│`;
+        } else if (i < filled + overflow && overflow > 0) {
+          bar += `${RED}█`;
+        } else {
+          bar += `${DIM}░`;
+        }
+      }
+      ctxBarStr = ` ${bar}${RESET}`;
+      ctxBarVisLen = 1 + BAR_WIDTH; // " " + bar chars
+    }
     // Build optional MCP status indicator (right side)
     let mcpColor = "";
     let mcpText = "";
@@ -309,17 +379,17 @@ function createTtyScreenManager(): ScreenManager {
       }
       mcpText = `MCP ${mcpConnected}/${mcpConfigured}`;
     }
-    // "── LABEL ──────... [MCP x/y] ──" layout
+    // "── LABEL [bar] ────... [MCP x/y] ──" layout
     const rightSuffix = mcpText
       ? ` ${mcpColor}${BOLD}${mcpText}${RESET}${color} ─`
       : "";
     // Visible length of rightSuffix (strip ANSI codes for length calc)
     const rightVisLen = mcpText ? 1 + mcpText.length + 2 : 0; // " " + text + " ─"
-    const fillLen = Math.max(size.columns - 3 - label.length - 1 - rightVisLen, 1);
+    const fillLen = Math.max(size.columns - 3 - label.length - 1 - ctxBarVisLen - rightVisLen, 1);
     rawWrite(moveTo(bottomSepRow, 1));
     rawWrite(CLEAR_LINE);
     rawWrite(
-      `${color}${"─".repeat(2)} ${BOLD}${label}${RESET}${color} ${"─".repeat(fillLen)}${rightSuffix}${RESET}`,
+      `${color}${"─".repeat(2)} ${BOLD}${label}${RESET}${color}${ctxBarStr}${color} ${"─".repeat(fillLen)}${rightSuffix}${RESET}`,
     );
 
     // Calculate cursor position accounting for line wrapping
@@ -463,6 +533,13 @@ function createTtyScreenManager(): ScreenManager {
       mcpConfigured = configured;
       // Redraw will happen on the next input redraw; no immediate redraw needed
       // (avoids cursor flicker when not actively typing)
+    },
+
+    setContextUsage(current: number, max: number, compactAt: number): void {
+      ctxCurrent = current;
+      ctxMax = max;
+      ctxCompactAt = compactAt;
+      // Redraw will happen on the next input redraw; no immediate redraw needed
     },
 
     setStatus(text: string): void {
@@ -610,6 +687,10 @@ function createDumbScreenManager(): ScreenManager {
 
     setMcpStatus(_connected: number, _configured: number): void {
       // No MCP status indicator in dumb mode
+    },
+
+    setContextUsage(_current: number, _max: number, _compactAt: number): void {
+      // No context bar in dumb mode
     },
 
     setStatus(_text: string): void {

--- a/src/gateway/chat.ts
+++ b/src/gateway/chat.ts
@@ -18,6 +18,7 @@
 
 import { createLogger } from "../core/logger/mod.ts";
 import { createOrchestrator } from "../agent/orchestrator.ts";
+import type { Orchestrator } from "../agent/orchestrator.ts";
 import type {
   OrchestratorEvent,
   OrchestratorEventCallback,
@@ -90,6 +91,19 @@ export type ChatEvent =
     readonly connected: number;
     /** Total number of configured (non-disabled) MCP servers. */
     readonly configured: number;
+  }
+  | {
+    /**
+     * Server → client: current context window usage.
+     * Sent on `connected`, after `llm_complete`, and after `compact_complete`.
+     */
+    readonly type: "context_usage";
+    /** Current estimated input tokens (conversation history only). */
+    readonly current: number;
+    /** Full model context window in tokens. */
+    readonly max: number;
+    /** Token threshold at which auto-compact fires (~70% of max). */
+    readonly compactAt: number;
   }
   | {
     /**
@@ -292,6 +306,11 @@ export interface ChatSession {
    */
   getMcpStatus?: () => { readonly connected: number; readonly configured: number } | null;
   /**
+   * Get current context window usage for the owner session.
+   * Used to send an initial `context_usage` event on new client connections.
+   */
+  getContextUsage?: () => { readonly current: number; readonly max: number; readonly compactAt: number };
+  /**
    * Update the stored MCP server connection status.
    * Called by the daemon when MCP connection state changes.
    */
@@ -401,9 +420,18 @@ export function createChatSession(config: ChatSessionConfig): ChatSession {
     }
   }
 
+  // Mutable ref: set after orchestrator is created to allow `onEvent` to call back.
+  let orchestratorRef: Orchestrator | null = null;
+
   const onEvent: OrchestratorEventCallback = (event: OrchestratorEvent) => {
     if (activeSend) {
       activeSend(event as ChatEvent);
+      // After each LLM turn completes, emit current context usage so clients
+      // can update their progress bars.
+      if (event.type === "llm_complete" && orchestratorRef) {
+        const usage = orchestratorRef.getContextUsage(getSession().id);
+        activeSend({ type: "context_usage", ...usage });
+      }
     }
   };
 
@@ -432,6 +460,7 @@ export function createChatSession(config: ChatSessionConfig): ChatSession {
     toolFloorRegistry: config.toolFloorRegistry,
     secretStore: config.secretStore,
   });
+  orchestratorRef = orchestrator;
 
   const initialSession = config.session;
   function getSession(): SessionState {
@@ -633,6 +662,9 @@ export function createChatSession(config: ChatSessionConfig): ChatSession {
         tokensBefore: result.tokensBefore,
         tokensAfter: result.tokensAfter,
       });
+      // Emit updated context usage after compaction
+      const usage = orchestrator.getContextUsage(getSession().id);
+      sendEvent({ type: "context_usage", ...usage });
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
       sendEvent({ type: "error", message: `Compact failed: ${msg}` });
@@ -681,6 +713,9 @@ export function createChatSession(config: ChatSessionConfig): ChatSession {
     setMcpStatus(connected: number, configured: number): void {
       mcpStatusConnected = connected;
       mcpStatusConfigured = configured;
+    },
+    getContextUsage(): { current: number; max: number; compactAt: number } {
+      return orchestrator.getContextUsage(getSession().id);
     },
     get providerName() {
       return providerName;

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -264,6 +264,14 @@ function handleChatWebSocket(
         }
       }
     }
+    // Send initial context usage
+    if (chat.getContextUsage) {
+      try {
+        socket.send(JSON.stringify({ type: "context_usage", ...chat.getContextUsage() }));
+      } catch {
+        // Client may have disconnected
+      }
+    }
   });
 
   socket.addEventListener("message", (event: MessageEvent) => {

--- a/src/tidepool/host.ts
+++ b/src/tidepool/host.ts
@@ -185,6 +185,14 @@ export function createA2UIHost(options?: A2UIHostOptions): A2UIHost {
                   // Client may have disconnected
                 }
               }
+              // Send initial context usage
+              if (chatSession && chatSession.getContextUsage) {
+                try {
+                  socket.send(JSON.stringify({ type: "context_usage", ...chatSession.getContextUsage() }));
+                } catch {
+                  // Client may have disconnected
+                }
+              }
             });
 
             socket.addEventListener("message", (event: MessageEvent) => {

--- a/src/tidepool/tmpl_chat.html
+++ b/src/tidepool/tmpl_chat.html
@@ -4,6 +4,14 @@
     <span>Triggerfish Tidepool</span>
     <span class="provider" id="provider-info"></span>
     <span class="mcp-status" id="mcp-status" style="display:none"></span>
+    <div id="context-bar" style="display:none">
+      <div id="context-bar-track">
+        <div id="context-bar-fill"></div>
+        <div id="context-bar-overflow"></div>
+        <div id="context-bar-marker"></div>
+      </div>
+      <span id="context-bar-label"></span>
+    </div>
     <span class="taint-badge public" id="taint-badge">PUBLIC</span>
   </div>
 

--- a/src/tidepool/tmpl_chat_script.html
+++ b/src/tidepool/tmpl_chat_script.html
@@ -148,6 +148,31 @@
         }
         break;
 
+      case "context_usage": {
+        var ctxBarEl = document.getElementById("context-bar");
+        var ctxFillEl = document.getElementById("context-bar-fill");
+        var ctxOverflowEl = document.getElementById("context-bar-overflow");
+        var ctxMarkerEl = document.getElementById("context-bar-marker");
+        var ctxLabelEl = document.getElementById("context-bar-label");
+        if (!ctxBarEl || !ctxFillEl || !ctxOverflowEl || !ctxMarkerEl || !ctxLabelEl) break;
+        if (evt.max === 0) { ctxBarEl.style.display = "none"; break; }
+        ctxBarEl.style.display = "flex";
+        var ctxPct = Math.min(evt.current / evt.max * 100, 100);
+        var compactPct = Math.min(evt.compactAt / evt.max * 100, 100);
+        if (evt.current <= evt.compactAt) {
+          ctxFillEl.style.width = ctxPct + "%";
+          ctxOverflowEl.style.display = "none";
+        } else {
+          ctxFillEl.style.width = compactPct + "%";
+          ctxOverflowEl.style.left = compactPct + "%";
+          ctxOverflowEl.style.width = (ctxPct - compactPct) + "%";
+          ctxOverflowEl.style.display = "";
+        }
+        ctxMarkerEl.style.left = compactPct + "%";
+        var fmtK = function(n) { return n >= 1000 ? Math.round(n / 1000) + "k" : String(n); };
+        ctxLabelEl.textContent = fmtK(evt.current) + " / " + fmtK(evt.max);
+        break;
+      }
       case "mcp_status": {
         var mcpEl = document.getElementById("mcp-status");
         if (!mcpEl) break;

--- a/src/tidepool/tmpl_styles.html
+++ b/src/tidepool/tmpl_styles.html
@@ -42,6 +42,14 @@
   .taint-badge.confidential { background: var(--orange); color: #1a1b26; }
   .taint-badge.restricted { background: var(--red); color: #1a1b26; }
 
+  /* Context usage progress bar */
+  #context-bar { display: flex; align-items: center; gap: 6px; flex: 1; max-width: 200px; }
+  #context-bar-track { position: relative; height: 6px; flex: 1; background: var(--bg3); border-radius: 3px; overflow: visible; }
+  #context-bar-fill { position: absolute; left: 0; top: 0; bottom: 0; background: #fff; border-radius: 3px 0 0 3px; transition: width 0.3s ease; }
+  #context-bar-overflow { position: absolute; top: 0; bottom: 0; background: var(--red); transition: left 0.3s ease, width 0.3s ease; }
+  #context-bar-marker { position: absolute; top: -2px; bottom: -2px; width: 2px; background: var(--accent); }
+  #context-bar-label { font-size: 10px; color: var(--fg3); white-space: nowrap; }
+
   /* Messages */
   #messages { flex: 1; overflow-y: auto; padding: 16px; display: flex; flex-direction: column; gap: 12px; }
   .msg { max-width: 85%; padding: 10px 14px; border-radius: 8px; line-height: 1.5; word-wrap: break-word; }

--- a/tests/cli/context_bar_test.ts
+++ b/tests/cli/context_bar_test.ts
@@ -1,0 +1,96 @@
+/**
+ * Unit tests for the CLI context usage progress bar logic.
+ *
+ * Tests the pure `buildContextBarSegments` helper that drives the visual
+ * bar rendered in the bottom separator line.
+ *
+ * @module
+ */
+
+import { assertEquals } from "@std/assert";
+import { buildContextBarSegments } from "../../src/cli/screen.ts";
+
+// ─── Empty / zero state ─────────────────────────────────────────
+
+Deno.test("buildContextBarSegments: returns all-empty when max=0", () => {
+  const seg = buildContextBarSegments(0, 0, 0);
+  assertEquals(seg.filled, 0);
+  assertEquals(seg.overflow, 0);
+  assertEquals(seg.empty, 20);
+  assertEquals(seg.markerPos, 0);
+});
+
+Deno.test("buildContextBarSegments: returns all-empty when current=0", () => {
+  const seg = buildContextBarSegments(0, 100_000, 70_000);
+  assertEquals(seg.filled, 0);
+  assertEquals(seg.overflow, 0);
+  assertEquals(seg.empty, 20);
+});
+
+// ─── Normal fill (below compact threshold) ──────────────────────
+
+Deno.test("buildContextBarSegments: 50% fill has no overflow", () => {
+  const seg = buildContextBarSegments(50_000, 100_000, 70_000);
+  assertEquals(seg.overflow, 0);
+  assertEquals(seg.filled, 10); // 50% of 20 = 10
+  assertEquals(seg.empty, 10);
+});
+
+Deno.test("buildContextBarSegments: exactly at compact threshold (70%)", () => {
+  const seg = buildContextBarSegments(70_000, 100_000, 70_000);
+  assertEquals(seg.overflow, 0);
+  assertEquals(seg.filled, 14); // 70% of 20 = 14
+  assertEquals(seg.empty, 6);
+  assertEquals(seg.markerPos, 14); // marker at 70%
+});
+
+// ─── Overflow (past compact threshold) ──────────────────────────
+
+Deno.test("buildContextBarSegments: 85% fill has overflow beyond marker", () => {
+  const seg = buildContextBarSegments(85_000, 100_000, 70_000);
+  assertEquals(seg.filled, 14); // up to compact threshold (70%)
+  // overflow = (85% - 70%) of 20 = 3
+  assertEquals(seg.overflow, 3);
+  assertEquals(seg.empty > 0, true);
+});
+
+Deno.test("buildContextBarSegments: at 100% clamps correctly", () => {
+  const seg = buildContextBarSegments(100_000, 100_000, 70_000);
+  assertEquals(seg.filled, 14); // up to compact threshold
+  assertEquals(seg.filled + seg.overflow, 20); // bar completely full
+  assertEquals(seg.empty, 0);
+});
+
+// ─── Marker position ────────────────────────────────────────────
+
+Deno.test("buildContextBarSegments: marker at correct position for 70% threshold", () => {
+  const seg = buildContextBarSegments(0, 200_000, 140_000); // 70% of 200k
+  assertEquals(seg.markerPos, 14); // 70% of 20 = 14
+});
+
+Deno.test("buildContextBarSegments: custom bar width scales correctly", () => {
+  const seg = buildContextBarSegments(50_000, 100_000, 70_000, 10);
+  assertEquals(seg.filled, 5); // 50% of 10
+  assertEquals(seg.markerPos, 7); // 70% of 10 = 7
+});
+
+// ─── Total always equals barWidth ───────────────────────────────
+
+Deno.test("buildContextBarSegments: filled+overflow+empty always equals barWidth", () => {
+  const cases: [number, number, number][] = [
+    [0, 100_000, 70_000],
+    [35_000, 100_000, 70_000],
+    [70_000, 100_000, 70_000],
+    [85_000, 100_000, 70_000],
+    [100_000, 100_000, 70_000],
+    [120_000, 100_000, 70_000], // over max → should clamp
+  ];
+  for (const [current, max, compactAt] of cases) {
+    const seg = buildContextBarSegments(current, max, compactAt);
+    assertEquals(
+      seg.filled + seg.overflow + seg.empty,
+      20,
+      `total must equal barWidth for current=${current}`,
+    );
+  }
+});

--- a/tests/gateway/context_usage_event_test.ts
+++ b/tests/gateway/context_usage_event_test.ts
@@ -1,0 +1,189 @@
+/**
+ * Tests for context_usage event emission.
+ *
+ * Verifies that the orchestrator's getContextUsage() returns sensible values
+ * and that createChatSession exposes getContextUsage().
+ *
+ * @module
+ */
+
+import { assertEquals, assertExists, assert } from "@std/assert";
+import { createOrchestrator } from "../../src/agent/orchestrator.ts";
+import { createChatSession } from "../../src/gateway/chat.ts";
+import { createProviderRegistry } from "../../src/agent/llm.ts";
+import type { LlmProvider } from "../../src/agent/llm.ts";
+import { createPolicyEngine } from "../../src/core/policy/engine.ts";
+import { createHookRunner, createDefaultRules } from "../../src/core/policy/hooks.ts";
+import { createSession } from "../../src/core/types/session.ts";
+import type { UserId, ChannelId } from "../../src/core/types/session.ts";
+import type { ChatEvent } from "../../src/gateway/chat.ts";
+
+// ─── Helpers ────────────────────────────────────────────────────
+
+function createMockProvider(response = "mock response"): LlmProvider {
+  return {
+    name: "mock",
+    supportsStreaming: false,
+    // deno-lint-ignore require-await
+    async complete(_messages, _tools, _options) {
+      return {
+        content: response,
+        toolCalls: [],
+        usage: { inputTokens: 10, outputTokens: 5 },
+      };
+    },
+  };
+}
+
+function makeHookRunner() {
+  const engine = createPolicyEngine();
+  for (const r of createDefaultRules()) engine.addRule(r);
+  return createHookRunner(engine);
+}
+
+function makeSession() {
+  return createSession({
+    userId: "u1" as UserId,
+    channelId: "cli" as ChannelId,
+  });
+}
+
+// ─── Orchestrator.getContextUsage() ─────────────────────────────
+
+Deno.test("Orchestrator.getContextUsage: returns zeros for empty history", () => {
+  const registry = createProviderRegistry();
+  registry.register(createMockProvider());
+  registry.setDefault("mock");
+
+  const orch = createOrchestrator({
+    hookRunner: makeHookRunner(),
+    providerRegistry: registry,
+    compactorConfig: { contextBudget: 100_000 },
+  });
+
+  const session = makeSession();
+  const usage = orch.getContextUsage(session.id);
+  assertEquals(usage.current, 0);
+  assertEquals(usage.max, 100_000);
+  assertEquals(usage.compactAt, 70_000);
+});
+
+Deno.test("Orchestrator.getContextUsage: compactAt is 70% of max", () => {
+  const registry = createProviderRegistry();
+  registry.register(createMockProvider());
+  registry.setDefault("mock");
+
+  const orch = createOrchestrator({
+    hookRunner: makeHookRunner(),
+    providerRegistry: registry,
+    compactorConfig: { contextBudget: 200_000 },
+  });
+
+  const session = makeSession();
+  const usage = orch.getContextUsage(session.id);
+  assertEquals(usage.max, 200_000);
+  assertEquals(usage.compactAt, 140_000); // 70% of 200k
+});
+
+Deno.test("Orchestrator.getContextUsage: current increases after processMessage", async () => {
+  const registry = createProviderRegistry();
+  registry.register(createMockProvider("Hello!"));
+  registry.setDefault("mock");
+
+  const orch = createOrchestrator({
+    hookRunner: makeHookRunner(),
+    providerRegistry: registry,
+    compactorConfig: { contextBudget: 100_000 },
+  });
+
+  const session = makeSession();
+  const before = orch.getContextUsage(session.id);
+  assertEquals(before.current, 0);
+
+  await orch.processMessage({
+    session,
+    message: "What is 2+2?",
+    targetClassification: "PUBLIC",
+  });
+
+  const after = orch.getContextUsage(session.id);
+  assert(after.current > 0, "current tokens must be > 0 after processing a message");
+});
+
+// ─── ChatSession.getContextUsage() ──────────────────────────────
+
+Deno.test("ChatSession: exposes getContextUsage()", () => {
+  const registry = createProviderRegistry();
+  registry.register(createMockProvider());
+  registry.setDefault("mock");
+
+  const session = makeSession();
+  const chatSession = createChatSession({
+    hookRunner: makeHookRunner(),
+    providerRegistry: registry,
+    session,
+    compactorConfig: { contextBudget: 100_000 },
+  });
+
+  assertExists(chatSession.getContextUsage);
+  const usage = chatSession.getContextUsage!();
+  assertEquals(usage.current, 0);
+  assertEquals(usage.max, 100_000);
+  assertEquals(usage.compactAt, 70_000);
+});
+
+// ─── context_usage emitted after llm_complete ───────────────────
+
+Deno.test("ChatSession: emits context_usage event after llm_complete", async () => {
+  const registry = createProviderRegistry();
+  registry.register(createMockProvider("Hello!"));
+  registry.setDefault("mock");
+
+  const session = makeSession();
+  const chatSession = createChatSession({
+    hookRunner: makeHookRunner(),
+    providerRegistry: registry,
+    session,
+    compactorConfig: { contextBudget: 100_000 },
+  });
+
+  const events: ChatEvent[] = [];
+  await chatSession.processMessage(
+    "Hi there",
+    (evt) => events.push(evt),
+  );
+
+  const contextUsageEvents = events.filter((e) => e.type === "context_usage");
+  assert(contextUsageEvents.length > 0, "must emit at least one context_usage event");
+
+  const lastUsage = contextUsageEvents[contextUsageEvents.length - 1];
+  if (lastUsage.type !== "context_usage") throw new Error("wrong type");
+  assert(lastUsage.current >= 0);
+  assertEquals(lastUsage.max, 100_000);
+  assertEquals(lastUsage.compactAt, 70_000);
+});
+
+// ─── context_usage emitted after compact ────────────────────────
+
+Deno.test("ChatSession: emits context_usage event after compact", async () => {
+  const registry = createProviderRegistry();
+  registry.register(createMockProvider("Hello!"));
+  registry.setDefault("mock");
+
+  const session = makeSession();
+  const chatSession = createChatSession({
+    hookRunner: makeHookRunner(),
+    providerRegistry: registry,
+    session,
+    compactorConfig: { contextBudget: 100_000 },
+  });
+
+  // Send a message first to populate history
+  await chatSession.processMessage("Hi there", () => {});
+
+  const events: ChatEvent[] = [];
+  await chatSession.compact((evt) => events.push(evt));
+
+  const contextUsageEvents = events.filter((e) => e.type === "context_usage");
+  assert(contextUsageEvents.length > 0, "must emit context_usage after compact");
+});


### PR DESCRIPTION
Implements a real-time context window usage progress bar in both the CLI bottom separator and the Tidepool status header.

Closes #61

Generated with [Claude Code](https://claude.ai/code)