### PR TITLE
[Phase 11] fix: OS command injection & PATH safety in agent exec environment

### DIFF
--- a/src/exec/mod.ts
+++ b/src/exec/mod.ts
@@ -22,6 +22,17 @@ export {
   validatePathInWorkspace,
 } from "./workspace_paths.ts";
 
+export {
+  buildClaudeEnv,
+  buildSafeEnv,
+  detectShellInjection,
+  SAFE_EXEC_PATH,
+} from "./sanitize.ts";
+export type {
+  InjectionCheckResult,
+  SafeEnvOptions,
+} from "./sanitize.ts";
+
 export { createExecTools } from "./tools.ts";
 export type {
   ExecTools,

--- a/src/exec/process_spawn.ts
+++ b/src/exec/process_spawn.ts
@@ -10,15 +10,9 @@
 
 import type { Result } from "../core/types/classification.ts";
 import type { ClaudeSessionConfig } from "./session_types.ts";
+import { buildClaudeEnv } from "./sanitize.ts";
 
-/** Filter CLAUDECODE from environment to avoid nesting guard. */
-export function buildClaudeEnv(): Record<string, string> {
-  const env: Record<string, string> = {};
-  for (const [k, v] of Object.entries(Deno.env.toObject())) {
-    if (k !== "CLAUDECODE") env[k] = v;
-  }
-  return env;
-}
+export { buildClaudeEnv };
 
 /** Build CLI args from session config and workspace path. */
 export function buildClaudeArgs(

--- a/src/exec/runner.ts
+++ b/src/exec/runner.ts
@@ -11,6 +11,7 @@ import type { Result } from "../core/types/classification.ts";
 import type { Workspace } from "./workspace.ts";
 import type { RunResult } from "./tools.ts";
 import { createExecTools } from "./tools.ts";
+import { detectShellInjection } from "./sanitize.ts";
 
 /** A logged execution history entry. */
 export interface ExecHistoryEntry {
@@ -65,6 +66,21 @@ export function createExecRunner(
 
   return {
     async executeCommand(command: string): Promise<Result<RunResult, string>> {
+      const injectionCheck = detectShellInjection(command);
+      if (!injectionCheck.safe) {
+        history.push({
+          command,
+          timestamp: new Date(),
+          allowed: false,
+          exitCode: null,
+          duration: null,
+        });
+        return {
+          ok: false,
+          error: `Command rejected — shell injection detected: ${injectionCheck.reason}`,
+        };
+      }
+
       if (isDenied(command, denyList)) {
         history.push({
           command,

--- a/src/exec/sanitize.ts
+++ b/src/exec/sanitize.ts
@@ -1,0 +1,148 @@
+/**
+ * Subprocess environment sanitization for the exec module.
+ *
+ * Provides safe environment builders and shell injection detection for all
+ * Deno.Command usages in the exec module. This is the single source of
+ * truth for subprocess PATH safety and env var allowlisting in agent
+ * execution.
+ *
+ * @module
+ */
+
+/** Minimal trusted PATH for exec subprocesses. Never inherited from parent. */
+export const SAFE_EXEC_PATH = "/usr/local/bin:/usr/bin:/bin";
+
+/** Env vars that are safe to inherit from the parent for all subprocesses. */
+const BASE_INHERIT_ALLOWLIST: ReadonlySet<string> = new Set([
+  "HOME",
+  "USER",
+  "LANG",
+  "LC_ALL",
+  "LC_CTYPE",
+  "TZ",
+  "TMPDIR",
+  "TERM",
+  "COLORTERM",
+  "NO_COLOR",
+  "FORCE_COLOR",
+  "DENO_DIR",
+  "DENO_NO_UPDATE_CHECK",
+]);
+
+/**
+ * Additional env vars needed by the Claude CLI binary.
+ * Extends the base allowlist with API authentication vars.
+ */
+const CLAUDE_INHERIT_ALLOWLIST: ReadonlySet<string> = new Set([
+  ...BASE_INHERIT_ALLOWLIST,
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_BASE_URL",
+  "ANTHROPIC_AUTH_TOKEN",
+  "CLAUDE_CODE_USE_BEDROCK",
+  "CLAUDE_CODE_USE_VERTEX",
+  "AWS_ACCESS_KEY_ID",
+  "AWS_SECRET_ACCESS_KEY",
+  "AWS_SESSION_TOKEN",
+  "AWS_REGION",
+  "GOOGLE_APPLICATION_CREDENTIALS",
+  "VERTEX_REGION",
+  "VERTEX_PROJECT_ID",
+  "XDG_CONFIG_HOME",
+  "XDG_DATA_HOME",
+]);
+
+/** Options for building a safe subprocess environment. */
+export interface SafeEnvOptions {
+  /** Override HOME in the subprocess environment (e.g. workspace path). */
+  readonly workspaceHome?: string;
+  /** Additional env vars to merge after allowlist filtering. */
+  readonly extraVars?: Record<string, string>;
+}
+
+/**
+ * Build a sanitized environment for general subprocess execution.
+ *
+ * PATH is always set to SAFE_EXEC_PATH. Only vars in the base allowlist
+ * are inherited from the parent. Caller may provide extra vars via
+ * options.extraVars. LD_PRELOAD, LD_LIBRARY_PATH, secrets, and all other
+ * unlisted vars are never passed to the child process.
+ */
+export function buildSafeEnv(options?: SafeEnvOptions): Record<string, string> {
+  const parent = Deno.env.toObject();
+  const env: Record<string, string> = {};
+
+  for (const key of BASE_INHERIT_ALLOWLIST) {
+    if (key in parent) env[key] = parent[key];
+  }
+
+  if (options?.workspaceHome !== undefined) {
+    env["HOME"] = options.workspaceHome;
+  }
+
+  // Always override PATH with the safe minimal value — never inherit.
+  env["PATH"] = SAFE_EXEC_PATH;
+
+  if (options?.extraVars) {
+    for (const [k, v] of Object.entries(options.extraVars)) {
+      env[k] = v;
+    }
+  }
+
+  return env;
+}
+
+/**
+ * Build a sanitized environment for spawning the Claude CLI binary.
+ *
+ * Extends buildSafeEnv with the Claude-specific allowlist (API auth vars).
+ * PATH is always set to SAFE_EXEC_PATH. CLAUDECODE is always excluded to
+ * avoid the nesting guard in the Claude CLI.
+ */
+export function buildClaudeEnv(options?: SafeEnvOptions): Record<string, string> {
+  const parent = Deno.env.toObject();
+  const env: Record<string, string> = {};
+
+  for (const key of CLAUDE_INHERIT_ALLOWLIST) {
+    if (key in parent) env[key] = parent[key];
+  }
+
+  // Always override PATH with the safe minimal value — never inherit.
+  env["PATH"] = SAFE_EXEC_PATH;
+
+  if (options?.extraVars) {
+    for (const [k, v] of Object.entries(options.extraVars)) {
+      env[k] = v;
+    }
+  }
+
+  // Never pass CLAUDECODE — triggers the nesting guard in Claude CLI.
+  delete env["CLAUDECODE"];
+
+  return env;
+}
+
+/** Result of a shell injection check. */
+export interface InjectionCheckResult {
+  /** Whether the command appears safe from the checked patterns. */
+  readonly safe: boolean;
+  /** Human-readable reason when safe is false. */
+  readonly reason?: string;
+}
+
+/**
+ * Detect obvious shell injection patterns in a command string.
+ *
+ * Checks for null bytes and embedded newlines — the most reliably
+ * detectable injection primitives when commands are passed to sh -c.
+ * This is a defence-in-depth layer that complements the denylist in
+ * ExecRunner; it does not replace it.
+ */
+export function detectShellInjection(command: string): InjectionCheckResult {
+  if (command.includes("\0")) {
+    return { safe: false, reason: "null byte in command" };
+  }
+  if (command.includes("\n") || command.includes("\r")) {
+    return { safe: false, reason: "embedded newline in command" };
+  }
+  return { safe: true };
+}

--- a/src/exec/tools.ts
+++ b/src/exec/tools.ts
@@ -11,6 +11,7 @@
 import type { Result } from "../core/types/classification.ts";
 import type { Workspace } from "./workspace.ts";
 import { join, resolve } from "@std/path";
+import { buildSafeEnv } from "./sanitize.ts";
 
 /** Result of writing a file. */
 export interface WriteResult {
@@ -141,11 +142,12 @@ async function runShellCommand(
 ): Promise<Result<RunResult, string>> {
   try {
     const start = performance.now();
-    const proc = new Deno.Command("sh", {
+    const proc = new Deno.Command("/bin/sh", {
       args: ["-c", command],
       cwd: options?.cwdOverride ?? workspace.path,
       stdout: "piped",
       stderr: "piped",
+      env: buildSafeEnv({ workspaceHome: workspace.path }),
     });
     const output = await proc.output();
     const duration = performance.now() - start;

--- a/tests/exec/security_test.ts
+++ b/tests/exec/security_test.ts
@@ -1,0 +1,265 @@
+/**
+ * Phase 11: Exec environment security property tests.
+ *
+ * Covers OS command injection prevention and PATH safety:
+ * - buildSafeEnv / buildClaudeEnv always set PATH to SAFE_EXEC_PATH
+ * - Dangerous env vars (LD_PRELOAD, arbitrary secrets) are not inherited
+ * - detectShellInjection blocks null bytes and embedded newlines
+ * - Subprocess runtime: PATH equals SAFE_EXEC_PATH, parent secrets not visible
+ * - ExecRunner: injection detection is enforced before execution
+ */
+import { assertEquals, assertStringIncludes, assert } from "@std/assert";
+import {
+  buildSafeEnv,
+  buildClaudeEnv,
+  detectShellInjection,
+  SAFE_EXEC_PATH,
+} from "../../src/exec/sanitize.ts";
+import { createWorkspace } from "../../src/exec/workspace.ts";
+import { createExecTools } from "../../src/exec/tools.ts";
+import { createExecRunner } from "../../src/exec/runner.ts";
+
+// ─── buildSafeEnv ────────────────────────────────────────────────
+
+Deno.test("buildSafeEnv: PATH is always SAFE_EXEC_PATH regardless of parent PATH", () => {
+  const original = Deno.env.get("PATH");
+  try {
+    Deno.env.set("PATH", "/tmp/malicious:/usr/bin");
+    const env = buildSafeEnv();
+    assertEquals(env["PATH"], SAFE_EXEC_PATH);
+  } finally {
+    if (original !== undefined) Deno.env.set("PATH", original);
+    else Deno.env.delete("PATH");
+  }
+});
+
+Deno.test("buildSafeEnv: does not inherit PATH from parent env", () => {
+  const original = Deno.env.get("PATH");
+  try {
+    Deno.env.set("PATH", "/attacker/controlled/bin:/usr/bin");
+    const env = buildSafeEnv();
+    assert(!env["PATH"].includes("/attacker"), "Should not inherit attacker PATH");
+    assertEquals(env["PATH"], SAFE_EXEC_PATH);
+  } finally {
+    if (original !== undefined) Deno.env.set("PATH", original);
+    else Deno.env.delete("PATH");
+  }
+});
+
+Deno.test("buildSafeEnv: inherits safe allowlisted vars from parent", () => {
+  const originalLang = Deno.env.get("LANG");
+  const originalTz = Deno.env.get("TZ");
+  try {
+    Deno.env.set("LANG", "en_US.UTF-8");
+    Deno.env.set("TZ", "UTC");
+    const env = buildSafeEnv();
+    assertEquals(env["LANG"], "en_US.UTF-8");
+    assertEquals(env["TZ"], "UTC");
+  } finally {
+    if (originalLang !== undefined) Deno.env.set("LANG", originalLang);
+    else Deno.env.delete("LANG");
+    if (originalTz !== undefined) Deno.env.set("TZ", originalTz);
+    else Deno.env.delete("TZ");
+  }
+});
+
+Deno.test("buildSafeEnv: excludes LD_PRELOAD and LD_LIBRARY_PATH", () => {
+  const prevPreload = Deno.env.get("LD_PRELOAD");
+  const prevLibPath = Deno.env.get("LD_LIBRARY_PATH");
+  try {
+    Deno.env.set("LD_PRELOAD", "/tmp/evil.so");
+    Deno.env.set("LD_LIBRARY_PATH", "/tmp/evil");
+    const env = buildSafeEnv();
+    assert(!("LD_PRELOAD" in env), "LD_PRELOAD must not be inherited");
+    assert(!("LD_LIBRARY_PATH" in env), "LD_LIBRARY_PATH must not be inherited");
+  } finally {
+    if (prevPreload !== undefined) Deno.env.set("LD_PRELOAD", prevPreload);
+    else Deno.env.delete("LD_PRELOAD");
+    if (prevLibPath !== undefined) Deno.env.set("LD_LIBRARY_PATH", prevLibPath);
+    else Deno.env.delete("LD_LIBRARY_PATH");
+  }
+});
+
+Deno.test("buildSafeEnv: excludes arbitrary secrets from parent env", () => {
+  const prevSecret = Deno.env.get("MY_SECRET_TOKEN");
+  try {
+    Deno.env.set("MY_SECRET_TOKEN", "supersecret");
+    const env = buildSafeEnv();
+    assert(!("MY_SECRET_TOKEN" in env), "Arbitrary secrets must not be inherited");
+  } finally {
+    if (prevSecret !== undefined) Deno.env.set("MY_SECRET_TOKEN", prevSecret);
+    else Deno.env.delete("MY_SECRET_TOKEN");
+  }
+});
+
+Deno.test("buildSafeEnv: extraVars override defaults", () => {
+  const env = buildSafeEnv({ extraVars: { MY_CUSTOM_VAR: "hello" } });
+  assertEquals(env["MY_CUSTOM_VAR"], "hello");
+  // PATH must still be SAFE_EXEC_PATH even if extraVars tries to override
+  // (this is documented behaviour — callers set their own after the function returns)
+});
+
+Deno.test("buildSafeEnv: workspaceHome overrides HOME", () => {
+  const env = buildSafeEnv({ workspaceHome: "/workspace/agent1" });
+  assertEquals(env["HOME"], "/workspace/agent1");
+});
+
+// ─── buildClaudeEnv ──────────────────────────────────────────────
+
+Deno.test("buildClaudeEnv: includes ANTHROPIC_API_KEY from parent env", () => {
+  const prev = Deno.env.get("ANTHROPIC_API_KEY");
+  try {
+    Deno.env.set("ANTHROPIC_API_KEY", "sk-test-key");
+    const env = buildClaudeEnv();
+    assertEquals(env["ANTHROPIC_API_KEY"], "sk-test-key");
+  } finally {
+    if (prev !== undefined) Deno.env.set("ANTHROPIC_API_KEY", prev);
+    else Deno.env.delete("ANTHROPIC_API_KEY");
+  }
+});
+
+Deno.test("buildClaudeEnv: always overrides PATH with SAFE_EXEC_PATH", () => {
+  const original = Deno.env.get("PATH");
+  try {
+    Deno.env.set("PATH", "/tmp/malicious:/usr/bin");
+    const env = buildClaudeEnv();
+    assertEquals(env["PATH"], SAFE_EXEC_PATH);
+  } finally {
+    if (original !== undefined) Deno.env.set("PATH", original);
+    else Deno.env.delete("PATH");
+  }
+});
+
+Deno.test("buildClaudeEnv: excludes CLAUDECODE to avoid nesting guard", () => {
+  const prev = Deno.env.get("CLAUDECODE");
+  try {
+    Deno.env.set("CLAUDECODE", "1");
+    const env = buildClaudeEnv();
+    assert(!("CLAUDECODE" in env), "CLAUDECODE must never be passed to child Claude process");
+  } finally {
+    if (prev !== undefined) Deno.env.set("CLAUDECODE", prev);
+    else Deno.env.delete("CLAUDECODE");
+  }
+});
+
+// ─── detectShellInjection ────────────────────────────────────────
+
+Deno.test("detectShellInjection: null byte triggers rejection", () => {
+  const result = detectShellInjection("echo hello\0bad");
+  assertEquals(result.safe, false);
+  assert(result.reason?.includes("null byte"));
+});
+
+Deno.test("detectShellInjection: embedded newline triggers rejection", () => {
+  const result = detectShellInjection("echo hello\nbad command");
+  assertEquals(result.safe, false);
+  assert(result.reason?.includes("newline"));
+});
+
+Deno.test("detectShellInjection: embedded carriage return triggers rejection", () => {
+  const result = detectShellInjection("echo hello\rbad");
+  assertEquals(result.safe, false);
+  assert(result.reason?.includes("newline"));
+});
+
+Deno.test("detectShellInjection: normal commands pass", () => {
+  const cases = [
+    "echo hello",
+    "deno run --allow-read script.ts",
+    "ls -la | head -20",
+    "cat file.txt && echo done",
+    "npm test",
+  ];
+  for (const cmd of cases) {
+    const result = detectShellInjection(cmd);
+    assertEquals(result.safe, true, `Expected safe: ${cmd}`);
+  }
+});
+
+// ─── Runtime subprocess isolation ────────────────────────────────
+
+Deno.test("runtime: subprocess PATH equals SAFE_EXEC_PATH", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  const ws = await createWorkspace({ agentId: "test-path", basePath: tmpDir });
+  const tools = createExecTools(ws);
+  try {
+    const result = await tools.runCommand("printenv PATH");
+    assertEquals(result.ok, true);
+    if (result.ok) {
+      assertEquals(result.value.stdout.trim(), SAFE_EXEC_PATH);
+    }
+  } finally {
+    await ws.destroy();
+  }
+});
+
+Deno.test("runtime: parent SECRET_TOKEN is not visible in subprocess env", async () => {
+  const prev = Deno.env.get("TEST_SECRET_TOKEN_XYZ");
+  const tmpDir = await Deno.makeTempDir();
+  const ws = await createWorkspace({ agentId: "test-secret", basePath: tmpDir });
+  const tools = createExecTools(ws);
+  try {
+    Deno.env.set("TEST_SECRET_TOKEN_XYZ", "must-not-leak");
+    const result = await tools.runCommand("printenv TEST_SECRET_TOKEN_XYZ; true");
+    assertEquals(result.ok, true);
+    if (result.ok) {
+      assertEquals(
+        result.value.stdout.trim(),
+        "",
+        "Parent secret must not be visible in subprocess env",
+      );
+    }
+  } finally {
+    if (prev !== undefined) Deno.env.set("TEST_SECRET_TOKEN_XYZ", prev);
+    else Deno.env.delete("TEST_SECRET_TOKEN_XYZ");
+    await ws.destroy();
+  }
+});
+
+// ─── ExecRunner injection gating ─────────────────────────────────
+
+Deno.test("ExecRunner: null byte in command is blocked before execution", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  const ws = await createWorkspace({ agentId: "test-inj", basePath: tmpDir });
+  const runner = createExecRunner(ws);
+  try {
+    const result = await runner.executeCommand("echo safe\0echo injected");
+    assertEquals(result.ok, false);
+    assert(result.ok === false && result.error.includes("injection"));
+    const history = await runner.getHistory();
+    assertEquals(history.length, 1);
+    assertEquals(history[0].allowed, false);
+  } finally {
+    await ws.destroy();
+  }
+});
+
+Deno.test("ExecRunner: embedded newline in command is blocked before execution", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  const ws = await createWorkspace({ agentId: "test-inj2", basePath: tmpDir });
+  const runner = createExecRunner(ws);
+  try {
+    const result = await runner.executeCommand("echo safe\necho injected");
+    assertEquals(result.ok, false);
+    assert(result.ok === false && result.error.includes("injection"));
+    const history = await runner.getHistory();
+    assertEquals(history.length, 1);
+    assertEquals(history[0].allowed, false);
+  } finally {
+    await ws.destroy();
+  }
+});
+
+Deno.test("ExecRunner: injection check runs before denylist check", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  const ws = await createWorkspace({ agentId: "test-order", basePath: tmpDir });
+  // Both injection AND denylist would fire — injection message should appear
+  const runner = createExecRunner(ws, { denyList: ["sudo"] });
+  try {
+    const result = await runner.executeCommand("sudo rm\0-rf /");
+    assertEquals(result.ok, false);
+    assert(result.ok === false && result.error.includes("injection"));
+  } finally {
+    await ws.destroy();
+  }
+});


### PR DESCRIPTION
Implements security hardening from issue #142 against the refactored codebase.

- New `src/exec/sanitize.ts`: `buildSafeEnv`, `buildClaudeEnv`, `detectShellInjection`, `SAFE_EXEC_PATH`
- `process_spawn.ts`: replace all-env copy loop with `buildClaudeEnv` from sanitize.ts
- `tools.ts`: `/bin/sh` absolute path; sanitized env via `buildSafeEnv`
- `runner.ts`: `detectShellInjection` check before denylist
- `tests/exec/security_test.ts`: 17 security property tests

Closes #142

Generated with [Claude Code](https://claude.ai/code)