### PR TITLE
fix(skills): rewrite deep-research SKILL.md for local models

### DIFF
--- a/src/skills/bundled/deep-research/SKILL.md
+++ b/src/skills/bundled/deep-research/SKILL.md
@@ -14,93 +14,90 @@ network_domains: []
 
 # Deep Research Methodology
 
-You have the ability to conduct thorough, multi-step research on any topic. When the user asks you to research something (indicated by words like "research", "investigate", "deep dive", "comprehensive analysis", "report on", or when a question clearly requires consulting multiple sources), follow this methodology.
+You are now in deep research mode. Follow this methodology exactly — do not skip steps or reduce the number of searches/fetches below the minimums specified.
 
-## When to Use Deep Research
+## Step 0: Select Depth
 
-- User explicitly asks for research or a report
-- Question requires synthesizing multiple sources
-- Topic is complex enough that a single search won't suffice
-- User asks for "thorough", "comprehensive", or "detailed" analysis
+Based on the user's wording, select a depth level. If unclear, default to Standard.
 
-Do NOT use deep research for simple factual questions that web_search can answer directly.
+| Depth | Min Sources to Fetch | Min Search Queries | Refinement Rounds | Trigger Words |
+|-------|---------------------|-------------------|-------------------|---------------|
+| Quick | 5 | 3 | 1 | "look into", "quick research", brief questions |
+| Standard | 10 | 8 | 2 | "research", "report on", default for any research request |
+| Deep | 20 | 15 | 3 | "thorough", "comprehensive", "deep dive", "detailed analysis" |
 
-## Depth Selection
+## Step 1: Generate Search Queries
 
-| Depth | Sources | Initial Queries | Refinement Rounds | When to Use |
-|-------|---------|----------------|-------------------|-------------|
-| Quick | 5 | 3 | 1 | "look into X", brief questions |
-| Standard | 10 | 8 | 2 | "research X", default depth |
-| Deep | 20 | 15 | 3 | "thorough analysis", "comprehensive report" |
-
-## Research Loop
-
-### Phase 1: Planning
-
-Decompose the topic into specific search queries. Use `llm_task` to generate a research plan if complex:
+Use `llm_task` to decompose the topic into diverse search queries:
 
 ```
-llm_task: "Given the research topic '{topic}', generate {N} specific search queries
-that cover different facets. Return as a JSON array of strings."
+llm_task: "Given the research topic '{topic}', generate exactly {N} specific search queries that cover different facets, angles, and perspectives. Include queries for: definitions, recent developments, expert opinions, counterarguments, statistics/data, and real-world examples. Return ONLY a JSON array of strings, nothing else."
 ```
 
-### Phase 2: Searching
+Where {N} is the "Min Search Queries" from the depth table above.
 
-Execute each query via `web_search`. Collect URLs. Deduplicate by domain — prefer source diversity.
+## Step 2: Execute ALL Search Queries
 
-### Phase 3: Fetching
+Call `web_search` for EVERY query from Step 1. Do not stop after one search. You must execute all {N} queries.
 
-Use `web_fetch` on top N URLs (based on depth). Prioritize original sources, reputable publications, recent content. Skip errors — don't stop the whole research if one fetch fails.
+**You can call multiple `web_search` tools in a single turn — do this to work efficiently.** For example, at Standard depth, call `web_search` 8 times in a single response.
 
-### Phase 4: Analyzing
+After all searches complete, collect all unique URLs. Deduplicate by domain — keep at most 2 URLs per domain to ensure source diversity.
 
-Use `llm_task` to extract findings from each source:
+## Step 3: Fetch Sources
 
-```
-llm_task: "Extract key findings from this content related to '{topic}'.
-Return structured JSON: { findings: [{ fact: string, confidence: 'high'|'medium'|'low', source_url: string }] }"
-```
+Call `web_fetch` on the top URLs from your deduplicated list. You MUST fetch at least the "Min Sources to Fetch" number from the depth table.
 
-### Phase 5: Gap Analysis
+**Call multiple `web_fetch` tools in a single turn for efficiency.** For Standard depth, fetch 10 URLs in one batch (or split across two turns if needed).
 
