### PR TITLE
[Phase 17] feat: add triggerfish run-triggers debug command

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -49,6 +49,7 @@ const KNOWN_COMMANDS = new Set([
   "cron",
   "disconnect",
   "run",
+  "run-triggers",
   "start",
   "stop",
   "status",
@@ -625,6 +626,11 @@ async function main(): Promise<void> {
     case "run": {
       const { runStart } = await import("../gateway/startup.ts");
       await runStart();
+      break;
+    }
+    case "run-triggers": {
+      const { runTriggers } = await import("./run_triggers.ts");
+      await runTriggers();
       break;
     }
     case "start":

--- a/src/cli/run_triggers.ts
+++ b/src/cli/run_triggers.ts
@@ -1,0 +1,50 @@
+/**
+ * CLI handler for `triggerfish run-triggers`.
+ *
+ * Forces an immediate trigger run on the running gateway by sending a
+ * POST request to the debug endpoint. Intended for debugging only.
+ *
+ * @module
+ */
+
+/** Gateway port (must match server.ts default). */
+const GATEWAY_PORT = 18789;
+
+/**
+ * Force an immediate trigger run via the running gateway.
+ *
+ * Sends POST /debug/run-triggers to the local gateway. Requires the
+ * gateway daemon to be running. The trigger runs asynchronously inside
+ * the daemon; this command returns as soon as the gateway acknowledges
+ * the request.
+ */
+export async function runTriggers(): Promise<void> {
+  const url = `http://127.0.0.1:${GATEWAY_PORT}/debug/run-triggers`;
+
+  let response: Response | undefined;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      signal: AbortSignal.timeout(5000),
+    });
+  } catch {
+    console.log("Error: Gateway is not running.");
+    console.log("Start it first with: triggerfish start");
+    Deno.exit(1);
+    return;
+  }
+
+  if (response.ok) {
+    console.log("Trigger fired. Check daemon logs for output.");
+    return;
+  }
+
+  let body = "";
+  try {
+    body = await response.text();
+  } catch {
+    // ignore
+  }
+  console.log(`Error: Gateway returned ${response.status}${body ? ` — ${body}` : ""}`);
+  Deno.exit(1);
+}

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -475,6 +475,26 @@ export function createGatewayServer(
             return handleWebhookHttp(request, url, schedulerService);
           }
 
+          // Debug: force an immediate trigger run
+          if (
+            request.method === "POST" &&
+            url.pathname === "/debug/run-triggers"
+          ) {
+            if (!schedulerService) {
+              return new Response(
+                JSON.stringify({ error: "Scheduler not configured" }),
+                { status: 503, headers: { "content-type": "application/json" } },
+              );
+            }
+            schedulerService.runTrigger().catch(() => {
+              // fire-and-forget; errors are logged inside runTrigger
+            });
+            return new Response(
+              JSON.stringify({ ok: true, message: "Trigger fired" }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            );
+          }
+
           // Default HTTP response
           return new Response("Triggerfish Gateway", { status: 200 });
         },

--- a/src/scheduler/service.ts
+++ b/src/scheduler/service.ts
@@ -112,6 +112,11 @@ export interface SchedulerService {
     body: string,
     signature: string,
   ): Promise<Result<void, string>>;
