### PR TITLE
[Phase 17] feat: add token usage logging to trigger runs

### DIFF
--- a/src/agent/orchestrator.ts
+++ b/src/agent/orchestrator.ts
@@ -200,6 +200,11 @@ export interface ProcessMessageOptions {
 /** Successful response from message processing. */
 export interface ProcessMessageResult {
   readonly response: string;
+  /** Cumulative token usage across all LLM calls made during this message turn. */
+  readonly tokenUsage: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+  };
 }
 
 /** A conversation history entry. */
@@ -696,6 +701,8 @@ export function createOrchestrator(config: OrchestratorConfig): Orchestrator {
     let iterations = 0;
     let emptyNudgeCount = 0; // Track empty-response recovery attempts
     const MAX_EMPTY_NUDGES = 2;
+    let totalInputTokens = 0;
+    let totalOutputTokens = 0;
     while (iterations < MAX_TOOL_ITERATIONS) {
       iterations++;
 
@@ -757,6 +764,10 @@ export function createOrchestrator(config: OrchestratorConfig): Orchestrator {
       const completion = await provider.complete(messages, nativeTools, {
         ...(signal ? { signal } : {}),
       });
+
+      // Accumulate token usage across all iterations in this turn.
+      totalInputTokens += completion.usage.inputTokens;
+      totalOutputTokens += completion.usage.outputTokens;
 
       // Close the race window: if the signal was aborted while the LLM was finishing,
       // treat the response as cancelled rather than emitting it.
@@ -880,7 +891,10 @@ export function createOrchestrator(config: OrchestratorConfig): Orchestrator {
 
         return {
           ok: true,
-          value: { response: responseText },
+          value: {
+            response: responseText,
+            tokenUsage: { inputTokens: totalInputTokens, outputTokens: totalOutputTokens },
+          },
         };
       }
 

--- a/src/scheduler/service.ts
+++ b/src/scheduler/service.ts
@@ -200,6 +200,10 @@ export function createSchedulerService(
         targetClassification: job.classificationCeiling,
       });
 
+      if (result.ok) {
+        const { inputTokens, outputTokens } = result.value.tokenUsage;
+        log.info(`[cron:${job.id}] Token usage — input: ${inputTokens}, output: ${outputTokens}, total: ${inputTokens + outputTokens}`);
+      }
       await deliverOutput(result, session.taint, `cron:${job.id}`);
 
       cronManager.recordExecution({
@@ -258,6 +262,10 @@ export function createSchedulerService(
       });
 
       log.info(`Trigger completed (ok: ${result.ok}, taint: ${session.taint})`);
+      if (result.ok) {
+        const { inputTokens, outputTokens } = result.value.tokenUsage;
+        log.info(`[trigger] Token usage — input: ${inputTokens}, output: ${outputTokens}, total: ${inputTokens + outputTokens}`);
+      }
       await deliverOutput(result, session.taint, "trigger");
     } catch (err) {
       log.error(`Trigger callback failed: ${err instanceof Error ? err.message : String(err)}`);
@@ -343,6 +351,10 @@ export function createSchedulerService(
           targetClassification: source.classification,
         });
 
+        if (result.ok) {
+          const { inputTokens, outputTokens } = result.value.tokenUsage;
+          log.info(`[webhook:${sourceId}] Token usage — input: ${inputTokens}, output: ${outputTokens}, total: ${inputTokens + outputTokens}`);
+        }
         await deliverOutput(result, session.taint, `webhook:${sourceId}`);
       } catch {
         // Webhook processing failures are logged but don't fail the HTTP response

--- a/tests/scheduler/scheduler_test.ts
+++ b/tests/scheduler/scheduler_test.ts
@@ -264,7 +264,7 @@ function createMockFactory(): {
       return {
         orchestrator: {
           // deno-lint-ignore require-await
-          processMessage: async () => ({ ok: true as const, value: { response: "done" } }),
+          processMessage: async () => ({ ok: true as const, value: { response: "done", tokenUsage: { inputTokens: 100, outputTokens: 50 } } }),
         // deno-lint-ignore no-explicit-any
         } as any,
         session: {
@@ -613,6 +613,56 @@ Deno.test("OrchestratorFactory: create() works without options (cron/subagent)",
   await factory.create("cron");
   assertEquals(options.length, 1);
   assertEquals(options[0], undefined);
+});
+
+// ── Token usage logging ──────────────────────────────────────────────
+
+/**
+ * Create a factory whose orchestrator returns a specific tokenUsage.
+ * Used to verify the scheduler correctly handles and logs token data.
+ */
+function createTokenAwareMockFactory(tokenUsage: { inputTokens: number; outputTokens: number }): {
+  factory: OrchestratorFactory;
+  calls: string[];
+} {
+  const calls: string[] = [];
+  const factory: OrchestratorFactory = {
+    // deno-lint-ignore require-await
+    async create(channelId: string) {
+      calls.push(channelId);
+      return {
+        orchestrator: {
+          // deno-lint-ignore require-await
+          processMessage: async () => ({
+            ok: true as const,
+            value: { response: "token test response", tokenUsage },
+          }),
+        // deno-lint-ignore no-explicit-any
+        } as any,
+        session: {
+          id: "mock-session",
+          taint: "PUBLIC",
+          createdAt: new Date(),
+          lastActivityAt: new Date(),
+          messages: [],
+          context: {},
+        // deno-lint-ignore no-explicit-any
+        } as any,
+      };
+    },
+  };
+  return { factory, calls };
+}
+
+Deno.test("SchedulerService: token usage from processMessage is logged without error (webhook)", async () => {
+  const { factory } = createTokenAwareMockFactory({ inputTokens: 1234, outputTokens: 567 });
+  const svc = createSchedulerService(createTestConfig(factory));
+
+  const body = '{"event":"push","data":{"ref":"main"}}';
+  const sig = await computeHmac(body, "gh-secret");
+  // Should succeed — the token logging code path runs without throwing
+  const result = await svc.handleWebhookRequest("github", body, sig);
+  assertEquals(result.ok, true);
 });
 
 Deno.test("SchedulerService: trigger callback passes isTrigger=true and ceiling to factory", async () => {


### PR DESCRIPTION
Accumulate inputTokens + outputTokens from every LLM provider.complete() call across all iterations in a processMessage turn. Surface the totals in ProcessMessageResult.tokenUsage and log them at INFO level in the scheduler service after each trigger, cron, and webhook execution completes.

Closes #110

Generated with [Claude Code](https://claude.ai/code)