### PR TITLE
fix: account for system prompt tokens in compaction threshold

### DIFF
--- a/src/agent/compactor.ts
+++ b/src/agent/compactor.ts
@@ -44,8 +44,20 @@ export interface CompactResult {
 
 /** The compactor interface for managing conversation history size. */
 export interface Compactor {
-  /** Auto-compact history if tokens exceed threshold. Returns new history. */
-  compact(history: readonly HistoryEntry[]): readonly HistoryEntry[];
+  /**
+   * Auto-compact history if total context usage exceeds threshold.
+   *
+   * @param history - Conversation history entries
+   * @param overheadTokens - Tokens already consumed by system prompt, tool
+   *   definitions, and other fixed context outside the history. The compactor
+   *   adds this to the history token count before comparing against the budget,
+   *   ensuring compaction fires based on *total* context usage rather than
+   *   history tokens alone. Defaults to 0 (backward-compatible).
+   */
+  compact(
+    history: readonly HistoryEntry[],
+    overheadTokens?: number,
+  ): readonly HistoryEntry[];
   /** Force LLM-based summarization. Returns new history (single summary message). */
   summarize(
     history: readonly HistoryEntry[],
@@ -197,10 +209,11 @@ export function createCompactor(
 
   function compact(
     history: readonly HistoryEntry[],
+    overheadTokens = 0,
   ): readonly HistoryEntry[] {
     if (history.length === 0) return history;
 
-    const totalTokens = estimateHistoryTokens(history);
+    const totalTokens = estimateHistoryTokens(history) + overheadTokens;
     if (totalTokens <= autoTriggerThreshold) return history;
 
     // Need at least something to compact

--- a/src/agent/orchestrator.ts
+++ b/src/agent/orchestrator.ts
@@ -29,7 +29,7 @@ import type { DomainClassifier } from "../web/domains.ts";
 import type { SessionState, SessionId } from "../core/types/session.ts";
 import type { HookRunner } from "../core/policy/hooks.ts";
 import type { LlmProviderRegistry, LlmMessage, LlmProvider } from "./llm.ts";
-import { createCompactor, estimateHistoryTokens } from "./compactor.ts";
+import { createCompactor, estimateHistoryTokens, countTokens } from "./compactor.ts";
 import type { Compactor, CompactorConfig, CompactResult } from "./compactor.ts";
 import type { MessageContent, ImageContentBlock, ContentBlock } from "../image/content.ts";
 import { extractText, hasImages, normalizeContent } from "../image/content.ts";
@@ -657,8 +657,11 @@ export function createOrchestrator(config: OrchestratorConfig): Orchestrator {
         "Do NOT use image_analyze or any other tool to re-examine these images — the descriptions are already complete.";
     }
 
-    // Auto-compact history if approaching context limits
-    const compacted = compactor.compact(history);
+    // Auto-compact history if approaching context limits.
+    // Pass system prompt token count as overhead so the compactor measures
+    // total context usage (system + history), not just history tokens alone.
+    const systemPromptTokens = countTokens(systemPrompt);
+    const compacted = compactor.compact(history, systemPromptTokens);
     if (compacted.length < history.length) {
       history.length = 0;
       history.push(...compacted);

--- a/tests/agent/compactor_test.ts
+++ b/tests/agent/compactor_test.ts
@@ -278,6 +278,56 @@ Deno.test("updateBudget changes the compaction threshold", () => {
   assertEquals(compacted.length, 1);
 });
 
+// ─── Overhead token accounting ──────────────────────────────────
+
+Deno.test("compact fires when overhead + history exceeds threshold", () => {
+  // History is well under 70% of the budget on its own, but when the
+  // system-prompt overhead is included the total exceeds the threshold.
+  const history: HistoryEntry[] = [];
+  // ~10 tokens per pair × 3 pairs = ~30 history tokens
+  for (let i = 0; i < 3; i++) {
+    history.push({ role: "user", content: `Hi ${i}` });
+    history.push({ role: "assistant", content: `Hello ${i}` });
+  }
+
+  // Budget of 100. Auto-trigger = 70.
+  // History alone ≈ 30 tokens (well under 70).
+  // Pass 60 as overhead — total ≈ 90 > 70, compaction must fire.
+  const compactor = createCompactor({ contextBudget: 100 });
+  const result = compactor.compact(history, 60);
+
+  assertEquals(result.length, 1);
+  assertEquals((result[0].content as string).startsWith("[Conversation context:"), true);
+});
+
+Deno.test("compact does NOT fire when overhead + history is under threshold", () => {
+  const history: HistoryEntry[] = [
+    { role: "user", content: "Hello" },
+    { role: "assistant", content: "Hi!" },
+    { role: "user", content: "How are you?" },
+    { role: "assistant", content: "I'm fine." },
+  ];
+
+  // Huge budget — even with 50-token overhead, total is well under 70% of 10 000
+  const compactor = createCompactor({ contextBudget: 10_000 });
+  const result = compactor.compact(history, 50);
+  assertEquals(result, history);
+});
+
+Deno.test("compact with zero overhead behaves identically to no argument", () => {
+  const history: HistoryEntry[] = [];
+  for (let i = 0; i < 20; i++) {
+    history.push({ role: "user", content: `Message ${i}: ${"x".repeat(100)}` });
+    history.push({ role: "assistant", content: `Response ${i}: ${"y".repeat(100)}` });
+  }
+
+  const compactor = createCompactor({ contextBudget: 200 });
+  const withZero = compactor.compact(history, 0);
+  const withNoArg = compactor.compact(history);
+  assertEquals(withZero.length, withNoArg.length);
+  assertEquals(withZero[0].content, withNoArg[0].content);
+});
+
 // ─── Keyword extraction ──────────────────────────────────────────
 
 Deno.test("compact summary includes topic keywords", () => {


### PR DESCRIPTION
Context compaction never fired because compact() only measured conversation history tokens, ignoring the system prompt. This fix passes the system prompt token count as overhead so compaction fires based on total context usage rather than history alone.

Closes #66

Generated with [Claude Code](https://claude.ai/code)