### PR TITLE
[Phase 17] feat: interval_minutes: 0 disables triggers

### DIFF
--- a/config/triggerfish.example.yaml
+++ b/config/triggerfish.example.yaml
@@ -77,7 +77,13 @@ web:
 
 # scheduler:
 #   trigger:
-#     enabled: true
+#     enabled: true                  # Set to false to disable periodic agent wakeups
+#     interval_minutes: 30           # How often the agent wakes up (default: 30).
+#                                    # Set to 0 to disable triggers without removing config.
+#     quiet_hours:
+#       start: 22                    # Don't wake between 10 PM …
+#       end: 7                       # … and 7 AM
+#     classification_ceiling: CONFIDENTIAL  # Max taint level for trigger sessions
 #   webhooks:
 #     sources:
 #       my-webhook:

--- a/docs/features/cron-and-triggers.md
+++ b/docs/features/cron-and-triggers.md
@@ -102,16 +102,25 @@ Trigger timing and constraints are set in `triggerfish.yaml`:
 ```yaml
 scheduler:
   trigger:
-    interval: 30m              # Check every 30 minutes
-    classification: INTERNAL   # Max taint ceiling
-    quiet_hours: "22:00-07:00" # Don't wake during quiet hours
+    enabled: true              # Set to false to disable triggers (default: true)
+    interval_minutes: 30       # Check every 30 minutes (default: 30)
+                               # Set to 0 to disable triggers without removing config
+    classification_ceiling: CONFIDENTIAL  # Max taint ceiling (default: CONFIDENTIAL)
+    quiet_hours:
+      start: 22                # Don't wake between 10 PM ...
+      end: 7                   # ... and 7 AM
 ```
 
 | Setting | Description |
 |---------|-------------|
-| `interval` | How often the agent wakes up to check triggers |
-| `classification` | Maximum classification level the trigger session can reach |
-| `quiet_hours` | Time range during which triggers are suppressed |
+| `enabled` | Whether periodic trigger wakeups are active. Set to `false` to disable. |
+| `interval_minutes` | How often (in minutes) the agent wakes up to check triggers. Default: `30`. Set to `0` to disable triggers without removing the config block. |
+| `classification_ceiling` | Maximum classification level the trigger session can reach. Default: `CONFIDENTIAL`. |
+| `quiet_hours.start` / `quiet_hours.end` | Hour range (24h clock) during which triggers are suppressed. |
+
+::: tip
+To temporarily disable triggers, set `interval_minutes: 0`. This is equivalent to `enabled: false` and lets you keep your other trigger settings in place so you can re-enable easily.
+:::
 
 ### Trigger Execution
 

--- a/src/gateway/factory.ts
+++ b/src/gateway/factory.ts
@@ -452,7 +452,8 @@ export function buildSchedulerConfig(
     orchestratorFactory: factory,
     triggerMdPath: join(baseDir, "TRIGGER.md"),
     trigger: {
-      enabled: sched?.trigger?.enabled ?? true,
+      // interval_minutes: 0 disables triggers without requiring the enabled flag
+      enabled: (sched?.trigger?.enabled ?? true) && (sched?.trigger?.interval_minutes ?? 30) !== 0,
       intervalMinutes: sched?.trigger?.interval_minutes ?? 30,
       quietHours: sched?.trigger?.quiet_hours
         ? {

--- a/tests/gateway/factory_test.ts
+++ b/tests/gateway/factory_test.ts
@@ -76,3 +76,29 @@ Deno.test("buildSchedulerConfig: trigger interval defaults to 30 minutes", () =>
   const result = buildSchedulerConfig(config, "/base", makeMockFactory());
   assertEquals(result.trigger.intervalMinutes, 30);
 });
+
+Deno.test("buildSchedulerConfig: interval_minutes 0 disables triggers", () => {
+  const config: TriggerFishConfig = {
+    scheduler: {
+      trigger: {
+        interval_minutes: 0,
+      },
+    },
+  };
+  const result = buildSchedulerConfig(config, "/base", makeMockFactory());
+  assertEquals(result.trigger.enabled, false);
+  assertEquals(result.trigger.intervalMinutes, 0);
+});
+
+Deno.test("buildSchedulerConfig: interval_minutes 0 disables triggers even when enabled is true", () => {
+  const config: TriggerFishConfig = {
+    scheduler: {
+      trigger: {
+        enabled: true,
+        interval_minutes: 0,
+      },
+    },
+  };
+  const result = buildSchedulerConfig(config, "/base", makeMockFactory());
+  assertEquals(result.trigger.enabled, false);
+});


### PR DESCRIPTION
Implements #113 — config option to control/disable triggers.

- `interval_minutes: 0` disables triggers (single-knob shorthand, overrides `enabled: true`)
- Default behavior unchanged (30-minute interval, enabled by default)
- Two new tests for the zero-disables behavior
- Example config updated to expose `interval_minutes`, `quiet_hours`, and `classification_ceiling`
- Docs fixed: wrong key names corrected and `interval_minutes: 0` documented

Generated with [Claude Code](https://claude.ai/code)