### PR TITLE
[Phase A3] feat: add structured debug logging to browser module

### DIFF
--- a/src/browser/manager.ts
+++ b/src/browser/manager.ts
@@ -23,6 +23,9 @@ import {
   escalateWatermark,
   getWatermark,
 } from "./watermark.ts";
+import { createLogger } from "../core/logger/mod.ts";
+
+const log = createLogger("browser-manager");
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -513,6 +516,7 @@ async function launchDirect(
     const page = pages[0] ?? await browser.newPage();
     return { ok: true, value: { browser, page } };
   } catch (err) {
+    log.error("browser launch exception", (err as Error).message);
     return { ok: false, error: `Browser launch failed: ${(err as Error).message}` };
   }
 }
@@ -558,6 +562,7 @@ async function launchFlatpak(
     });
     proc = cmd.spawn();
   } catch (err) {
+    log.error("flatpak spawn exception", (err as Error).message);
     return { ok: false, error: `Failed to spawn flatpak: ${(err as Error).message}` };
   }
 
@@ -583,6 +588,7 @@ async function launchFlatpak(
 
     return { ok: true, value: { browser, page, process: proc, port } };
   } catch (err) {
+    log.error("puppeteer connect exception", (err as Error).message);
     await killChromeProcess(proc);
     return { ok: false, error: `puppeteer.connect() failed: ${(err as Error).message}` };
   }
@@ -613,6 +619,8 @@ export function createBrowserManager(config: BrowserManagerConfig): BrowserManag
       agentId: string,
       sessionTaint: ClassificationLevel,
     ): Promise<Result<BrowserInstance, string>> {
+      log.debug("browser launch start", { agentId, sessionTaint });
+
       // Check watermark access
       const currentWatermark = await getWatermark(config.storage, agentId);
       if (
@@ -683,6 +691,7 @@ export function createBrowserManager(config: BrowserManagerConfig): BrowserManag
       // Branch on launch strategy
       if (detection.kind === "flatpak") {
         const result = await launchFlatpak(config, detection, profilePath, timeoutMs);
+        log.debug("flatpak launch result", { ok: result.ok, error: result.ok ? undefined : result.error });
         if (!result.ok) return result;
 
         const { browser, page, process: proc, port } = result.value;
@@ -706,11 +715,13 @@ export function createBrowserManager(config: BrowserManagerConfig): BrowserManag
           debugPort: port,
         });
 
+        log.debug("browser launch success", { agentId, strategy: "flatpak", watermark });
         return { ok: true, value: instance };
       }
 
       // Direct launch
       const result = await launchDirect(config, detection.target, profilePath, timeoutMs);
+      log.debug("direct launch result", { ok: result.ok, error: result.ok ? undefined : result.error });
       if (!result.ok) return result;
 
       const { browser, page } = result.value;
@@ -728,6 +739,7 @@ export function createBrowserManager(config: BrowserManagerConfig): BrowserManag
 
       instances.set(agentId, { browser, page, instance });
 
+      log.debug("browser launch success", { agentId, strategy: "direct", watermark });
       return { ok: true, value: instance };
     },
 

--- a/src/browser/tools.ts
+++ b/src/browser/tools.ts
@@ -16,6 +16,9 @@ import type { ToolDefinition } from "../agent/orchestrator.ts";
 import { resolveAndCheck } from "../web/domains.ts";
 import type { BrowserManager } from "./manager.ts";
 import type { LlmProvider } from "../agent/llm.ts";
+import { createLogger } from "../core/logger/mod.ts";
+
+const log = createLogger("browser-tools");
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -491,13 +494,20 @@ export function createBrowserToolExecutor(
     switch (name) {
       case "browser_navigate": {
         const url = input.url;
+        log.debug("browser_navigate", { inputKeys: Object.keys(input), urlType: typeof url, url: String(url) });
         if (typeof url !== "string" || url.trim().length === 0) {
+          log.warn("browser_navigate validation failed", "url is missing or not a non-empty string");
           return "Error: browser_navigate requires a non-empty 'url' argument.";
         }
         const result = await tools.navigate(url);
-        if (!result.ok) return `Navigation error: ${result.error}`;
+        if (!result.ok) {
+          log.warn("browser_navigate navigation error", result.error);
+          return `Navigation error: ${result.error}`;
+        }
         lastScreenshot = undefined;
-        return JSON.stringify(result.value);
+        const responseJson = JSON.stringify(result.value);
+        log.debug("browser_navigate success", { responseLength: responseJson.length });
+        return responseJson;
       }
 
       case "browser_snapshot": {


### PR DESCRIPTION
Add structured debug logging to `src/browser/manager.ts` and `src/browser/tools.ts` using `createLogger()` from the project logger module.

All launch milestones, exceptions, and navigate validation failures are now visible in daemon logs at `~/.triggerfish/logs/`.

Fixes #80

Generated with [Claude Code](https://claude.ai/code)