### PR TITLE
fix(ci): rewrite PR workflows with correct plugin config and tool permissions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,21 +3,10 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
 
 jobs:
-  claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
+  code-review:
+    if: "!github.event.pull_request.draft"
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -31,16 +20,20 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          claude_args: "--model sonnet --max-turns 10"
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+          plugin_marketplaces: 'https://github.com/anthropics/claude-plugins-official.git'
+          plugins: 'code-review@claude-plugins-official'
+          additional_permissions: |
+            actions: read
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Run /code-review on this pull request.
+          claude_args: "--model sonnet --max-turns 15"

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -1,7 +1,8 @@
 name: PR Hygiene Check
+
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, ready_for_review, reopened]
 
 permissions:
   contents: read
@@ -9,20 +10,35 @@ permissions:
   id-token: write
 
 jobs:
-  check:
+  hygiene:
+    if: "!github.event.pull_request.draft"
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
+
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          use_sticky_comment: true
           prompt: |
-            Review only the files changed in this PR for hygiene issues:
-            - Any new file over 300 lines?
-            - Any new exported function with a vague name (process, handle, run, execute, check, validate, do, perform, manage)?
-            - Any new file missing a JSDoc @module comment?
-            - Any new file not re-exported by its directory's mod.ts?
-            - Any .claude/rules/ paths frontmatter that should be updated given the changes?
-            Post findings as a PR comment. If everything is clean, comment "Hygiene check passed."
-          claude_args: "--model sonnet --max-turns 10"
+            You are a PR hygiene checker for the Triggerfish project.
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            First, gather data by running these two commands:
+            1. `gh pr diff ${{ github.event.pull_request.number }} --stat`
+            2. `gh pr diff ${{ github.event.pull_request.number }}`
+
+            Then evaluate these hygiene criteria on the changed files ONLY:
+            1. Any new file over 300 lines?
+            2. Any new exported function with a vague name (process, handle, run, execute, check, validate, do, perform, manage)?
+            3. Any new file missing a JSDoc @module comment?
+            4. Any new file not re-exported by its directory's mod.ts?
+            5. Any .claude/rules/ paths frontmatter that should be updated?
+
+            Post a single PR comment with your findings as a markdown table.
+            If everything is clean, comment "Hygiene check passed."
+          claude_args: "--model sonnet --max-turns 6 --allowedTools 'Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*)'"


### PR DESCRIPTION
## Summary

Fixes #126 — both PR workflows fail on every PR. Previous fix (bumping max-turns to 10) wasn't enough because the root causes were deeper.

### Root causes found in run logs
1. **Bash denied** — `claude-code-action` disables Bash by default; Claude couldn't run any commands without `--allowedTools`
2. **Vague prompt** — hygiene check wasted all turns figuring out *how* to get changed files instead of actually checking them  
3. **Wrong plugin marketplace** — code review pointed at `claude-code` instead of `claude-plugins-official`
4. **`--max-turns` still too low** for code review plugin (spawns 5 parallel sub-agents)

### Changes

**PR Hygiene Check:**
- Prescriptive prompt: tells Claude exactly which `gh` commands to run
- Added `--allowedTools` to explicitly allow `gh pr diff/view/comment`
- `use_sticky_comment: true` to avoid comment spam on re-pushes
- `--max-turns 6` (sufficient for a focused, prescriptive task)
- Skip draft PRs

**Code Review:**
- Fixed plugin marketplace: `claude-plugins-official` (was `claude-code`)
- `--max-turns 15` (plugin spawns 5 parallel agents)
- `fetch-depth: 0` (plugin needs git history)
- `additional_permissions: actions: read`
- Skip draft PRs

## Test plan

- [ ] Both workflows trigger on this PR
- [ ] PR Hygiene Check completes without `error_max_turns`
- [ ] Claude Code Review completes without permission denials
- [ ] Both post their comments/reviews successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)