### PR TITLE
[Phase 17] feat: isTrigger() + classification-ordered trigger execution

### DIFF
--- a/src/agent/orchestrator.ts
+++ b/src/agent/orchestrator.ts
@@ -121,6 +121,13 @@ export interface OrchestratorConfig {
   /** Whether the active session belongs to the owner. */
   readonly isOwnerSession?: () => boolean;
   /**
+   * Whether the active session is a trigger session.
+   * Trigger sessions are not owner sessions but may call all built-in tools
+   * and integration tools classified at or below their ceiling.
+   * Undefined is always false — must be explicitly set to enable trigger behaviour.
+   */
+  readonly isTriggerSession?: () => boolean;
+  /**
    * Classification ceiling for the active non-owner session.
    * null = no explicit classification → all tools blocked.
    * Non-null = tools classified at or below this level are allowed.
@@ -292,6 +299,8 @@ export function createOrchestrator(config: OrchestratorConfig): Orchestrator {
     readonly resourceClassification: ClassificationLevel | null;
     readonly operationType: "read" | "write" | null;
     readonly isOwner: boolean;
+    /** True when the active session is a trigger session. Undefined isTriggerSession is always false. */
+    readonly isTrigger: boolean;
     readonly nonOwnerCeiling: ClassificationLevel | null;
     readonly resourceParam: string | null;
   }
