### PR TITLE
[Phase 20] feat: implement read_skill tool

### DIFF
--- a/src/skills/mod.ts
+++ b/src/skills/mod.ts
@@ -28,3 +28,6 @@ export type {
   SkillAuthor,
   SkillAuthorOptions,
 } from "./author.ts";
+
+export { createSkillToolExecutor, getSkillToolDefinitions } from "./tools.ts";
+export type { SkillToolContext, SkillType } from "./tools.ts";

--- a/src/skills/tools.ts
+++ b/src/skills/tools.ts
@@ -1,0 +1,140 @@
+/**
+ * Skill tools — LLM-callable operations for reading skills.
+ *
+ * Provides the `read_skill` tool which reads SKILL.md content from
+ * bundled or user-provided skills WITHOUT escalating session taint.
+ *
+ * Regular `read_file` triggers path-based classification and may escalate
+ * session taint. `read_skill` bypasses this by accessing skills through
+ * the skill loader abstraction, which is classification-neutral.
+ *
+ * @module
+ */
+
+import { join } from "@std/path";
+import type { ToolDefinition } from "../agent/orchestrator.ts";
+import type { SkillLoader } from "./loader.ts";
+
+/** Skill type argument accepted by read_skill. */
+export type SkillType = "BUNDLED" | "USER_PROVIDED";
+
+/** Context required by the skill tool executor. */
+export interface SkillToolContext {
+  /** Skill loader used to discover available skills. */
+  readonly skillLoader: SkillLoader;
+}
+
+/** Tool definitions for skill reading operations. */
+export function getSkillToolDefinitions(): readonly ToolDefinition[] {
+  return [
+    {
+      name: "read_skill",
+      description:
+        "Read the full content of a skill (SKILL.md) by type and name. " +
+        "Use this to learn what a skill does, how to activate it, and what " +
+        "tools it requires. Reading a skill never escalates the session " +
+        "security level — use this instead of read_file when you need to " +
+        "inspect skill instructions. " +
+        "type must be BUNDLED (skills shipped with Triggerfish) or " +
+        "USER_PROVIDED (skills installed or authored by the user).",
+      parameters: {
+        type: {
+          type: "string",
+          description: "Skill source type: BUNDLED or USER_PROVIDED",
+          required: true,
+          enum: ["BUNDLED", "USER_PROVIDED"],
+        },
+        skill_name: {
+          type: "string",
+          description:
+            "Name of the skill to read (e.g. 'weather', 'deep-research')",
+          required: true,
+        },
+      },
+    },
+  ];
+}
+
+/**
+ * Create a tool executor for skill reading operations.
+ *
+ * Returns null for unknown tool names (allowing chaining with other executors).
+ *
+ * Reading a skill does NOT escalate session taint. The executor deliberately
+ * takes no sessionTaint parameter — taint decisions belong in the orchestrator
+ * layer, not in this tool. Skills are capability metadata, not classified data.
+ *
+ * @param ctx - Context containing the skill loader
+ */
+export function createSkillToolExecutor(
+  ctx: SkillToolContext,
+): (name: string, input: Record<string, unknown>) => Promise<string | null> {
+  return async (
+    name: string,
+    input: Record<string, unknown>,
+  ): Promise<string | null> => {
+    if (name !== "read_skill") return null;
+
+    const type = input.type;
+    const skillName = input.skill_name;
+
+    if (
+      typeof type !== "string" ||
+      (type !== "BUNDLED" && type !== "USER_PROVIDED")
+    ) {
+      return "Error: read_skill requires 'type' to be BUNDLED or USER_PROVIDED.";
+    }
+
+    if (typeof skillName !== "string" || skillName.trim().length === 0) {
+      return "Error: read_skill requires a non-empty 'skill_name' argument.";
+    }
+
+    const trimmedName = skillName.trim();
+    const skills = await ctx.skillLoader.discover();
+
+    const matchesType = type === "BUNDLED"
+      ? (s: { source: string }) => s.source === "bundled"
+      : (s: { source: string }) =>
+        s.source === "managed" || s.source === "workspace";
+
+    const skill = skills.find(
+      (s) => s.name === trimmedName && matchesType(s),
+    );
+
+    if (!skill) {
+      const available = skills
+        .filter(matchesType)
+        .map((s) => s.name)
+        .sort()
+        .join(", ");
+      return JSON.stringify({
+        found: false,
+        skill_name: trimmedName,
+        type,
+        available: available || "(none)",
+      });
+    }
+
+    // Read the SKILL.md content from disk
+    const skillMdPath = join(skill.path, "SKILL.md");
+    let content: string;
+    try {
+      content = await Deno.readTextFile(skillMdPath);
+    } catch (err) {
+      return `Error: Failed to read skill "${trimmedName}": ${
+        err instanceof Error ? err.message : String(err)
+      }`;
+    }
+
+    return JSON.stringify({
+      found: true,
+      skill_name: skill.name,
+      type,
+      source: skill.source,
+      classification_ceiling: skill.classificationCeiling,
+      requires_tools: skill.requiresTools,
+      network_domains: skill.networkDomains,
+      content,
+    });
+  };
+}

