### PR TITLE
[Phase 13] feat: add triggerfish tidepool url command and surface Tidepool URL at startup

### DIFF
--- a/src/cli/constants.ts
+++ b/src/cli/constants.ts
@@ -1,0 +1,13 @@
+/**
+ * CLI-facing port constants for the Triggerfish gateway components.
+ *
+ * Single source of truth for well-known port numbers referenced by CLI
+ * commands, startup output, and probe functions.
+ * @module
+ */
+
+/** Port that the Tidepool A2UI server listens on. */
+export const TIDEPOOL_PORT = 18790;
+
+/** Port that the Gateway WebSocket server listens on. */
+export const GATEWAY_PORT = 18789;

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -24,6 +24,7 @@ import {
   updateTriggerfish,
 } from "./daemon.ts";
 import { VERSION } from "./version.ts";
+import { TIDEPOOL_PORT } from "./constants.ts";
 import { Confirm } from "@cliffy/prompt";
 
 // Re-export config types and functions for backward-compatibility (tests and other modules import from here)
@@ -54,6 +55,7 @@ const KNOWN_COMMANDS = new Set([
   "config",
   "dive",
   "patrol",
+  "tidepool",
   "update",
   "help",
   "version",
@@ -160,6 +162,10 @@ export function parseCommand(
     const sub = positional[1];
     return { command, subcommand: sub, flags };
   }
+  if (command === "tidepool" && positional.length > 1) {
+    const sub = positional[1];
+    return { command, subcommand: sub, flags };
+  }
 
   return { command, flags };
 }
@@ -189,6 +195,7 @@ COMMANDS:
   status      Show daemon status
   logs        View daemon logs (--tail to follow)
   patrol      Run health diagnostics
+  tidepool    Tidepool A2UI controls
   update      Pull latest code, recompile, and restart
   help        Show this help message
   version     Show version information
@@ -208,6 +215,9 @@ CRON SUBCOMMANDS:
   cron add "<schedule>" <task>           Create a new cron job
   cron delete <job_id>                   Delete a cron job
   cron history <job_id>                  Show execution history
+
+TIDEPOOL SUBCOMMANDS:
+  tidepool url                           Print Tidepool A2UI URL (if running)
 
 INTEGRATIONS:
   connect google                         Authenticate with Google Workspace
@@ -236,6 +246,7 @@ EXAMPLES:
   triggerfish connect google                          # Link Google account
   triggerfish disconnect google                       # Remove Google account
   triggerfish patrol                                # Health check
+  triggerfish tidepool url                          # Show Tidepool A2UI URL
   triggerfish update                                # Update to latest version
 
 For more information, visit: https://trigger.fish/docs
@@ -478,6 +489,7 @@ async function runDaemonStart(): Promise<void> {
   const result = await installAndStartDaemon(Deno.execPath());
   if (result.ok) {
     console.log("✓ Daemon installed and started");
+    console.log(`  Tidepool: http://127.0.0.1:${TIDEPOOL_PORT} (available once daemon is ready)`);
   } else {
     console.log(`✗ ${result.message}`);
     Deno.exit(1);
@@ -607,6 +619,11 @@ async function main(): Promise<void> {
     case "logs":
       await runDaemonLogs(parsed.flags);
       break;
+    case "tidepool": {
+      const { runTidepool } = await import("./tidepool.ts");
+      await runTidepool(parsed.subcommand, parsed.flags);
+      break;
+    }
     case "update":
       await runUpdate();
       break;

--- a/src/cli/tidepool.ts
+++ b/src/cli/tidepool.ts
@@ -1,0 +1,64 @@
+/**
+ * Tidepool CLI command handler.
+ *
+ * Provides the `triggerfish tidepool url` subcommand.
+ * Tidepool is an embedded component of the gateway process and cannot be
+ * started or stopped independently — only `url` is a valid subcommand.
+ * @module
+ */
+
+import { TIDEPOOL_PORT } from "./constants.ts";
+
+/**
+ * Returns the URL at which the Tidepool A2UI server is expected to listen.
+ */
+export function getTidepoolUrl(): string {
+  return `http://127.0.0.1:${TIDEPOOL_PORT}`;
+}
+
+/**
+ * Probes the Tidepool HTTP endpoint to check if it is currently running.
+ *
+ * @returns `true` if the server responded successfully, `false` otherwise.
+ */
+export async function probeTidepool(): Promise<boolean> {
+  try {
+    const response = await fetch(getTidepoolUrl(), {
+      signal: AbortSignal.timeout(2000),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Handle the `triggerfish tidepool` command.
+ *
+ * Supported subcommands:
+ * - `url` — probe port and print the Tidepool URL if live
+ * - (none) — same as `url`
+ *
+ * @param subcommand - The subcommand string parsed from the CLI args.
+ * @param _flags     - Parsed flags (unused; reserved for future options).
+ */
+export async function runTidepool(
+  subcommand: string | undefined,
+  _flags: Readonly<Record<string, boolean | string>>,
+): Promise<void> {
+  if (subcommand === undefined || subcommand === "url") {
+    const alive = await probeTidepool();
+    if (alive) {
+      console.log(`  Tidepool: ${getTidepoolUrl()}`);
+    } else {
+      console.log("✗ Tidepool is not running.");
+      console.log("  Run 'triggerfish run' or 'triggerfish start' to launch the gateway.");
+    }
+    return;
+  }
+
+  // Unrecognised subcommand
+  console.log(`Unknown tidepool subcommand: ${subcommand}`);
+  console.log("Valid subcommand: url");
+  console.log("  triggerfish tidepool url   # Print Tidepool URL if running");
+}

--- a/src/gateway/startup.ts
+++ b/src/gateway/startup.ts
@@ -152,6 +152,7 @@ import {
 import { logDir as resolveLogDir } from "../cli/daemon.ts";
 import { loadConfigWithSecrets } from "../core/config.ts";
 import { resolveBaseDir, resolveConfigPath } from "../cli/paths.ts";
+import { TIDEPOOL_PORT } from "../cli/constants.ts";
 import { buildSkillsSystemPrompt, buildTriggersSystemPrompt } from "../skills/prompts.ts";
 import {
   buildGoogleExecutor,
@@ -854,10 +855,10 @@ export async function runStart(): Promise<void> {
   // Start Tidepool + Gateway EARLY so `triggerfish chat` can connect
   // while channels and MCP servers finish wiring in the background.
   const tidepoolHost = createA2UIHost({ chatSession: tidepoolChatSession });
-  const tidepoolPort = 18790;
-  await tidepoolHost.start(tidepoolPort);
+  await tidepoolHost.start(TIDEPOOL_PORT);
   tidepoolTools = createTidePoolTools(tidepoolHost);
-  log.info(`Tidepool listening on http://127.0.0.1:${tidepoolPort}`);
+  log.info(`Tidepool listening on http://127.0.0.1:${TIDEPOOL_PORT}`);
+  console.log(`  Tidepool: http://127.0.0.1:${TIDEPOOL_PORT}`);
   // Wire up MCP status indicator for Tidepool
   _mcpTidepoolRef = tidepoolHost;
 

--- a/tests/cli/tidepool_test.ts
+++ b/tests/cli/tidepool_test.ts
@@ -1,0 +1,58 @@
+/**
+ * Tests for the `triggerfish tidepool` CLI command and related constants.
+ */
+import { assertEquals } from "@std/assert";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+Deno.test("tidepool: TIDEPOOL_PORT is 18790", async () => {
+  const { TIDEPOOL_PORT } = await import("../../src/cli/constants.ts");
+  assertEquals(TIDEPOOL_PORT, 18790);
+});
+
+Deno.test("tidepool: GATEWAY_PORT is 18789", async () => {
+  const { GATEWAY_PORT } = await import("../../src/cli/constants.ts");
+  assertEquals(GATEWAY_PORT, 18789);
+});
+
+// ─── getTidepoolUrl ───────────────────────────────────────────────────────────
+
+Deno.test("tidepool: getTidepoolUrl returns expected URL", async () => {
+  const { getTidepoolUrl } = await import("../../src/cli/tidepool.ts");
+  assertEquals(getTidepoolUrl(), "http://127.0.0.1:18790");
+});
+
+// ─── parseCommand for tidepool ────────────────────────────────────────────────
+
+Deno.test({
+  name: "CLI: parses 'tidepool' command (no subcommand)",
+  sanitizeResources: false,
+  fn: async () => {
+    const { parseCommand } = await import("../../src/cli/main.ts");
+    const cmd = parseCommand(["tidepool"]);
+    assertEquals(cmd.command, "tidepool");
+    assertEquals(cmd.subcommand, undefined);
+  },
+});
+
+Deno.test({
+  name: "CLI: parses 'tidepool url' subcommand",
+  sanitizeResources: false,
+  fn: async () => {
+    const { parseCommand } = await import("../../src/cli/main.ts");
+    const cmd = parseCommand(["tidepool", "url"]);
+    assertEquals(cmd.command, "tidepool");
+    assertEquals(cmd.subcommand, "url");
+  },
+});
+
+Deno.test({
+  name: "CLI: parses 'tidepool unknown' subcommand (rejected at runtime)",
+  sanitizeResources: false,
+  fn: async () => {
+    const { parseCommand } = await import("../../src/cli/main.ts");
+    const cmd = parseCommand(["tidepool", "unknown"]);
+    assertEquals(cmd.command, "tidepool");
+    assertEquals(cmd.subcommand, "unknown");
+  },
+});


### PR DESCRIPTION
Implements `triggerfish tidepool url` subcommand and restores Tidepool URL display at daemon startup.

Closes #98

Generated with [Claude Code](https://claude.ai/code)