### PR TITLE
fix(ci): allow claude bot to trigger PR workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,4 +36,5 @@ jobs:
             PR NUMBER: ${{ github.event.pull_request.number }}
 
             Run /code-review on this pull request.
+          allowed_bots: 'claude'
           claude_args: "--model sonnet --max-turns 15"

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -41,4 +41,5 @@ jobs:
 
             Post a single PR comment with your findings as a markdown table.
             If everything is clean, comment "Hygiene check passed."
+          allowed_bots: 'claude'
           claude_args: "--model sonnet --max-turns 6 --allowedTools 'Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*)'"


### PR DESCRIPTION
## Summary
- Add `allowed_bots: 'claude'` to code review and PR hygiene workflows
- Fixes the "Workflow initiated by non-human actor" error when the Claude issue bot pushes commits to a PR and the PR workflows re-trigger

## Test plan
- [ ] Have Claude bot push a commit to a PR and verify the code review and hygiene workflows run instead of erroring

🤖 Generated with [Claude Code](https://claude.com/claude-code)