@@ -359,6 +368,9 @@ export function createOrchestrator(config: OrchestratorConfig): Orchestrator {
     // Identity context
     const isOwner = config.isOwnerSession?.() ?? true;
     hookInput.is_owner = isOwner;
+    // isTrigger: undefined is always false — must be explicitly set
+    const isTrigger = config.isTriggerSession?.() ?? false;
+    hookInput.is_trigger = isTrigger;
     const nonOwnerCeiling = config.getNonOwnerCeiling?.() ?? null;
     if (nonOwnerCeiling !== null) {
       hookInput.non_owner_ceiling = nonOwnerCeiling;
@@ -366,7 +378,7 @@ export function createOrchestrator(config: OrchestratorConfig): Orchestrator {
 
     return {
       input: hookInput,
-      ctx: { toolName, toolFloor, resourceClassification, operationType, isOwner, nonOwnerCeiling, resourceParam },
+      ctx: { toolName, toolFloor, resourceClassification, operationType, isOwner, isTrigger, nonOwnerCeiling, resourceParam },
     };
   }
 
@@ -418,8 +430,25 @@ export function createOrchestrator(config: OrchestratorConfig): Orchestrator {
   // blocked=true can be set on the tool_result event for channel notification.
   const toolExecutor: ToolExecutor | undefined = rawToolExecutor
     ? async (name: string, input: Record<string, unknown>): Promise<string> => {
-        // Non-owner tool access enforcement.
-        if (config.isOwnerSession && !config.isOwnerSession()) {
+        // Trigger session tool access enforcement.
+        // Trigger sessions are not owners but may call all built-in tools.
+        // Integration tools are ceiling-gated to the trigger's classification ceiling.
+        // isTriggerSession undefined is always false — must be explicitly set.
+        const isActiveTrigger = config.isTriggerSession?.() ?? false;
+        if (isActiveTrigger) {
+          const ceiling = config.getNonOwnerCeiling?.() ?? null;
+          if (ceiling !== null && config.toolClassifications) {
+            for (const [prefix, level] of config.toolClassifications) {
+              if (name.startsWith(prefix)) {
+                if (!canFlowTo(level, ceiling)) {
+                  return `Error: ${name} (classified ${level}) exceeds trigger ceiling ${ceiling}. Access denied.`;
+                }
+                break;
+              }
+            }
+          }
+        // Non-owner tool access enforcement (external channels only — not triggers).
+        } else if (config.isOwnerSession && !config.isOwnerSession()) {
           const ceiling = config.getNonOwnerCeiling?.() ?? null;
 
           // No explicit classification → all tools blocked.
@@ -905,12 +934,14 @@ export function createOrchestrator(config: OrchestratorConfig): Orchestrator {
         if (resultText === undefined) {
           const { input: secInput, ctx: secCtx } = buildSecurityHookInput(call);
 
-          // Owner pre-escalation: escalate taint from the resolved resource
+          // Owner/trigger pre-escalation: escalate taint from the resolved resource
           // classification BEFORE the hook so tool floor checks see the
           // post-escalation taint. Owner sessions have no ceiling — reads
-          // are always allowed. Write-down checks still work because
-          // maxClassification only goes up (taint ≥ resource → no write-down).
-          if (secCtx.resourceClassification !== null && secCtx.isOwner && config.escalateTaint) {
+          // are always allowed. Trigger sessions are ceiling-gated but also
+          // pre-escalate so that tool floor checks work correctly.
+          // Write-down checks still work because maxClassification only goes up
+          // (taint ≥ resource → no write-down).
+          if (secCtx.resourceClassification !== null && (secCtx.isOwner || secCtx.isTrigger) && config.escalateTaint) {
             config.escalateTaint(secCtx.resourceClassification, `${call.name}: ${secCtx.resourceParam}`);
           }
 
@@ -949,8 +980,9 @@ export function createOrchestrator(config: OrchestratorConfig): Orchestrator {
             }
 
             if (resultText === undefined) {
-              // Non-owner escalation: only after hook confirms the read/write is allowed
-              if (secCtx.resourceClassification !== null && !secCtx.isOwner && config.escalateTaint) {
+              // Non-owner escalation: only after hook confirms the read/write is allowed.
+              // Excludes trigger sessions — they escalate pre-hook (same as owners).
+              if (secCtx.resourceClassification !== null && !secCtx.isOwner && !secCtx.isTrigger && config.escalateTaint) {
                 config.escalateTaint(secCtx.resourceClassification, `${call.name}: ${secCtx.resourceParam}`);
               }
               resultText = await toolExecutor!(call.name, call.args);

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -63,6 +63,14 @@ export interface TriggerFishConfig {
         readonly start?: number;
         readonly end?: number;
       };
+      /**
+       * Classification ceiling for trigger sessions.
+       * Integration tools classified above this level are blocked.
+       * Defaults to "CONFIDENTIAL" when not set — triggers routinely need
+       * access to CONFIDENTIAL integrations such as Gmail.
+       * Set to "INTERNAL" explicitly to restrict trigger access.
+       */
+      readonly classification_ceiling?: string;
     };
     readonly webhooks?: {
       readonly enabled?: boolean;

--- a/src/gateway/agent_tools.ts
+++ b/src/gateway/agent_tools.ts
@@ -309,6 +309,15 @@ export interface ToolExecutorOptions {
     name: string,
     input: Record<string, unknown>,
   ) => Promise<string | null>;
+  /**
+   * Executor for `get_tool_classification` — available in trigger sessions
+   * so the agent can look up tool classifications and order its work from
+   * lowest to highest classification before calling any integration tools.
+   */
+  readonly triggerClassificationExecutor?: (
+    name: string,
+    input: Record<string, unknown>,
+  ) => Promise<string | null>;
   readonly skillExecutor?: (
     name: string,
     input: Record<string, unknown>,
@@ -441,6 +450,12 @@ export function createToolExecutor(opts: ToolExecutorOptions): ToolExecutor {
     if (opts.triggerExecutor) {
       const triggerResult = await opts.triggerExecutor(name, input);
       if (triggerResult !== null) return triggerResult;
+    }
+
+    // Try trigger classification tool (get_tool_classification — for trigger sessions)
+    if (opts.triggerClassificationExecutor) {
+      const triggerClassResult = await opts.triggerClassificationExecutor(name, input);
+      if (triggerClassResult !== null) return triggerClassResult;
     }
 
     // Try skill tools (returns null if not a skill tool)

--- a/src/gateway/factory.ts
+++ b/src/gateway/factory.ts
@@ -88,11 +88,16 @@ import { createKeychain } from "../secrets/keychain.ts";
 import {
   createSessionToolExecutor,
 } from "./tools.ts";
+import {
+  createTriggerClassificationToolExecutor,
+  TRIGGER_SESSION_SYSTEM_PROMPT,
+} from "./trigger_tools.ts";
 import type { EnhancedSessionManager } from "./sessions.ts";
 import type { CronManager } from "../scheduler/cron.ts";
 import type { StorageProvider } from "../core/storage/provider.ts";
 import type {
   OrchestratorFactory,
+  OrchestratorCreateOptions,
   SchedulerServiceConfig,
   WebhookSourceConfig,
 } from "../scheduler/service.ts";
@@ -240,7 +245,7 @@ export function createOrchestratorFactory(
   let factorySkillsDiscovered = false;
 
   return {
-    async create(channelId: string) {
+    async create(channelId: string, options?: OrchestratorCreateOptions) {
       if (!factorySkillsDiscovered) {
         factorySkillsDiscovered = true;
         try {
@@ -250,6 +255,8 @@ export function createOrchestratorFactory(
           // Non-fatal
         }
       }
+      const isTrigger = options?.isTrigger ?? false;
+      const triggerCeiling = options?.ceiling ?? null;
       const agentId = `scheduler-${channelId}-${Date.now()}`;
       const workspace = await createWorkspace({
         agentId,
@@ -360,6 +367,11 @@ export function createOrchestratorFactory(
         }),
         skillExecutor: factorySkillExecutor,
         providerRegistry: registry,
+        // Trigger classification tool: available in all scheduler sessions,
+        // but only instructed to use in trigger sessions via system prompt.
+        triggerClassificationExecutor: createTriggerClassificationToolExecutor(
+          schedulerToolClassifications,
+        ),
       });
       // Build path classifier for scheduler workspace
       const schedulerPathClassifier = fsPathMap ? createPathClassifier(
@@ -386,6 +398,10 @@ export function createOrchestratorFactory(
           LLM_TASK_SYSTEM_PROMPT,
           SUMMARIZE_SYSTEM_PROMPT,
           factorySkillsPrompt,
+          // Inject trigger-specific classification ordering instructions when
+          // this session is a trigger session. Cron jobs and subagents do not
+          // get this section — it is only relevant for trigger sessions.
+          ...(isTrigger ? [TRIGGER_SESSION_SYSTEM_PROMPT] : []),
         ],
         visionProvider: schedulerVisionProvider,
         toolClassifications: schedulerToolClassifications,
@@ -396,6 +412,15 @@ export function createOrchestratorFactory(
         pathClassifier: schedulerPathClassifier,
         domainClassifier: schedulerDomainClassifier,
         toolFloorRegistry: schedulerToolFloorRegistry,
+        // Trigger sessions are not owner sessions but get built-in tool access
+        // and integration tools classified at or below their ceiling.
+        // isTriggerSession undefined is always false — must be explicitly set.
+        ...(isTrigger
+          ? {
+            isTriggerSession: () => true,
+            getNonOwnerCeiling: () => triggerCeiling,
+          }
+          : {}),
       });
 
       return { orchestrator, session };
@@ -435,7 +460,7 @@ export function buildSchedulerConfig(
           end: sched.trigger.quiet_hours.end ?? 7,
         }
         : { start: 22, end: 7 },
-      classificationCeiling: "INTERNAL" as ClassificationLevel,
+      classificationCeiling: (sched?.trigger?.classification_ceiling ?? "CONFIDENTIAL") as ClassificationLevel,
     },
     webhooks: {
       enabled: sched?.webhooks?.enabled ?? false,

--- a/src/gateway/trigger_tools.ts
+++ b/src/gateway/trigger_tools.ts
@@ -1,9 +1,12 @@
 /**
  * Trigger context tools for the agent orchestrator.
  *
- * Provides the `trigger_add_to_context` tool that allows the agent to
- * load the most recent trigger output into the current conversation
- * context, subject to the no-write-down rule.
+ * Provides:
+ * - `trigger_add_to_context` — loads the most recent trigger output into the
+ *   current conversation context, subject to the no-write-down rule.
+ * - `get_tool_classification` — returns the classification level of one or more
+ *   tools so that trigger sessions can order their work from lowest to highest
+ *   classification, avoiding write-down violations mid-session.
  *
  * Classification enforcement:
  * - The trigger result's classification must be >= the current session taint.
@@ -41,6 +44,14 @@ export interface TriggerToolContext {
 /** Default trigger source used when none is specified. */
 const DEFAULT_SOURCE = "trigger";
 
+/** Classification level ordering for sorting (lower number = lower classification). */
+const CLASSIFICATION_ORDER: Readonly<Record<string, number>> = {
+  PUBLIC: 0,
+  INTERNAL: 1,
+  CONFIDENTIAL: 2,
+  RESTRICTED: 3,
+};
+
 /** Get the tool definitions for trigger context tools. */
 export function getTriggerToolDefinitions(): readonly ToolDefinition[] {
   return [
@@ -60,10 +71,33 @@ export function getTriggerToolDefinitions(): readonly ToolDefinition[] {
         },
       },
     },
+    {
+      name: "get_tool_classification",
+      description:
+        "Look up the classification level of one or more tools. " +
+        "In trigger sessions, call this before executing your planned tool calls to determine " +
+        "the correct order (lowest to highest classification). " +
+        "Built-in tools (exec, memory, web, etc.) are PUBLIC. " +
+        "Integration tools (gmail_, calendar_, github_, etc.) have their configured classification.",
+      parameters: {
+        tools: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "List of tool names to classify. Returns classifications and recommended call order.",
+          required: true,
+        },
+      },
+    },
   ];
 }
 
-/** System prompt section explaining trigger tools to the LLM. */
+/** Get trigger tool definitions for the main (user) session — only trigger_add_to_context. */
+export function getTriggerContextToolDefinitions(): readonly ToolDefinition[] {
+  return getTriggerToolDefinitions().filter((t) => t.name === "trigger_add_to_context");
+}
+
+/** System prompt section explaining trigger_add_to_context to the user-session LLM. */
 export const TRIGGER_TOOLS_SYSTEM_PROMPT =
   `## Trigger Context
 
@@ -77,6 +111,103 @@ You can retrieve recent trigger outputs and inject them into the conversation.
 - When a trigger is successfully added, its content and classification are visible in context.
 - If the trigger's classification exceeds your current session taint, your session taint
   will automatically escalate to match it.`;
+
+/**
+ * System prompt section for trigger sessions — explains classification-ordered execution.
+ *
+ * Injected into the orchestrator system prompt when isTriggerSession is true.
+ * Instructs the agent to call get_tool_classification first and order its work
+ * from lowest to highest classification to avoid write-down violations mid-session.
+ */
+export const TRIGGER_SESSION_SYSTEM_PROMPT =
+  `## Trigger Session — Classification-Ordered Execution
+
+You are running in a trigger session. Your session taint starts at PUBLIC and escalates as you call classified tools. Calling a lower-classified tool AFTER a higher-classified one is blocked as a write-down violation.
+
+**Required protocol before calling any integration tools (gmail_, calendar_, drive_, github_, etc.):**
+
+1. **Identify all tools** you plan to call in this session.
+2. **Call \`get_tool_classification\`** with your full list of planned tools to get their classification levels.
+3. **Order your work from lowest to highest classification** — PUBLIC first, then INTERNAL, then CONFIDENTIAL, then RESTRICTED.
+4. **Execute in order** — your session taint escalates naturally. Your final session taint reflects the highest classification you accessed.
+
+Your output is stored in the trigger store and stamped with your final session taint. The owner can then optionally pull it into their session via \`trigger_add_to_context\`, at which point their session taint may escalate to match yours.
+
+If you skip classification ordering and call a higher-classified tool before a lower one, subsequent lower-classified calls will be blocked by write-down enforcement. Always call \`get_tool_classification\` first.`;
+
+/**
+ * Create a tool executor for the `get_tool_classification` tool.
+ *
+ * Accepts a tool-prefix → classification map (the same map used by the
+ * orchestrator for enforcement). Given a list of tool names, returns their
+ * classification levels and a recommended call order (lowest → highest).
+ * Built-in tools not in the map are returned as PUBLIC.
+ *
+ * This executor is intended for trigger sessions so the agent can plan its
+ * work order before calling any tools, avoiding mid-session write-down blocks.
+ *
+ * Returns null for unrecognised tool names (allowing chaining with other executors).
+ *
+ * @param toolClassifications - Map of tool prefix → classification level.
+ * @returns An executor function: (name, input) => Promise<string | null>
+ */
+export function createTriggerClassificationToolExecutor(
+  toolClassifications: ReadonlyMap<string, ClassificationLevel>,
+): (name: string, input: Record<string, unknown>) => Promise<string | null> {
+  return async (
+    name: string,
+    input: Record<string, unknown>,
+  ): Promise<string | null> => {
+    if (name !== "get_tool_classification") return null;
+
+    const rawTools = input.tools;
+    const toolNames: string[] = Array.isArray(rawTools)
+      ? rawTools.filter((t): t is string => typeof t === "string")
+      : typeof rawTools === "string"
+      ? [rawTools]
+      : [];
+
+    if (toolNames.length === 0) {
+      return "Error: 'tools' parameter must be a non-empty array of tool names.";
+    }
+
+    const classifications: Array<{ tool: string; classification: ClassificationLevel }> = [];
+
+    for (const toolName of toolNames) {
+      let found = false;
+      for (const [prefix, level] of toolClassifications) {
+        if (toolName.startsWith(prefix)) {
+          classifications.push({ tool: toolName, classification: level });
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        // Built-in tools not in the classification map are ungated (PUBLIC).
+        classifications.push({ tool: toolName, classification: "PUBLIC" as ClassificationLevel });
+      }
+    }
+
+    // Sort by classification level: lowest first so the recommended order is
+    // safe to execute top-to-bottom without write-down violations.
+    const sorted = [...classifications].sort(
+      (a, b) =>
+        (CLASSIFICATION_ORDER[a.classification] ?? 0) -
+        (CLASSIFICATION_ORDER[b.classification] ?? 0),
+    );
+
+    const result = {
+      classifications,
+      recommended_order: sorted.map((c) => ({ tool: c.tool, classification: c.classification })),
+      instruction:
+        "Execute tools in the recommended_order sequence (lowest classification first). " +
+        "Your session taint escalates as you call higher-classified tools. " +
+        "Calling a lower-classified tool after a higher-classified one will be blocked.",
+    };
+
+    return JSON.stringify(result, null, 2);
+  };
+}
 
 /**
  * Create a tool executor for trigger context tools.

--- a/src/scheduler/service.ts
+++ b/src/scheduler/service.ts
@@ -28,6 +28,22 @@ import { createLogger } from "../core/logger/mod.ts";
 
 const log = createLogger("scheduler");
 
+/** Options passed to OrchestratorFactory.create() to configure the session type. */
+export interface OrchestratorCreateOptions {
+  /**
+   * When true, the orchestrator is configured as a trigger session.
+   * Trigger sessions may call all built-in tools and integration tools
+   * classified at or below the ceiling. They are never owner sessions.
+   */
+  readonly isTrigger?: boolean;
+  /**
+   * Classification ceiling for this session.
+   * Integration tools classified above this level are blocked.
+   * Ignored unless isTrigger is true (owner sessions have no ceiling).
+   */
+  readonly ceiling?: ClassificationLevel;
+}
+
 /**
  * Factory that creates an isolated orchestrator + session per execution.
  *
@@ -37,7 +53,7 @@ const log = createLogger("scheduler");
  */
 export interface OrchestratorFactory {
   /** Create a new orchestrator and session for a scheduled task. */
-  create(channelId: string): Promise<{
+  create(channelId: string, options?: OrchestratorCreateOptions): Promise<{
     readonly orchestrator: Orchestrator;
     readonly session: SessionState;
   }>;
@@ -229,7 +245,10 @@ export function createSchedulerService(
     try {
       log.info("Creating trigger orchestrator session");
       const { orchestrator, session } =
-        await config.orchestratorFactory.create("trigger");
+        await config.orchestratorFactory.create("trigger", {
+          isTrigger: true,
+          ceiling: config.trigger.classificationCeiling,
+        });
 
       log.info("Trigger orchestrator processing TRIGGER.md");
       const result = await orchestrator.processMessage({

--- a/tests/agent/orchestrator_test.ts
+++ b/tests/agent/orchestrator_test.ts
@@ -3,7 +3,7 @@
  * Tests MUST FAIL until orchestrator.ts and llm.ts are implemented.
  * Tests LlmProvider interface, provider registry, orchestrator loop.
  */
-import { assertEquals, assertExists, assert } from "@std/assert";
+import { assertEquals, assertExists, assert, assertStringIncludes } from "@std/assert";
 import {
   type LlmProvider,
   createProviderRegistry,
@@ -424,3 +424,173 @@ Deno.test("LEAKED_INTENT_PATTERN: does not match normal response text", () => {
 // Note: The leaked-intent guard was removed from the orchestrator because it
 // caused blank responses with some LLM providers. The LEAKED_INTENT_PATTERN
 // regex is still exported and tested above for potential future use.
+
+// --- isTriggerSession tests ---
+
+Deno.test("Orchestrator: isTriggerSession=undefined is always false (default deny)", async () => {
+  // Without isTriggerSession set, the orchestrator should NOT behave as a trigger session.
+  // isOwnerSession && !isOwnerSession() = false (isOwnerSession is undefined) — the
+  // non-owner check is skipped. This is the legacy behaviour, not the trigger behaviour.
+  // This test documents the baseline: isTrigger defaults to false.
+  const engine = createPolicyEngine();
+  for (const r of createDefaultRules()) engine.addRule(r);
+  const runner = createHookRunner(engine);
+  const registry = createProviderRegistry();
+  registry.register(createMockProvider("mock", "response"));
+  registry.setDefault("mock");
+
+  let calledTool = "";
+  const orchestrator = createOrchestrator({
+    hookRunner: runner,
+    providerRegistry: registry,
+    tools: [{ name: "read_file", description: "Read a file", parameters: { path: { type: "string", description: "path" } } }],
+    toolExecutor: async (name) => { calledTool = name; return "result"; },
+    // isTriggerSession not set — must be false per "undefined is always false" rule
+  });
+
+  const session = createSession({ userId: "u" as UserId, channelId: "c" as ChannelId });
+  // With no isOwnerSession or isTriggerSession set, the non-owner check is bypassed
+  // (legacy behaviour). The tool runs because neither check activates.
+  const result = await orchestrator.processMessage({
+    session,
+    message: "do something",
+    targetClassification: "INTERNAL",
+  });
+  // Passes because the orchestrator has no integration toolClassifications blocking it
+  assertEquals(result.ok, true);
+});
+
+Deno.test("Orchestrator: trigger session allows built-in tools (not blocked as non-owner)", async () => {
+  const engine = createPolicyEngine();
+  for (const r of createDefaultRules()) engine.addRule(r);
+  const runner = createHookRunner(engine);
+  const registry = createProviderRegistry();
+  registry.register(createMockProvider("mock", "result"));
+  registry.setDefault("mock");
+
+  let calledTool = "";
+  const orchestrator = createOrchestrator({
+    hookRunner: runner,
+    providerRegistry: registry,
+    tools: [{ name: "memory_save", description: "Save memory", parameters: { key: { type: "string", description: "key" }, value: { type: "string", description: "value" } } }],
+    toolExecutor: async (name) => { calledTool = name; return "saved"; },
+    isTriggerSession: () => true,
+    getNonOwnerCeiling: () => "CONFIDENTIAL" as const,
+    toolClassifications: new Map([["gmail_", "CONFIDENTIAL" as const]]),
+    getSessionTaint: () => "PUBLIC" as const,
+    escalateTaint: () => {},
+  });
+
+  const session = createSession({ userId: "u" as UserId, channelId: "c" as ChannelId });
+  const result = await orchestrator.processMessage({
+    session,
+    message: "use memory tool",
+    targetClassification: "CONFIDENTIAL",
+  });
+  // Trigger sessions can call built-in tools (memory_save is not in toolClassifications)
+  assertEquals(result.ok, true);
+});
+
+Deno.test("Orchestrator: trigger session blocks integration tool above ceiling", async () => {
+  const engine = createPolicyEngine();
+  for (const r of createDefaultRules()) engine.addRule(r);
+  const runner = createHookRunner(engine);
+  const registry = createProviderRegistry();
+
+  // Provider returns a tool call to a CONFIDENTIAL integration, then a final response
+  let callCount = 0;
+  const toolProvider: LlmProvider = {
+    name: "tool-test",
+    supportsStreaming: false,
+    // deno-lint-ignore require-await
+    async complete(_messages, _tools, _options) {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          content: "",
+          toolCalls: [{ type: "function", function: { name: "gmail_list", arguments: "{}" } }],
+          usage: { inputTokens: 10, outputTokens: 5 },
+        };
+      }
+      return { content: "Done.", toolCalls: [], usage: { inputTokens: 10, outputTokens: 5 } };
+    },
+  };
+  registry.register(toolProvider);
+  registry.setDefault("tool-test");
+
+  let toolResult = "";
+  const orchestrator = createOrchestrator({
+    hookRunner: runner,
+    providerRegistry: registry,
+    tools: [{ name: "gmail_list", description: "List gmail", parameters: {} }],
+    toolExecutor: async (name) => { return `${name} result`; },
+    isTriggerSession: () => true,
+    // Ceiling is INTERNAL — gmail (CONFIDENTIAL) is above ceiling → blocked
+    getNonOwnerCeiling: () => "INTERNAL" as const,
+    toolClassifications: new Map([["gmail_", "CONFIDENTIAL" as const]]),
+    getSessionTaint: () => "PUBLIC" as const,
+    escalateTaint: () => {},
+    onEvent: (evt) => {
+      if (evt.type === "tool_result") toolResult = evt.result;
+    },
+  });
+
+  const session = createSession({ userId: "u" as UserId, channelId: "c" as ChannelId });
+  await orchestrator.processMessage({
+    session,
+    message: "list gmail",
+    targetClassification: "INTERNAL",
+  });
+  // gmail_list (CONFIDENTIAL) is above INTERNAL ceiling — should be blocked
+  assertStringIncludes(toolResult, "exceeds trigger ceiling");
+});
+
+Deno.test("Orchestrator: trigger session allows integration tool at ceiling level", async () => {
+  const engine = createPolicyEngine();
+  for (const r of createDefaultRules()) engine.addRule(r);
+  const runner = createHookRunner(engine);
+  const registry = createProviderRegistry();
+
+  let callCount = 0;
+  const toolProvider: LlmProvider = {
+    name: "tool-test",
+    supportsStreaming: false,
+    // deno-lint-ignore require-await
+    async complete(_messages, _tools, _options) {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          content: "",
+          toolCalls: [{ type: "function", function: { name: "github_search_repos", arguments: "{}" } }],
+          usage: { inputTokens: 10, outputTokens: 5 },
+        };
+      }
+      return { content: "Done.", toolCalls: [], usage: { inputTokens: 10, outputTokens: 5 } };
+    },
+  };
+  registry.register(toolProvider);
+  registry.setDefault("tool-test");
+
+  let toolExecuted = false;
+  const orchestrator = createOrchestrator({
+    hookRunner: runner,
+    providerRegistry: registry,
+    tools: [{ name: "github_search_repos", description: "Search GitHub repos", parameters: {} }],
+    toolExecutor: async () => { toolExecuted = true; return "repos found"; },
+    isTriggerSession: () => true,
+    // Ceiling is INTERNAL — github (INTERNAL) is at ceiling → allowed
+    getNonOwnerCeiling: () => "INTERNAL" as const,
+    toolClassifications: new Map([["github_", "INTERNAL" as const]]),
+    getSessionTaint: () => "PUBLIC" as const,
+    escalateTaint: () => {},
+  });
+
+  const session = createSession({ userId: "u" as UserId, channelId: "c" as ChannelId });
+  await orchestrator.processMessage({
+    session,
+    message: "search repos",
+    targetClassification: "INTERNAL",
+  });
+  // github_ (INTERNAL) is at the ceiling level — tool should execute
+  assertEquals(toolExecuted, true);
+});

--- a/tests/gateway/trigger_tools_test.ts
+++ b/tests/gateway/trigger_tools_test.ts
@@ -8,7 +8,9 @@ import { createTriggerStore } from "../../src/scheduler/trigger_store.ts";
 import type { TriggerResult } from "../../src/scheduler/trigger_store.ts";
 import {
   createTriggerToolExecutor,
+  createTriggerClassificationToolExecutor,
   getTriggerToolDefinitions,
+  getTriggerContextToolDefinitions,
 } from "../../src/gateway/trigger_tools.ts";
 import type { TriggerToolContext } from "../../src/gateway/trigger_tools.ts";
 
@@ -38,8 +40,16 @@ function makeCtx(
 
 // ── Tool definitions ──────────────────────────────────────────────────
 
-Deno.test("getTriggerToolDefinitions: returns trigger_add_to_context", () => {
+Deno.test("getTriggerToolDefinitions: returns trigger_add_to_context and get_tool_classification", () => {
   const defs = getTriggerToolDefinitions();
+  assertEquals(defs.length, 2);
+  const names = defs.map((d) => d.name);
+  assertEquals(names.includes("trigger_add_to_context"), true);
+  assertEquals(names.includes("get_tool_classification"), true);
+});
+
+Deno.test("getTriggerContextToolDefinitions: returns only trigger_add_to_context", () => {
+  const defs = getTriggerContextToolDefinitions();
   assertEquals(defs.length, 1);
   assertEquals(defs[0].name, "trigger_add_to_context");
 });
@@ -198,4 +208,72 @@ Deno.test("trigger executor: returns error when context is undefined", async () 
   const exec = createTriggerToolExecutor(undefined);
   const result = await exec("trigger_add_to_context", {});
   assertStringIncludes(result as string, "not available");
+});
+
+// ── get_tool_classification ───────────────────────────────────────────
+
+Deno.test("get_tool_classification: returns PUBLIC for built-in tools", async () => {
+  const map = new Map<string, "PUBLIC" | "INTERNAL" | "CONFIDENTIAL" | "RESTRICTED">([
+    ["gmail_", "CONFIDENTIAL"],
+    ["github_", "INTERNAL"],
+  ]);
+  const exec = createTriggerClassificationToolExecutor(map);
+  const result = await exec("get_tool_classification", { tools: ["web_search", "memory_save"] });
+  const parsed = JSON.parse(result as string);
+  assertEquals(parsed.classifications.length, 2);
+  assertEquals(parsed.classifications.find((c: { tool: string }) => c.tool === "web_search").classification, "PUBLIC");
+  assertEquals(parsed.classifications.find((c: { tool: string }) => c.tool === "memory_save").classification, "PUBLIC");
+});
+
+Deno.test("get_tool_classification: returns correct classification for integration tools", async () => {
+  const map = new Map<string, "PUBLIC" | "INTERNAL" | "CONFIDENTIAL" | "RESTRICTED">([
+    ["gmail_", "CONFIDENTIAL"],
+    ["github_", "INTERNAL"],
+  ]);
+  const exec = createTriggerClassificationToolExecutor(map);
+  const result = await exec("get_tool_classification", { tools: ["gmail_list", "github_search_repos"] });
+  const parsed = JSON.parse(result as string);
+  assertEquals(parsed.classifications.find((c: { tool: string }) => c.tool === "gmail_list").classification, "CONFIDENTIAL");
+  assertEquals(parsed.classifications.find((c: { tool: string }) => c.tool === "github_search_repos").classification, "INTERNAL");
+});
+
+Deno.test("get_tool_classification: recommended_order sorts lowest to highest", async () => {
+  const map = new Map<string, "PUBLIC" | "INTERNAL" | "CONFIDENTIAL" | "RESTRICTED">([
+    ["gmail_", "CONFIDENTIAL"],
+    ["github_", "INTERNAL"],
+  ]);
+  const exec = createTriggerClassificationToolExecutor(map);
+  const result = await exec("get_tool_classification", {
+    tools: ["gmail_list", "web_search", "github_search_repos"],
+  });
+  const parsed = JSON.parse(result as string);
+  const order = parsed.recommended_order.map((c: { classification: string }) => c.classification);
+  // web_search = PUBLIC, github = INTERNAL, gmail = CONFIDENTIAL
+  assertEquals(order[0], "PUBLIC");
+  assertEquals(order[1], "INTERNAL");
+  assertEquals(order[2], "CONFIDENTIAL");
+});
+
+Deno.test("get_tool_classification: returns error for empty tools list", async () => {
+  const map = new Map<string, "PUBLIC" | "INTERNAL" | "CONFIDENTIAL" | "RESTRICTED">();
+  const exec = createTriggerClassificationToolExecutor(map);
+  const result = await exec("get_tool_classification", { tools: [] });
+  assertStringIncludes(result as string, "Error");
+});
+
+Deno.test("get_tool_classification: returns null for non-matching tool names", async () => {
+  const map = new Map<string, "PUBLIC" | "INTERNAL" | "CONFIDENTIAL" | "RESTRICTED">();
+  const exec = createTriggerClassificationToolExecutor(map);
+  const result = await exec("some_other_tool", { tools: ["foo"] });
+  assertEquals(result, null);
+});
+
+Deno.test("get_tool_classification: includes instruction in output", async () => {
+  const map = new Map<string, "PUBLIC" | "INTERNAL" | "CONFIDENTIAL" | "RESTRICTED">([
+    ["gmail_", "CONFIDENTIAL"],
+  ]);
+  const exec = createTriggerClassificationToolExecutor(map);
+  const result = await exec("get_tool_classification", { tools: ["gmail_list"] });
+  const parsed = JSON.parse(result as string);
+  assertStringIncludes(parsed.instruction, "lowest classification first");
 });

--- a/tests/scheduler/scheduler_test.ts
+++ b/tests/scheduler/scheduler_test.ts
@@ -19,6 +19,7 @@ import {
 import { createSchedulerService } from "../../src/scheduler/service.ts";
 import type {
   OrchestratorFactory,
+  OrchestratorCreateOptions,
   SchedulerServiceConfig,
 } from "../../src/scheduler/service.ts";
 
@@ -247,16 +248,19 @@ Deno.test("WebhookHandler: ignores unregistered event types", async () => {
 
 // ── SchedulerService ─────────────────────────────────────────────────
 
-/** Create a mock OrchestratorFactory that records calls. */
+/** Create a mock OrchestratorFactory that records calls and options. */
 function createMockFactory(): {
   factory: OrchestratorFactory;
   calls: string[];
+  options: (OrchestratorCreateOptions | undefined)[];
 } {
   const calls: string[] = [];
+  const options: (OrchestratorCreateOptions | undefined)[] = [];
   const factory: OrchestratorFactory = {
     // deno-lint-ignore require-await
-    async create(channelId: string) {
+    async create(channelId: string, opts?: OrchestratorCreateOptions) {
       calls.push(channelId);
+      options.push(opts);
       return {
         orchestrator: {
           // deno-lint-ignore require-await
@@ -275,7 +279,7 @@ function createMockFactory(): {
       };
     },
   };
-  return { factory, calls };
+  return { factory, calls, options };
 }
 
 function createTestConfig(
@@ -592,4 +596,53 @@ Deno.test("CLI: parses 'cron history' with job ID", () => {
   assertEquals(cmd.command, "cron");
   assertEquals(cmd.subcommand, "history");
   assertEquals(cmd.flags["job_id"], "abc-123");
+});
+
+// ── OrchestratorFactory trigger options ──────────────────────────────
+
+Deno.test("OrchestratorFactory: create() accepts isTrigger option", async () => {
+  const { factory, options } = createMockFactory();
+  await factory.create("trigger", { isTrigger: true, ceiling: "CONFIDENTIAL" });
+  assertEquals(options.length, 1);
+  assertEquals(options[0]?.isTrigger, true);
+  assertEquals(options[0]?.ceiling, "CONFIDENTIAL");
+});
+
+Deno.test("OrchestratorFactory: create() works without options (cron/subagent)", async () => {
+  const { factory, options } = createMockFactory();
+  await factory.create("cron");
+  assertEquals(options.length, 1);
+  assertEquals(options[0], undefined);
+});
+
+Deno.test("SchedulerService: trigger callback passes isTrigger=true and ceiling to factory", async () => {
+  const { factory, options } = createMockFactory();
+  const config: SchedulerServiceConfig = {
+    orchestratorFactory: factory,
+    triggerMdPath: "/tmp/nonexistent-trigger.md",
+    trigger: {
+      enabled: true,
+      intervalMinutes: 1,
+      classificationCeiling: "CONFIDENTIAL",
+    },
+    webhooks: { enabled: false, sources: {} },
+  };
+
+  const svc = createSchedulerService(config);
+  // Manually invoke the trigger by starting and stopping immediately.
+  // The trigger fires once immediately on start.
+  svc.start();
+  // Wait briefly for the async trigger callback
+  await new Promise((r) => setTimeout(r, 50));
+  svc.stop();
+
+  // At least one orchestrator was created, and it was for the trigger
+  const triggerOpts = options.find((_, i) => {
+    const call = (svc as unknown as { _calls?: string[] });
+    return true; // All calls in this test are from the trigger
+  });
+  // Verify the factory was called with trigger options
+  const triggerCall = options.find((o) => o?.isTrigger === true);
+  assert(triggerCall !== undefined, "Expected trigger to call factory with isTrigger=true");
+  assertEquals(triggerCall?.ceiling, "CONFIDENTIAL");
 });


### PR DESCRIPTION
Implements `isTriggerSession` as a dedicated identity flag separate from `isOwnerSession`. Adds `get_tool_classification` tool so triggers can plan their work order (lowest to highest classification) before executing, avoiding write-down violations mid-session.

Closes #96

Generated with [Claude Code](https://claude.ai/code)