### PR TITLE
[Phase 10] fix: isOwnerSession undefined defaults to false, not true

### DIFF
--- a/src/agent/orchestrator.ts
+++ b/src/agent/orchestrator.ts
@@ -366,7 +366,8 @@ export function createOrchestrator(config: OrchestratorConfig): Orchestrator {
     }
 
     // Identity context
-    const isOwner = config.isOwnerSession?.() ?? true;
+    // isOwner: undefined is always false — must be explicitly set (matches isTrigger pattern)
+    const isOwner = config.isOwnerSession?.() ?? false;
     hookInput.is_owner = isOwner;
     // isTrigger: undefined is always false — must be explicitly set
     const isTrigger = config.isTriggerSession?.() ?? false;


### PR DESCRIPTION
When isOwnerSession is undefined, the `?? true` default silently granted owner-level escalation and bypassed non-owner ceiling enforcement. Changed to `?? false` to match the correct isTriggerSession pattern.

Call sites audited: chat.ts already explicitly sets isOwnerSession; factory.ts trigger/scheduler sessions correctly omit it.

Fixes #100

Generated with [Claude Code](https://claude.ai/code)