### PR TITLE
fix: remove INTERNAL floor from browser interactive tools

### DIFF
--- a/src/core/security/constants.ts
+++ b/src/core/security/constants.ts
@@ -68,23 +68,20 @@ export const URL_WRITE_TOOLS: ReadonlySet<string> = new Set([
 /**
  * Tools with hardcoded classification floors (non-overridable minimums).
  *
- * Browser read-only tools (navigate, snapshot, scroll, wait) have no floor —
- * navigating to a public website is a PUBLIC activity. The browser profile
- * watermark system (src/browser/watermark.ts) separately prevents a lower-tainted
- * session from reusing a profile that was previously used at a higher level.
- *
- * Interactive browser tools (click, type, select) require INTERNAL — they submit
- * data into forms and carry a higher risk of unintended data disclosure.
+ * Browser tools (read-only and interactive) have no floor — the existing
+ * resource-write-down check already prevents a higher-tainted session from
+ * submitting data to a lower-classified domain. A floor would create an
+ * impossible situation in owner sessions: escalating to INTERNAL to satisfy
+ * the floor would immediately trigger write-down against a PUBLIC domain,
+ * making browser interaction on public websites impossible. The browser
+ * profile watermark system (src/browser/watermark.ts) separately prevents
+ * a lower-tainted session from reusing a profile used at a higher level.
  *
  * run_command requires CONFIDENTIAL — shell execution is a different risk category.
  */
 export const HARDCODED_TOOL_FLOORS: ReadonlyMap<string, ClassificationLevel> =
   new Map<string, ClassificationLevel>([
     ["run_command", "CONFIDENTIAL"],
-    // Interactive browser tools that submit data require INTERNAL floor
-    ["browser_click", "INTERNAL"],
-    ["browser_type", "INTERNAL"],
-    ["browser_select", "INTERNAL"],
     // claude_* exec tools require INTERNAL (spawning sub-agents)
     ["claude_start", "INTERNAL"],
     ["claude_send", "INTERNAL"],

--- a/tests/core/security/tool_floors_test.ts
+++ b/tests/core/security/tool_floors_test.ts
@@ -13,7 +13,12 @@ Deno.test("tool floor: run_command has CONFIDENTIAL floor", () => {
   assertEquals(registry.getFloor("run_command"), "CONFIDENTIAL");
 });
 
-Deno.test("tool floor: interactive browser tools have INTERNAL floor", () => {
+Deno.test("tool floor: interactive browser tools have no floor", () => {
+  // Browser interactive tools have no hardcoded floor. The resource-write-down
+  // rule already prevents higher-tainted sessions from submitting data to
+  // lower-classified domains. A floor would create an impossible situation:
+  // escalating to INTERNAL to satisfy the floor would immediately trigger
+  // write-down against a PUBLIC domain in owner sessions.
   const registry = createToolFloorRegistry();
   const interactiveBrowserTools = [
     "browser_click",
@@ -21,19 +26,22 @@ Deno.test("tool floor: interactive browser tools have INTERNAL floor", () => {
     "browser_select",
   ];
   for (const tool of interactiveBrowserTools) {
-    assertEquals(registry.getFloor(tool), "INTERNAL", `${tool} should have INTERNAL floor`);
+    assertEquals(registry.getFloor(tool), null, `${tool} should have no floor`);
   }
 });
 
-Deno.test("tool floor: read-only browser tools have no floor", () => {
+Deno.test("tool floor: all browser tools have no floor", () => {
   const registry = createToolFloorRegistry();
-  const readOnlyBrowserTools = [
+  const allBrowserTools = [
     "browser_navigate",
     "browser_snapshot",
     "browser_scroll",
     "browser_wait",
+    "browser_click",
+    "browser_type",
+    "browser_select",
   ];
-  for (const tool of readOnlyBrowserTools) {
+  for (const tool of allBrowserTools) {
     assertEquals(registry.getFloor(tool), null, `${tool} should have no floor`);
   }
 });
@@ -86,16 +94,18 @@ Deno.test("tool floor: PUBLIC session can invoke browser_navigate (no floor)", (
   assertEquals(registry.canInvoke("browser_navigate", "PUBLIC"), true);
 });
 
-// --- Scenario 5: PUBLIC session cannot invoke browser_click (INTERNAL floor) ---
+// --- Scenario 5: PUBLIC session can invoke browser_click (no floor) ---
 
-Deno.test("tool floor: PUBLIC session cannot invoke browser_click", () => {
+Deno.test("tool floor: PUBLIC session can invoke browser_click (no floor)", () => {
+  // No hardcoded floor for browser interactive tools — resource-write-down
+  // handles domain-level enforcement in the PRE_TOOL_CALL hook.
   const registry = createToolFloorRegistry();
-  assertEquals(registry.canInvoke("browser_click", "PUBLIC"), false);
+  assertEquals(registry.canInvoke("browser_click", "PUBLIC"), true);
 });
 
-// --- Scenario 5b: INTERNAL session can invoke browser_click (meets INTERNAL floor) ---
+// --- Scenario 5b: INTERNAL session can invoke browser_click (no floor) ---
 
-Deno.test("tool floor: INTERNAL session can invoke browser_click", () => {
+Deno.test("tool floor: INTERNAL session can invoke browser_click (no floor)", () => {
   const registry = createToolFloorRegistry();
   assertEquals(registry.canInvoke("browser_click", "INTERNAL"), true);
 });
@@ -141,9 +151,7 @@ Deno.test("tool floor: enterprise can add floor to tool that had none", () => {
 Deno.test("tool floor: PUBLIC session cannot invoke floored tools", () => {
   const registry = createToolFloorRegistry();
   assertEquals(registry.canInvoke("run_command", "PUBLIC"), false);
-  assertEquals(registry.canInvoke("browser_click", "PUBLIC"), false);
-  assertEquals(registry.canInvoke("browser_type", "PUBLIC"), false);
-  assertEquals(registry.canInvoke("browser_select", "PUBLIC"), false);
+  // browser_click, browser_type, browser_select have no floor — not included here
 });
 
 Deno.test("tool floor: PUBLIC session can invoke unfloored tools", () => {


### PR DESCRIPTION
Removes the hardcoded INTERNAL floor from browser_click, browser_type, and browser_select. These tools now follow the same execution path as all other tools: owner pre-escalation based on domain classification + write-down enforcement. The floor was redundant (write-down already handles the security property) and broke browser automation on public domains in owner sessions.

Fixes #94

Generated with [Claude Code](https://claude.ai/code)