### PR TITLE
[Phase 14] fix: wire CLI WebSocket and Tidepool into notification fan-out

### DIFF
--- a/src/channels/cli/chat.ts
+++ b/src/channels/cli/chat.ts
@@ -168,6 +168,18 @@ export async function runChat(): Promise<void> {
         return;
       }
 
+      if (evt.type === "notification") {
+        if (isTty) {
+          screen.writeOutput(`  \x1b[33m⚡ [trigger]\x1b[0m ${evt.message}`);
+          screen.writeOutput("");
+          screen.redrawInput(editor);
+        } else {
+          console.log(`\n  [trigger] ${evt.message}\n`);
+          renderPrompt();
+        }
+        return;
+      }
+
       if (evt.type === "secret_prompt") {
         if (isTty) {
           // Enter password mode — capture keystrokes for the secret value

--- a/src/gateway/chat.ts
+++ b/src/gateway/chat.ts
@@ -105,6 +105,8 @@ export type ChatEvent =
     /** Optional human-readable hint for the user. */
     readonly hint?: string;
   }
+  /** Server → client: a trigger/scheduler notification delivered to the owner. */
+  | { readonly type: "notification"; readonly message: string }
   /** Server → client: cancel acknowledged — the in-flight request was aborted. */
   | { readonly type: "cancelled" };
 

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -48,6 +48,10 @@ export interface GatewayServer {
    * Used for push notifications such as MCP server status changes.
    */
   broadcastChatEvent(event: Record<string, unknown>): void;
+  /**
+   * Broadcast a trigger/scheduler notification to all connected /chat WebSocket clients.
+   */
+  broadcastNotification(message: string): void;
 }
 
 /** JSON-RPC 2.0 request. */
@@ -378,6 +382,19 @@ export function createGatewayServer(
   return {
     broadcastChatEvent(event: Record<string, unknown>): void {
       const json = JSON.stringify(event);
+      for (const ws of chatSockets) {
+        try {
+          if (ws.readyState === WebSocket.OPEN) {
+            ws.send(json);
+          }
+        } catch {
+          chatSockets.delete(ws);
+        }
+      }
+    },
+
+    broadcastNotification(message: string): void {
+      const json = JSON.stringify({ type: "notification", message });
       for (const ws of chatSockets) {
         try {
           if (ws.readyState === WebSocket.OPEN) {

--- a/src/gateway/startup.ts
+++ b/src/gateway/startup.ts
@@ -861,6 +861,11 @@ export async function runStart(): Promise<void> {
   console.log(`  Tidepool: http://127.0.0.1:${TIDEPOOL_PORT}`);
   // Wire up MCP status indicator for Tidepool
   _mcpTidepoolRef = tidepoolHost;
+  // Register Tidepool for trigger/scheduler notification delivery
+  notificationService.registerChannel({
+    name: "tidepool",
+    send: async (msg) => { tidepoolHost.broadcastNotification(msg); },
+  });
 
   // Wrap the chatSession for CLI WebSocket clients so that secret_save prompts
   // are sent over the WebSocket (just like the Tidepool variant) instead of
@@ -890,6 +895,11 @@ export async function runStart(): Promise<void> {
   log.info(`Gateway listening on ${addr.hostname}:${addr.port}`);
   // Wire gateway server for MCP status broadcasting
   _mcpGatewayServerRef = server;
+  // Register CLI WebSocket for trigger/scheduler notification delivery
+  notificationService.registerChannel({
+    name: "cli-websocket",
+    send: async (msg) => { server.broadcastNotification(msg); },
+  });
 
   // --- Telegram channel wiring ---
   const telegramConfig = config.channels?.telegram as {

--- a/src/tidepool/host.ts
+++ b/src/tidepool/host.ts
@@ -93,6 +93,10 @@ export interface A2UIHost {
    * @param configured - Total number of configured (non-disabled) MCP servers
    */
   broadcastMcpStatus(connected: number, configured: number): void;
+  /**
+   * Broadcast a trigger/scheduler notification to all connected Tidepool clients.
+   */
+  broadcastNotification(message: string): void;
   /** The number of currently connected WebSocket clients. */
   readonly connections: number;
 }
@@ -319,6 +323,11 @@ export function createA2UIHost(options?: A2UIHostOptions): A2UIHost {
       lastMcpConnected = connected;
       lastMcpConfigured = configured;
       const json = JSON.stringify({ type: "mcp_status", connected, configured });
+      sendToAll(json);
+    },
+
+    broadcastNotification(message: string): void {
+      const json = JSON.stringify({ type: "notification", message });
       sendToAll(json);
     },
 

--- a/tests/gateway/notifications_test.ts
+++ b/tests/gateway/notifications_test.ts
@@ -148,6 +148,25 @@ Deno.test("deliver: fans out to multiple channels", async () => {
   assertEquals((await svc.getPending(USER)).length, 0);
 });
 
+Deno.test("deliver: cli-websocket channel receives trigger notifications via fan-out", async () => {
+  const storage = createMemoryStorage();
+  const svc = createNotificationService(storage);
+  const received: string[] = [];
+
+  svc.registerChannel({
+    name: "cli-websocket",
+    // deno-lint-ignore require-await
+    send: async (msg) => { received.push(msg); },
+  });
+
+  await svc.deliver({ userId: USER, message: "trigger fired", priority: "normal" });
+
+  assertEquals(received.length, 1);
+  assertEquals(received[0], "trigger fired");
+  // Auto-acknowledged after successful delivery
+  assertEquals((await svc.getPending(USER)).length, 0);
+});
+
 // ── flushPending ──────────────────────────────────────────────────────
 
 Deno.test("flushPending: delivers queued notifications when channel becomes available", async () => {


### PR DESCRIPTION
Trigger messages were only reaching Telegram because CLI WebSocket and Tidepool clients were never registered as notification delivery channels.

## Changes

- Add `notification` event type to `ChatEvent` union
- Add `broadcastNotification()` to `GatewayServer` interface + implementation
- Add `broadcastNotification()` to `A2UIHost` interface + implementation
- Register `cli-websocket` and `tidepool` channels in `startup.ts`
- Handle `notification` events in CLI WebSocket chat client
- Add test for cli-websocket fan-out

Closes #109

Generated with [Claude Code](https://claude.ai/code)