### PR TITLE
fix(ci): increase max-turns and fix permissions for PR workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,11 +19,13 @@ jobs:
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
+      actions: read
 
     steps:
       - name: Checkout repository
@@ -39,7 +41,6 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          claude_args: "--model opus --max-turns 5"
+          claude_args: "--model sonnet --max-turns 10"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: anthropics/claude-code-action@v1
@@ -24,4 +25,4 @@ jobs:
             - Any new file not re-exported by its directory's mod.ts?
             - Any .claude/rules/ paths frontmatter that should be updated given the changes?
             Post findings as a PR comment. If everything is clean, comment "Hygiene check passed."
-          claude_args: "--model opus --max-turns 5"
+          claude_args: "--model sonnet --max-turns 10"


### PR DESCRIPTION
## Summary

Fixes #126 — both PR Hygiene Check and Claude Code Review workflows fail on every PR (100% failure rate across 5 recent runs).

- **Raise `--max-turns` from 5 to 10** — Both workflows hit the turn limit (`error_max_turns`, exit code 1) before completing their work
- **Switch model from `opus` to `sonnet`** — Hygiene checks and code reviews don't need opus-level reasoning; saves ~$1/run
- **Add `timeout-minutes`** — Prevents runaway costs (10min for hygiene, 15min for code review)
- **Code Review: upgrade `pull-requests` and `issues` to `write`** — Required to post review comments and PR comments
- **Code Review: add `actions: read`** — Lets Claude check CI status for context

## Test plan

- [ ] Both workflows trigger on this PR
- [ ] PR Hygiene Check completes without `error_max_turns`
- [ ] Claude Code Review completes without permission denials
- [ ] Both post their comments/reviews successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)