--- a/tests/skills/tools_test.ts
+++ b/tests/skills/tools_test.ts
@@ -1,0 +1,194 @@
+/**
+ * Tests for read_skill tool.
+ *
+ * Verifies that read_skill reads skill content correctly for both BUNDLED
+ * and USER_PROVIDED types, returns appropriate errors for invalid input,
+ * and — crucially — does not escalate session taint.
+ */
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { createSkillLoader } from "../../src/skills/loader.ts";
+import {
+  createSkillToolExecutor,
+  getSkillToolDefinitions,
+} from "../../src/skills/tools.ts";
+
+const bundledDir = new URL("../../skills/bundled", import.meta.url).pathname;
+
+function makeBundledLoader() {
+  return createSkillLoader({
+    directories: [bundledDir],
+    dirTypes: { [bundledDir]: "bundled" },
+  });
+}
+
+Deno.test("getSkillToolDefinitions: returns read_skill definition", () => {
+  const defs = getSkillToolDefinitions();
+  assertEquals(defs.length, 1);
+  assertEquals(defs[0].name, "read_skill");
+  assertEquals(defs[0].parameters.type.enum, ["BUNDLED", "USER_PROVIDED"]);
+  assertEquals(defs[0].parameters.type.required, true);
+  assertEquals(defs[0].parameters.skill_name.required, true);
+});
+
+Deno.test("read_skill: returns null for unknown tool names", async () => {
+  const executor = createSkillToolExecutor({ skillLoader: makeBundledLoader() });
+  const result = await executor("some_other_tool", {
+    type: "BUNDLED",
+    skill_name: "weather",
+  });
+  assertEquals(result, null);
+});
+
+Deno.test("read_skill: reads a bundled skill successfully", async () => {
+  const executor = createSkillToolExecutor({ skillLoader: makeBundledLoader() });
+  const result = await executor("read_skill", {
+    type: "BUNDLED",
+    skill_name: "weather",
+  });
+
+  const parsed = JSON.parse(result!);
+  assertEquals(parsed.found, true);
+  assertEquals(parsed.skill_name, "weather");
+  assertEquals(parsed.type, "BUNDLED");
+  assertEquals(parsed.source, "bundled");
+  assertStringIncludes(parsed.content, "weather");
+  assertEquals(typeof parsed.classification_ceiling, "string");
+  assertEquals(Array.isArray(parsed.requires_tools), true);
+  assertEquals(Array.isArray(parsed.network_domains), true);
+});
+
+Deno.test("read_skill: not found returns available skill list", async () => {
+  const executor = createSkillToolExecutor({ skillLoader: makeBundledLoader() });
+  const result = await executor("read_skill", {
+    type: "BUNDLED",
+    skill_name: "nonexistent-skill",
+  });
+
+  const parsed = JSON.parse(result!);
+  assertEquals(parsed.found, false);
+  assertEquals(parsed.skill_name, "nonexistent-skill");
+  assertEquals(parsed.type, "BUNDLED");
+  assertStringIncludes(parsed.available, "weather");
+});
+
+Deno.test("read_skill: invalid type returns error message", async () => {
+  const executor = createSkillToolExecutor({ skillLoader: makeBundledLoader() });
+  const result = await executor("read_skill", {
+    type: "INVALID",
+    skill_name: "weather",
+  });
+  assertStringIncludes(result!, "Error:");
+  assertStringIncludes(result!, "BUNDLED");
+  assertStringIncludes(result!, "USER_PROVIDED");
+});
+
+Deno.test("read_skill: empty skill_name returns error message", async () => {
+  const executor = createSkillToolExecutor({ skillLoader: makeBundledLoader() });
+  const result = await executor("read_skill", {
+    type: "BUNDLED",
+    skill_name: "",
+  });
+  assertStringIncludes(result!, "Error:");
+  assertStringIncludes(result!, "skill_name");
+});
+
+Deno.test("read_skill: missing skill_name returns error message", async () => {
+  const executor = createSkillToolExecutor({ skillLoader: makeBundledLoader() });
+  const result = await executor("read_skill", { type: "BUNDLED" });
+  assertStringIncludes(result!, "Error:");
+  assertStringIncludes(result!, "skill_name");
+});
+
+Deno.test(
+  "read_skill: USER_PROVIDED returns not-found when only bundled skills loaded",
+  async () => {
+    const executor = createSkillToolExecutor({
+      skillLoader: makeBundledLoader(),
+    });
+    const result = await executor("read_skill", {
+      type: "USER_PROVIDED",
+      skill_name: "weather",
+    });
+
+    const parsed = JSON.parse(result!);
+    assertEquals(parsed.found, false);
+    assertEquals(parsed.type, "USER_PROVIDED");
+    // Bundled weather should not appear in USER_PROVIDED results
+    assertEquals(parsed.available, "(none)");
+  },
+);
+
+Deno.test("read_skill: USER_PROVIDED finds managed and workspace skills", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    await Deno.mkdir(`${tmpDir}/my-skill`);
+    await Deno.writeTextFile(
+      `${tmpDir}/my-skill/SKILL.md`,
+      `---
+name: my-skill
+description: A user-provided test skill
+classification_ceiling: INTERNAL
+---
+# My Skill
+Does something useful.
+`,
+    );
+
+    const loader = createSkillLoader({
+      directories: [tmpDir],
+      dirTypes: { [tmpDir]: "managed" },
+    });
+    const executor = createSkillToolExecutor({ skillLoader: loader });
+
+    const result = await executor("read_skill", {
+      type: "USER_PROVIDED",
+      skill_name: "my-skill",
+    });
+
+    const parsed = JSON.parse(result!);
+    assertEquals(parsed.found, true);
+    assertEquals(parsed.skill_name, "my-skill");
+    assertEquals(parsed.type, "USER_PROVIDED");
+    assertEquals(parsed.source, "managed");
+    assertEquals(parsed.classification_ceiling, "INTERNAL");
+    assertStringIncludes(parsed.content, "Does something useful");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test(
+  "read_skill: does not require or manipulate session taint",
+  async () => {
+    // The executor is constructed with no taint context and makes no taint
+    // decisions. Session taint management belongs in the orchestrator layer.
+    // This test verifies the executor works without any taint wiring.
+    const executor = createSkillToolExecutor({
+      skillLoader: makeBundledLoader(),
+    });
+
+    const result = await executor("read_skill", {
+      type: "BUNDLED",
+      skill_name: "weather",
+    });
+
+    const parsed = JSON.parse(result!);
+    assertEquals(parsed.found, true);
+    // No taint-related fields in the skill tool response
+    assertEquals("taint" in parsed, false);
+    assertEquals("session_taint" in parsed, false);
+    assertEquals("escalated" in parsed, false);
+  },
+);
+
+Deno.test("read_skill: skill_name is trimmed before lookup", async () => {
+  const executor = createSkillToolExecutor({ skillLoader: makeBundledLoader() });
+  const result = await executor("read_skill", {
+    type: "BUNDLED",
+    skill_name: "  weather  ",
+  });
+
+  const parsed = JSON.parse(result!);
+  assertEquals(parsed.found, true);
+  assertEquals(parsed.skill_name, "weather");
+});


### PR DESCRIPTION
Implements the `read_skill` tool requested in #89.

Adds a new `read_skill` tool to the skills module that reads SKILL.md content from bundled or user-provided skills WITHOUT escalating session taint.

Regular `read_file` triggers path-based classification and may escalate session taint. `read_skill` bypasses this by going through the SkillLoader abstraction, treating skills as capability metadata rather than classified data.

Closes #89

Generated with [Claude Code](https://claude.ai/code)