### PR TITLE
[Phase A3] fix: remove automation detection parameters from BrowserManager

### DIFF
--- a/src/browser/manager.ts
+++ b/src/browser/manager.ts
@@ -368,19 +368,80 @@ function drainStderr(
 // Launch strategies
 // ---------------------------------------------------------------------------
 
-/** Standard Chrome launch arguments shared by both strategies. */
-function baseChromeArgs(config: BrowserManagerConfig): string[] {
+/**
+ * Standard Chrome launch arguments shared by both strategies.
+ *
+ * Includes anti-automation-detection flags that prevent Chrome from
+ * advertising itself as WebDriver-controlled.
+ *
+ * @exported for testing
+ */
+export function baseChromeArgs(config: BrowserManagerConfig): string[] {
   return [
     "--no-first-run",
     "--disable-default-apps",
     "--disable-extensions",
     "--disable-sync",
     "--disable-background-networking",
+    // Remove Chrome's automation-mode advertising
+    "--disable-blink-features=AutomationControlled",
+    "--disable-infobars",
+    "--exclude-switches=enable-automation",
     ...(config.credentialAutofill === true
       ? []
       : ["--disable-save-password-bubble"]),
     ...(config.launchArgs ?? []),
   ];
+}
+
+/**
+ * Apply stealth patches to a puppeteer Page to suppress automation fingerprints.
+ *
+ * Patches applied on every new document (via `evaluateOnNewDocument`):
+ * 1. `navigator.webdriver` → `undefined` (eliminates the #1 CDP detection signal)
+ * 2. `window.chrome` → `{ runtime: {} }` if absent (matches real Chrome environment)
+ *
+ * Additionally, strips `"HeadlessChrome"` from the live user-agent string and
+ * re-injects the cleaned UA for subsequent navigations.
+ *
+ * Must be called immediately after the page is obtained, before any navigation.
+ *
+ * @exported for testing
+ */
+export async function applyStealthPatches(page: Page): Promise<void> {
+  // 1. Override navigator.webdriver — the #1 automation detection signal
+  await page.evaluateOnNewDocument(() => {
+    Object.defineProperty(navigator, "webdriver", { get: () => undefined });
+  });
+
+  // 2. Populate window.chrome so the environment looks like a real browser
+  await page.evaluateOnNewDocument(() => {
+    if (!("chrome" in window)) {
+      Object.defineProperty(window, "chrome", {
+        writable: true,
+        enumerable: true,
+        configurable: false,
+        value: { runtime: {} },
+      });
+    }
+  });
+
+  // 3. Strip "HeadlessChrome" token from the navigator.userAgent string.
+  //    Also re-override via evaluateOnNewDocument so navigations preserve the patch.
+  const ua = await page.evaluate(() => navigator.userAgent) as string;
+  const patchedUa = ua.replace(/HeadlessChrome\//g, "Chrome/");
+  if (patchedUa !== ua) {
+    await page.setUserAgent(patchedUa);
+    await page.evaluateOnNewDocument(
+      (cleanUa: string) => {
+        Object.defineProperty(navigator, "userAgent", {
+          get: () => cleanUa,
+          configurable: true,
+        });
+      },
+      patchedUa,
+    );
+  }
 }
 
 /** Launch Chrome via puppeteer.launch() for a direct binary, wrapped in a timeout. */
@@ -583,6 +644,7 @@ export function createBrowserManager(config: BrowserManagerConfig): BrowserManag
 
         const vp = config.viewport ?? DEFAULT_VIEWPORT;
         await page.setViewport({ width: vp.width, height: vp.height });
+        await applyStealthPatches(page);
 
         const instance: BrowserInstance = {
           agentId,
@@ -610,6 +672,7 @@ export function createBrowserManager(config: BrowserManagerConfig): BrowserManag
 
       const vp = config.viewport ?? DEFAULT_VIEWPORT;
       await page.setViewport({ width: vp.width, height: vp.height });
+      await applyStealthPatches(page);
 
       const instance: BrowserInstance = {
         agentId,

--- a/src/browser/mod.ts
+++ b/src/browser/mod.ts
@@ -15,6 +15,8 @@ export {
 } from "./domains.ts";
 
 export {
+  applyStealthPatches,
+  baseChromeArgs,
   createBrowserManager,
   type BrowserInstance,
   type BrowserManager,

--- a/tests/browser/manager_test.ts
+++ b/tests/browser/manager_test.ts
@@ -8,6 +8,8 @@
 
 import { assertEquals, assertRejects } from "@std/assert";
 import {
+  applyStealthPatches,
+  baseChromeArgs,
   detectChrome,
   findFreePort,
   pollCdpReady,
@@ -148,6 +150,73 @@ Deno.test("withTimeout: propagates original rejection", async () => {
     Error,
     "original error",
   );
+});
+
+// ---------------------------------------------------------------------------
+// baseChromeArgs — anti-automation-detection flags
+// ---------------------------------------------------------------------------
+
+Deno.test("baseChromeArgs: includes --disable-blink-features=AutomationControlled", () => {
+  const config = {
+    profileBaseDir: "/tmp/test",
+    domainPolicy: createDomainPolicy({ allowList: [], denyList: [], classifications: {} }),
+    storage: createMemoryStorage(),
+  };
+  const args = baseChromeArgs(config);
+  assertEquals(args.includes("--disable-blink-features=AutomationControlled"), true);
+});
+
+Deno.test("baseChromeArgs: includes --disable-infobars", () => {
+  const config = {
+    profileBaseDir: "/tmp/test",
+    domainPolicy: createDomainPolicy({ allowList: [], denyList: [], classifications: {} }),
+    storage: createMemoryStorage(),
+  };
+  const args = baseChromeArgs(config);
+  assertEquals(args.includes("--disable-infobars"), true);
+});
+
+Deno.test("baseChromeArgs: includes --exclude-switches=enable-automation", () => {
+  const config = {
+    profileBaseDir: "/tmp/test",
+    domainPolicy: createDomainPolicy({ allowList: [], denyList: [], classifications: {} }),
+    storage: createMemoryStorage(),
+  };
+  const args = baseChromeArgs(config);
+  assertEquals(args.includes("--exclude-switches=enable-automation"), true);
+});
+
+Deno.test("baseChromeArgs: retains base operational flags", () => {
+  const config = {
+    profileBaseDir: "/tmp/test",
+    domainPolicy: createDomainPolicy({ allowList: [], denyList: [], classifications: {} }),
+    storage: createMemoryStorage(),
+  };
+  const args = baseChromeArgs(config);
+  assertEquals(args.includes("--no-first-run"), true);
+  assertEquals(args.includes("--disable-extensions"), true);
+  assertEquals(args.includes("--disable-sync"), true);
+});
+
+Deno.test("baseChromeArgs: propagates extra launchArgs", () => {
+  const config = {
+    profileBaseDir: "/tmp/test",
+    domainPolicy: createDomainPolicy({ allowList: [], denyList: [], classifications: {} }),
+    storage: createMemoryStorage(),
+    launchArgs: ["--some-custom-flag"],
+  };
+  const args = baseChromeArgs(config);
+  assertEquals(args.includes("--some-custom-flag"), true);
+});
+
+// ---------------------------------------------------------------------------
+// applyStealthPatches — exported function presence
+// ---------------------------------------------------------------------------
+
+Deno.test("applyStealthPatches: is exported as an async function", () => {
+  assertEquals(typeof applyStealthPatches, "function");
+  // Calling it with a minimal mock-like object should return a Promise
+  // (we can't run a real browser in unit tests; integration tests cover this)
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #71

Removes obvious automation parameters from BrowserManager across all launch paths:

- Adds `--disable-blink-features=AutomationControlled`, `--disable-infobars`, `--exclude-switches=enable-automation` to `baseChromeArgs()`
- Adds `applyStealthPatches(page)`: overrides `navigator.webdriver`, patches `window.chrome`, strips HeadlessChrome from UA
- Applied to both flatpak and direct launch paths
- 6 new unit tests

Generated with [Claude Code](https://claude.ai/code)