### PR TITLE
fix: improve maps skill discoverability and web_fetch parameter clarity

### DIFF
--- a/skills/bundled/maps/SKILL.md
+++ b/skills/bundled/maps/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: maps
 description: >
-  Geocode addresses and get directions using web_fetch.
+  Geocode addresses and get turn-by-turn directions or driving/walking distances
+  between any two locations (addresses, cities, ZIP codes, coordinates).
   Uses Nominatim (OpenStreetMap) and OSRM — no API key required.
 classification_ceiling: PUBLIC
 requires_tools:
@@ -13,37 +14,61 @@ network_domains:
 
 # Maps & Directions
 
-Geocode addresses and get directions using `web_fetch`. Nominatim and OSRM are free, open APIs.
+Use this skill for tasks like:
+- "Get directions from A to B"
+- "How far is X from Y?" / "Distance between two cities/addresses/ZIP codes"
+- "What are the coordinates of [address]?"
+- "What address is at [lat, lon]?"
+- "How long does it take to drive/walk from A to B?"
+
+All API calls return JSON — use `mode: "raw"` with `web_fetch`.
 
 ## Geocoding
 
-### Forward (Address → Coordinates)
+### Forward (Address / City / ZIP → Coordinates)
 ```
-web_fetch: { url: "https://nominatim.openstreetmap.org/search?q=1600+Pennsylvania+Ave+Washington+DC&format=json&limit=1" }
+web_fetch: { url: "https://nominatim.openstreetmap.org/search?q=1600+Pennsylvania+Ave+Washington+DC&format=json&limit=3", mode: "raw" }
 ```
-Returns JSON with `lat`, `lon`, `display_name`.
+Returns JSON array. Each result has `lat`, `lon`, `display_name`. Use the first result or ask the user if ambiguous.
+
+URL-encode the address: replace spaces with `+`, commas with `%2C`.
 
 ### Reverse (Coordinates → Address)
 ```
-web_fetch: { url: "https://nominatim.openstreetmap.org/reverse?lat=38.8977&lon=-77.0365&format=json" }
+web_fetch: { url: "https://nominatim.openstreetmap.org/reverse?lat=38.8977&lon=-77.0365&format=json", mode: "raw" }
 ```
 
-## Directions
+## Directions & Distance
+
+Always geocode both endpoints first to get coordinates, then call OSRM:
 
 ```
-web_fetch: { url: "https://router.project-osrm.org/route/v1/driving/-122.4194,37.7749;-73.9857,40.7484?overview=full&steps=true" }
+web_fetch: { url: "https://router.project-osrm.org/route/v1/driving/{lon1},{lat1};{lon2},{lat2}?overview=false&steps=true", mode: "raw" }
 ```
+
+**Important:** OSRM uses `{longitude},{latitude}` order (lon first, lat second).
 
 Format: `/route/v1/{mode}/{lon1},{lat1};{lon2},{lat2}`
 Modes: `driving`, `walking`, `cycling`
 
-Response: `routes[0].distance` (meters), `routes[0].duration` (seconds), `routes[0].legs[0].steps` (turn-by-turn)
+Response fields:
+- `routes[0].distance` — total distance in **meters** → convert to miles (÷ 1609.34) or km (÷ 1000)
+- `routes[0].duration` — total time in **seconds** → convert to minutes/hours
+- `routes[0].legs[0].steps` — turn-by-turn directions
 
-Multi-stop: chain coordinates with `;`
+Multi-stop route: chain coordinates with `;` — e.g. `lon1,lat1;lon2,lat2;lon3,lat3`
+
+## Step-by-Step Workflow
+
+1. Geocode the origin → get `(lat1, lon1)`
+2. Geocode the destination → get `(lat2, lon2)`
+3. Call OSRM with `lon1,lat1;lon2,lat2` (lon first!)
+4. Extract distance and duration; convert units
+5. Present result to user (e.g. "142 miles, ~2 hr 18 min driving")
 
 ## Key Behaviors
 - Always geocode first, then route
 - Convert meters→miles/km and seconds→minutes/hours
-- If ambiguous location, show top 3 and ask user
+- If location is ambiguous (multiple results), show top 3 and ask the user
 - PUBLIC classification
-- Max 1 req/sec to Nominatim, 5 routing req/min to OSRM
+- Rate limits: max 1 req/sec to Nominatim, 5 routing req/min to OSRM

--- a/src/skills/prompts.ts
+++ b/src/skills/prompts.ts
@@ -22,13 +22,17 @@ export function buildSkillsSystemPrompt(skills: readonly Skill[]): string {
 
   return `## Available Skills
 
-You have the following skills available. To use a skill, call read_skill with the skill name and type for detailed instructions.
+Skills extend your capabilities for specific domains. **Skills are NOT tools you call directly.** To use a skill you MUST:
+1. Call \`read_skill\` with the skill's name and type to load its instructions.
+2. Follow those instructions using the standard tools (e.g. \`web_fetch\`).
+
+Skipping \`read_skill\` means you won't have the API endpoints, parameters, or steps needed to complete the task.
 
 | Skill | Description | Type |
 |-------|-------------|------|
 ${rows}
 
-When a task matches a skill, use read_skill to load it for detailed guidance before proceeding.`;
+**Rule:** Whenever a user's request matches a skill above, call \`read_skill\` first — before taking any other action.`;
 }
 
 /** Build a system prompt section about TRIGGER.md awareness. */

--- a/src/web/tools.ts
+++ b/src/web/tools.ts
@@ -42,13 +42,14 @@ export function getWebToolDefinitions(): readonly ToolDefinition[] {
       parameters: {
         url: {
           type: "string",
-          description: "The URL to fetch. Use URLs from web_search results.",
+          description:
+            "The URL to fetch. Can be a webpage URL from web_search results, or a direct API endpoint (e.g. from a skill's instructions). For JSON APIs, use mode 'raw'.",
           required: true,
         },
         mode: {
           type: "string",
           description:
-            "Extraction mode: 'readability' (default, article text) or 'raw' (full HTML). Use 'raw' if readability returns too little content.",
+            "Extraction mode: 'readability' (default, article text) or 'raw' (full HTML/JSON). Use 'raw' for JSON API endpoints or if readability returns too little content.",
           required: false,
         },
       },


### PR DESCRIPTION
Fixes three issues that prevented the maps skill from being used by LLMs:

1. `web_fetch` url parameter description implied only web_search result URLs were valid
2. Skills system prompt language was too weak to enforce the read_skill pattern
3. Maps SKILL.md lacked use-case triggers, mode:raw hints, and a step-by-step workflow

Closes #120

Generated with [Claude Code](https://claude.ai/code)