-Use `llm_task` to identify what's missing and generate follow-up queries:
+If a fetch fails, skip it and fetch the next URL. Do NOT stop the research because one fetch failed.
 
-```
-llm_task: "Given these findings about '{topic}': {findings_summary}
-What important aspects are missing? Generate {M} follow-up search queries. Return as JSON array."
-```
+## Step 4: Analyze Each Source
 
-Repeat Phases 2-4 for each refinement round.
-
-### Phase 6: Synthesis
-
-Produce a structured report with `llm_task`:
+Use `llm_task` to extract findings from EACH fetched source individually:
 
 ```
-llm_task: "Synthesize these findings into a structured report about '{topic}'.
-Include: executive summary, key findings with inline citations [1] [2], areas of consensus,
-areas of disagreement, and a sources list."
+llm_task: "Extract key findings from this content related to '{topic}'. Content: {fetched_content}. Return structured JSON: { findings: [{ fact: string, confidence: 'high'|'medium'|'low', source_url: string }] }"
 ```
+
+You may batch multiple `llm_task` calls in a single turn.
+
+## Step 5: Gap Analysis and Refinement
+
+Use `llm_task` to identify gaps in your findings:
+
+```
+llm_task: "Given these findings about '{topic}': {all_findings_summary}. What important aspects are still missing or underrepresented? Generate {M} follow-up search queries to fill these gaps. Return ONLY a JSON array of strings."
+```
+
+Then repeat Steps 2-4 with the follow-up queries. Do this for the number of "Refinement Rounds" specified by the depth level.
+
+## Step 6: Synthesize Report
+
+After all rounds are complete, write the final report directly (do NOT use llm_task for the final synthesis — write it yourself so you can use the full conversation context).
 
 ## Output Format
+
+Structure your report exactly as follows:
 
 ### Executive Summary
 2-3 sentences capturing the key takeaway.
 
 ### Key Findings
-Numbered findings with inline citations referencing the sources list.
+Numbered findings with inline citations like [1], [2] referencing the Sources list.
 
 ### Analysis
-Deeper discussion of patterns, disagreements, or surprising findings.
+Deeper discussion: patterns, areas of consensus, areas of disagreement, surprising discoveries.
 
 ### Sources
-Numbered list of all URLs consulted with brief descriptions.
+Numbered list of ALL URLs you fetched, with a one-line description of each.
 
-## Important Rules
+## Rules
 
-- Always cite sources with inline references
-- Note when sources disagree
-- Flag low-confidence findings
-- If insufficient coverage, say so — don't fabricate
-- Respect rate limits: space web_fetch calls
-- All fetched content inherits session taint automatically
+- You MUST execute the minimum number of searches and fetches for the selected depth. Doing fewer is a failure.
+- Always cite sources with inline [N] references.
+- Note when sources disagree with each other.
+- Flag low-confidence findings explicitly.
+- If you cannot find enough information, say so — never fabricate.
+- All fetched content inherits session taint automatically.
+- Call multiple tools per turn whenever possible to stay within iteration limits.


### PR DESCRIPTION
## Summary
- Rewrote deep-research SKILL.md from descriptive/passive methodology to imperative numbered steps with explicit minimums
- Added mandatory depth table (Quick/Standard/Deep) with minimum search queries and source fetches
- Changed wording to direct commands: "You MUST fetch at least...", "Doing fewer is a failure"
- Clarified that final synthesis should be written directly, not via llm_task

## Context
Local models (e.g. gpt-oss-120b via LM Studio) were only executing 1-2 searches and 1 fetch instead of the required minimums. The descriptive wording ("use web_fetch on top N URLs") wasn't being followed as instructions. Note: local models may still struggle with multi-step agentic loops regardless of SKILL.md wording — cloud models (Claude, GPT-4o) handle this reliably.

## Test plan
- [ ] Run deep research with a cloud model (Anthropic/OpenAI) — should execute 8+ searches and 10+ fetches at Standard depth
- [ ] Run deep research with LM Studio — verify improvement in search/fetch counts
- [ ] Verify skill loads correctly: `triggerfish chat` → `/research <topic>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)