+  /**
+   * Force an immediate trigger run, bypassing the interval timer.
+   * Used for debugging via `triggerfish run-triggers`.
+   */
+  runTrigger(): Promise<void>;
 }
 
 /**
@@ -304,6 +309,11 @@ export function createSchedulerService(
         trigger.stop();
         trigger = undefined;
       }
+    },
+
+    async runTrigger(): Promise<void> {
+      log.info("Forced trigger run requested");
+      await triggerCallback();
     },
 
     async handleWebhookRequest(

--- a/tests/cli/main_test.ts
+++ b/tests/cli/main_test.ts
@@ -114,6 +114,20 @@ Deno.test("CLI: parses 'config remove-channel' without type", async () => {
   assertEquals(cmd.flags.channel_type, undefined);
 });
 
+Deno.test("CLI: parses 'run-triggers' command", async () => {
+  const { parseCommand } = await import("../../src/cli/main.ts");
+  const cmd = parseCommand(["run-triggers"]);
+  assertEquals(cmd.command, "run-triggers");
+});
+
+Deno.test("CLI: 'run-triggers' does not fall through to help (hidden debug command)", async () => {
+  // run-triggers should parse as itself (not fall through to "help"),
+  // confirming it is a known command even though it is absent from showHelp().
+  const { parseCommand } = await import("../../src/cli/main.ts");
+  const cmd = parseCommand(["run-triggers"]);
+  assertEquals(cmd.command, "run-triggers");
+});
+
 Deno.test("CLI: unknown command returns help suggestion", async () => {
   const { parseCommand } = await import("../../src/cli/main.ts");
   const cmd = parseCommand(["nonexistent"]);

--- a/tests/gateway/server_test.ts
+++ b/tests/gateway/server_test.ts
@@ -23,6 +23,55 @@ Deno.test("GatewayServer: starts on configurable port", async () => {
   }
 });
 
+Deno.test("GatewayServer: POST /debug/run-triggers returns 503 when no scheduler", async () => {
+  const server = createGatewayServer({ port: 0 });
+  try {
+    const addr = await server.start();
+    const response = await fetch(
+      `http://127.0.0.1:${addr.port}/debug/run-triggers`,
+      { method: "POST" },
+    );
+    assertEquals(response.status, 503);
+    const body = await response.json();
+    assertEquals(body.error, "Scheduler not configured");
+  } finally {
+    await server.stop();
+  }
+});
+
+Deno.test("GatewayServer: POST /debug/run-triggers fires trigger when scheduler present", async () => {
+  // Minimal mock scheduler service
+  let runTriggerCalled = false;
+  const mockScheduler = {
+    start() {},
+    stop() {},
+    cronManager: { list: () => [], create: () => ({ ok: true as const, value: {} as never }), delete: () => ({ ok: true as const, value: undefined }), history: () => [], recordExecution: () => {} },
+    webhookHandler: { on: () => {}, handle: async () => {} },
+    // deno-lint-ignore require-await
+    async handleWebhookRequest() { return { ok: false as const, error: "unused" }; },
+    // deno-lint-ignore require-await
+    async runTrigger() { runTriggerCalled = true; },
+  };
+
+  // deno-lint-ignore no-explicit-any
+  const server = createGatewayServer({ port: 0, schedulerService: mockScheduler as any });
+  try {
+    const addr = await server.start();
+    const response = await fetch(
+      `http://127.0.0.1:${addr.port}/debug/run-triggers`,
+      { method: "POST" },
+    );
+    assertEquals(response.status, 200);
+    const body = await response.json();
+    assertEquals(body.ok, true);
+    // Give the fire-and-forget a moment to execute
+    await new Promise((r) => setTimeout(r, 20));
+    assertEquals(runTriggerCalled, true);
+  } finally {
+    await server.stop();
+  }
+});
+
 // --- Enhanced session manager ---
 
 Deno.test("EnhancedSessionManager: sessions_list returns active sessions", async () => {

--- a/tests/scheduler/scheduler_test.ts
+++ b/tests/scheduler/scheduler_test.ts
@@ -665,6 +665,18 @@ Deno.test("SchedulerService: token usage from processMessage is logged without e
   assertEquals(result.ok, true);
 });
 
+Deno.test("SchedulerService: runTrigger() fires trigger callback immediately", async () => {
+  const { factory, calls, options } = createMockFactory();
+  const svc = createSchedulerService(createTestConfig(factory));
+
+  await svc.runTrigger();
+
+  // The trigger callback should have created exactly one orchestrator session
+  assertEquals(calls.length, 1);
+  assertEquals(calls[0], "trigger");
+  assertEquals(options[0]?.isTrigger, true);
+});
+
 Deno.test("SchedulerService: trigger callback passes isTrigger=true and ceiling to factory", async () => {
   const { factory, options } = createMockFactory();
   const config: SchedulerServiceConfig = {


### PR DESCRIPTION
Adds a hidden `run-triggers` CLI command that forces an immediate trigger run on the running daemon without waiting for the configured interval.

**Changes:**
- `SchedulerService`: add `runTrigger()` method to interface and implementation
- `GatewayServer`: add `POST /debug/run-triggers` HTTP endpoint
- CLI: register `run-triggers` command (hidden from help text)
- `src/cli/run_triggers.ts`: POST to daemon debug endpoint, print result

Closes #114

Generated with [Claude Code](https://claude.ai/code)