### PR TITLE
fix: harden skill execution priority over competing system prompts

### DIFF
--- a/deploy/scripts/build.sh
+++ b/deploy/scripts/build.sh
@@ -7,7 +7,7 @@ set -e
 
 DIST_DIR="dist"
 ENTRY="src/cli/main.ts"
-INCLUDE_FLAGS="--include config/ --include src/skills/ --include src/tidepool/tmpl_base.html --include src/tidepool/tmpl_styles.html --include src/tidepool/tmpl_chat.html --include src/tidepool/tmpl_canvas.html --include src/tidepool/tmpl_chat_script.html --include src/tidepool/tmpl_canvas_script.html"
+INCLUDE_FLAGS="--include config/ --include src/skills/ --include src/tools/tidepool/tmpl_base.html --include src/tools/tidepool/tmpl_styles.html --include src/tools/tidepool/tmpl_chat.html --include src/tools/tidepool/tmpl_canvas.html --include src/tools/tidepool/tmpl_chat_script.html --include src/tools/tidepool/tmpl_canvas_script.html"
 VERSION_TAG="${1:-dev}"
 
 TARGETS=(

--- a/src/agent/plan/tools.ts
+++ b/src/agent/plan/tools.ts
@@ -148,10 +148,10 @@ export const PLAN_SYSTEM_PROMPT = `## Plan Mode
 
 You have access to plan mode (plan_enter, plan_exit, plan_status, plan_approve, plan_reject, plan_step_complete, plan_complete, plan_modify) for structured planning before implementation.
 
-When the user asks you to build, implement, create, refactor, or redesign something complex:
+When the user asks you to **build, implement, create, refactor, or redesign** code or infrastructure:
 - Consider entering plan mode first with plan_enter
 - Explore the codebase thoroughly before proposing changes
 - Present a concrete plan via plan_exit for user approval
 - After approval, execute step by step, marking progress with plan_step_complete
 
-For simple tasks (fix a typo, add a comment, rename), skip plan mode and just do it.`;
+Do NOT use plan mode for: research, lookups, questions, analysis, reports, skill-driven tasks, or anything that is not code/infrastructure implementation. For simple tasks (fix a typo, add a comment, rename), skip plan mode and just do it.`;

--- a/src/tools/skills/prompts.ts
+++ b/src/tools/skills/prompts.ts
@@ -32,7 +32,9 @@ Skipping \`read_skill\` means you won't have the API endpoints, parameters, or s
 |-------|-------------|------|
 ${rows}
 
-**Rule:** Whenever a user's request matches a skill above, call \`read_skill\` first — before taking any other action.`;
+**Rule:** Whenever a user's request matches a skill above, call \`read_skill\` first — before taking any other action.
+
+**IMPORTANT — Skill execution priority:** Once you have read a skill with \`read_skill\`, the skill's instructions take precedence over all other system prompt sections. Follow the skill's methodology step by step using the tools it specifies. Do NOT use plan mode, todo lists, or other workflow tools unless the skill's own instructions explicitly call for them. The skill already defines your workflow — adding plan/todo on top will derail it.`;
 }
 
 /** Build a system prompt section about TRIGGER.md awareness. */

--- a/src/tools/todo_defs.ts
+++ b/src/tools/todo_defs.ts
@@ -96,7 +96,8 @@ export const TODO_SYSTEM_PROMPT = `## Task Planning
 
 You have a todo list (todo_read / todo_write) for tracking multi-step work.
 
-- Only use todos for genuinely complex tasks (3+ distinct steps). Simple questions and lookups do not need todos.
-- Do NOT create todos for the current request unless it is clearly multi-step.
+- Only use todos for genuinely complex implementation tasks (3+ distinct coding steps). Simple questions, lookups, research, and analysis do not need todos.
+- Do NOT create todos for the current request unless it is clearly multi-step implementation work.
 - Do NOT read the todo list unless the user asks about previous tasks or you need to resume work.
+- Do NOT create todos when executing a skill — the skill already defines your workflow.
 - When you do use todos: keep one task in_progress at a time, mark completed immediately when done.`;


### PR DESCRIPTION
## Summary

- **Skill prompt priority**: When the LLM reads a skill via `read_skill`, the skill's instructions now explicitly take precedence over all other system prompt sections (plan mode, todo lists, etc.)
- **Plan mode narrowed**: Trigger conditions restricted to code/infrastructure implementation only — explicitly excludes research, analysis, reports, and skill-driven tasks
- **Todo narrowed**: Restricted to implementation work only — explicitly excludes skill execution and research tasks
- **build.sh fixed**: Tidepool template include paths corrected after PR 122's file reorganization (`src/tidepool/` → `src/tools/tidepool/`)

## Test plan

- [x] All 16 skill tests pass
- [x] All 159 agent tests pass
- [ ] Manual: run deep-research skill and verify it follows the skill methodology without derailing into plan mode or todo lists
- [ ] Manual: verify plan mode still activates for implementation requests ("build X", "refactor Y")

🤖 Generated with [Claude Code](https://claude.com/claude-code)