### PR TITLE
fix(ci): add gh api to allowed tools and bump max-turns for PR hygiene

### DIFF
--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -42,4 +42,4 @@ jobs:
             Post a single PR comment with your findings as a markdown table.
             If everything is clean, comment "Hygiene check passed."
           allowed_bots: 'claude'
-          claude_args: "--model sonnet --max-turns 6 --allowedTools 'Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*)'"
+          claude_args: "--model sonnet --max-turns 10 --allowedTools 'Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh api:*)'"


### PR DESCRIPTION
## Summary
- Added `Bash(gh api:*)` to PR hygiene workflow's allowed tools — Claude Code was burning turns on permission-denied `gh api` calls trying to resolve repo context
- Bumped `--max-turns` from 6 to 10 to give enough runway after context-gathering

## Test plan
- [x] Confirmed PR #156 hygiene failure was caused by denied `gh api` calls hitting the 6-turn limit
- [ ] Merge and verify hygiene passes on subsequent PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)