### PR TITLE
[Phase B1] fix: live taint closure for GoogleToolExecutor + buildSchedulerConfig ceiling tests

### DIFF
--- a/src/gateway/factory.ts
+++ b/src/gateway/factory.ts
@@ -352,7 +352,7 @@ export function createOrchestratorFactory(
         memoryExecutor: schedulerMemoryExecutor,
         planExecutor,
         sessionExecutor,
-        googleExecutor: buildGoogleExecutor(session.taint, session.id),
+        googleExecutor: buildGoogleExecutor(() => session.taint, session.id),
         githubExecutor: schedulerGithubExecutor,
         llmTaskExecutor: registry
           ? createLlmTaskToolExecutor(registry)
@@ -477,7 +477,7 @@ export function buildSchedulerConfig(
  * clear error at tool-call time, not at startup.
  */
 export function buildGoogleExecutor(
-  sessionTaint: ClassificationLevel,
+  getSessionTaint: () => ClassificationLevel,
   sourceSessionId: SessionId,
 ):
   | ((name: string, input: Record<string, unknown>) => Promise<string | null>)
@@ -492,7 +492,7 @@ export function buildGoogleExecutor(
       tasks: createTasksService(apiClient),
       drive: createDriveService(apiClient),
       sheets: createSheetsService(apiClient),
-      sessionTaint,
+      sessionTaint: getSessionTaint,
       sourceSessionId,
     });
   } catch {

--- a/src/gateway/startup.ts
+++ b/src/gateway/startup.ts
@@ -747,7 +747,7 @@ export async function runStart(): Promise<void> {
     imageExecutor,
     sessionExecutor,
     exploreExecutor,
-    googleExecutor: buildGoogleExecutor(session.taint, session.id),
+    googleExecutor: buildGoogleExecutor(() => session.taint, session.id),
     githubExecutor,
     obsidianExecutor,
     llmTaskExecutor: registry ? createLlmTaskToolExecutor(registry) : undefined,

--- a/src/google/types.ts
+++ b/src/google/types.ts
@@ -313,7 +313,8 @@ export interface GoogleToolContext {
   readonly tasks: TasksService;
   readonly drive: DriveService;
   readonly sheets: SheetsService;
-  readonly sessionTaint: ClassificationLevel;
+  /** Live getter for current session taint. Returns the taint at call time, not at creation time. */
+  readonly sessionTaint: () => ClassificationLevel;
   readonly sourceSessionId: SessionId;
   readonly lineageStore?: LineageStore;
   readonly classificationFloors?: Readonly<

--- a/tests/gateway/factory_test.ts
+++ b/tests/gateway/factory_test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for gateway factory helpers — buildSchedulerConfig.
+ */
+import { assertEquals } from "@std/assert";
+import { buildSchedulerConfig } from "../../src/gateway/factory.ts";
+import type { TriggerFishConfig } from "../../src/core/config.ts";
+import type { OrchestratorFactory } from "../../src/scheduler/service.ts";
+
+function makeMockFactory(): OrchestratorFactory {
+  return {
+    create: async (_channelId: string, _opts?: unknown) => {
+      await Promise.resolve();
+      throw new Error("Not implemented in mock");
+    },
+  };
+}
+
+// ── buildSchedulerConfig: trigger classification_ceiling ─────────────────────
+
+Deno.test("buildSchedulerConfig: trigger ceiling defaults to CONFIDENTIAL when not set", () => {
+  const config: TriggerFishConfig = {};
+  const result = buildSchedulerConfig(config, "/base", makeMockFactory());
+  assertEquals(result.trigger.classificationCeiling, "CONFIDENTIAL");
+});
+
+Deno.test("buildSchedulerConfig: trigger ceiling defaults to CONFIDENTIAL when scheduler is empty", () => {
+  const config: TriggerFishConfig = { scheduler: {} };
+  const result = buildSchedulerConfig(config, "/base", makeMockFactory());
+  assertEquals(result.trigger.classificationCeiling, "CONFIDENTIAL");
+});
+
+Deno.test("buildSchedulerConfig: trigger ceiling reads from YAML when explicitly set to INTERNAL", () => {
+  const config: TriggerFishConfig = {
+    scheduler: {
+      trigger: {
+        classification_ceiling: "INTERNAL",
+      },
+    },
+  };
+  const result = buildSchedulerConfig(config, "/base", makeMockFactory());
+  assertEquals(result.trigger.classificationCeiling, "INTERNAL");
+});
+
+Deno.test("buildSchedulerConfig: trigger ceiling reads from YAML when explicitly set to CONFIDENTIAL", () => {
+  const config: TriggerFishConfig = {
+    scheduler: {
+      trigger: {
+        classification_ceiling: "CONFIDENTIAL",
+      },
+    },
+  };
+  const result = buildSchedulerConfig(config, "/base", makeMockFactory());
+  assertEquals(result.trigger.classificationCeiling, "CONFIDENTIAL");
+});
+
+Deno.test("buildSchedulerConfig: trigger ceiling reads from YAML when explicitly set to RESTRICTED", () => {
+  const config: TriggerFishConfig = {
+    scheduler: {
+      trigger: {
+        classification_ceiling: "RESTRICTED",
+      },
+    },
+  };
+  const result = buildSchedulerConfig(config, "/base", makeMockFactory());
+  assertEquals(result.trigger.classificationCeiling, "RESTRICTED");
+});
+
+Deno.test("buildSchedulerConfig: trigger enabled defaults to true", () => {
+  const config: TriggerFishConfig = {};
+  const result = buildSchedulerConfig(config, "/base", makeMockFactory());
+  assertEquals(result.trigger.enabled, true);
+});
+
+Deno.test("buildSchedulerConfig: trigger interval defaults to 30 minutes", () => {
+  const config: TriggerFishConfig = {};
+  const result = buildSchedulerConfig(config, "/base", makeMockFactory());
+  assertEquals(result.trigger.intervalMinutes, 30);
+});

--- a/tests/google/classification_test.ts
+++ b/tests/google/classification_test.ts
@@ -166,7 +166,7 @@ function createContextWithTaint(
     tasks: createMinimalTasksService(),
     drive: createMinimalDriveService(),
     sheets: createMinimalSheetsService(),
-    sessionTaint: taint,
+    sessionTaint: () => taint,
     sourceSessionId: "test-session" as SessionId,
     classificationFloors: floors,
   };
@@ -176,17 +176,17 @@ function createContextWithTaint(
 
 Deno.test("classification: Google tool context carries session taint", () => {
   const ctx = createContextWithTaint("CONFIDENTIAL");
-  assertEquals(ctx.sessionTaint, "CONFIDENTIAL");
+  assertEquals(ctx.sessionTaint(), "CONFIDENTIAL");
 });
 
 Deno.test("classification: PUBLIC session has PUBLIC taint", () => {
   const ctx = createContextWithTaint("PUBLIC");
-  assertEquals(ctx.sessionTaint, "PUBLIC");
+  assertEquals(ctx.sessionTaint(), "PUBLIC");
 });
 
 Deno.test("classification: RESTRICTED session has RESTRICTED taint", () => {
   const ctx = createContextWithTaint("RESTRICTED");
-  assertEquals(ctx.sessionTaint, "RESTRICTED");
+  assertEquals(ctx.sessionTaint(), "RESTRICTED");
 });
 
 // ─── Test 2: Classification floors escalate taint ───────────────────────────
@@ -200,7 +200,7 @@ Deno.test("classification: per-service floors can escalate taint", () => {
   // Gmail floor is CONFIDENTIAL — accessing Gmail data should escalate
   // a PUBLIC session to at least CONFIDENTIAL
   const gmailFloor = ctx.classificationFloors?.["gmail"] ?? "PUBLIC";
-  const escalated = maxClassification(ctx.sessionTaint, gmailFloor);
+  const escalated = maxClassification(ctx.sessionTaint(), gmailFloor);
   assertEquals(escalated, "CONFIDENTIAL");
 });
 
@@ -210,7 +210,7 @@ Deno.test("classification: floor does not downgrade taint", () => {
   });
 
   const gmailFloor = ctx.classificationFloors?.["gmail"] ?? "PUBLIC";
-  const result = maxClassification(ctx.sessionTaint, gmailFloor);
+  const result = maxClassification(ctx.sessionTaint(), gmailFloor);
   // RESTRICTED is higher than INTERNAL — stays RESTRICTED
   assertEquals(result, "RESTRICTED");
 });

--- a/tests/google/integration_test.ts
+++ b/tests/google/integration_test.ts
@@ -291,7 +291,7 @@ Deno.test("integration: executor routes gmail_search end-to-end", async () => {
       tasks: createTasksService(apiClient),
       drive: createDriveService(apiClient),
       sheets: createSheetsService(apiClient),
-      sessionTaint: "INTERNAL" as ClassificationLevel,
+      sessionTaint: () => "INTERNAL" as ClassificationLevel,
       sourceSessionId: "integration-session" as SessionId,
     });
 

--- a/tests/google/tools_test.ts
+++ b/tests/google/tools_test.ts
@@ -178,7 +178,7 @@ function createMockContext(): GoogleToolContext {
     tasks: createMockTasksService(),
     drive: createMockDriveService(),
     sheets: createMockSheetsService(),
-    sessionTaint: "INTERNAL",
+    sessionTaint: () => "INTERNAL",
     sourceSessionId: "test-session" as SessionId,
   };
 }


### PR DESCRIPTION
Changes remaining from issue #96 plan:

- `GoogleToolContext.sessionTaint` changed from `ClassificationLevel` to `() => ClassificationLevel` so the executor always reads live taint, not a frozen PUBLIC snapshot
- `buildGoogleExecutor` updated to accept `() => ClassificationLevel` at both call sites (factory.ts and startup.ts)
- All Google tests updated to use the function form
- New `tests/gateway/factory_test.ts`: tests that `buildSchedulerConfig` defaults trigger ceiling to CONFIDENTIAL

Closes #96

Generated with [Claude Code](https://claude.ai/code)