### PR TITLE
fix: serviceability audit findings from #168

### DIFF
--- a/src/gateway/startup/factory/orchestrator_factory.ts
+++ b/src/gateway/startup/factory/orchestrator_factory.ts
@@ -54,6 +54,9 @@ import {
   buildSchedulerSkillLoader,
 } from "../tools/scheduler_tool_assembly.ts";
 import { createSkillContextTracker } from "../../../tools/skills/mod.ts";
+import { createLogger } from "../../../core/logger/logger.ts";
+
+const log = createLogger("orchestrator-factory");
 
 /** Symlink SPINE.md into a workspace directory. */
 async function symlinkSpineToWorkspace(
@@ -64,10 +67,21 @@ async function symlinkSpineToWorkspace(
     const workspaceSpine = join(workspacePath, "SPINE.md");
     try {
       await Deno.remove(workspaceSpine);
-    } catch { /* doesn't exist yet */ }
+    } catch (err: unknown) {
+      log.debug("Workspace SPINE.md symlink not present for removal", {
+        operation: "symlinkSpineToWorkspace",
+        workspacePath,
+        err,
+      });
+    }
     await Deno.symlink(spinePath, workspaceSpine);
-  } catch {
-    // SPINE.md may not exist yet — not fatal
+  } catch (err: unknown) {
+    log.debug("SPINE.md symlink to workspace skipped", {
+      operation: "symlinkSpineToWorkspace",
+      spinePath,
+      workspacePath,
+      err,
+    });
   }
 }
 
@@ -81,8 +95,11 @@ async function discoverSkillsOnce(
   try {
     const skills = await loader.discover();
     state.prompt = buildSkillsSystemPrompt(skills);
-  } catch {
-    // Non-fatal
+  } catch (err: unknown) {
+    log.warn("Skill discovery failed during orchestrator creation", {
+      operation: "discoverSkillsOnce",
+      err,
+    });
   }
 }
 

--- a/src/tools/skills/integrity.ts
+++ b/src/tools/skills/integrity.ts
@@ -80,7 +80,12 @@ export async function loadSkillHashRecord(
   try {
     const content = await Deno.readTextFile(hashPath);
     return JSON.parse(content) as SkillHashRecord;
-  } catch {
+  } catch (err: unknown) {
+    log.debug("Skill hash record not loadable", {
+      operation: "loadSkillHashRecord",
+      hashPath,
+      err,
+    });
     return null;
   }
 }


### PR DESCRIPTION
## Summary
Fixes 4 blocking serviceability findings from the skill supply chain PR (#168):

- `src/tools/skills/integrity.ts:83` — `loadSkillHashRecord` catch block now logs parse/permission errors before returning null
- `src/gateway/startup/factory/orchestrator_factory.ts:67` — `Deno.remove` catch in `symlinkSpineToWorkspace` now logs at DEBUG
- `src/gateway/startup/factory/orchestrator_factory.ts:69` — `Deno.symlink` catch now logs at DEBUG
- `src/gateway/startup/factory/orchestrator_factory.ts:84` — `discoverSkillsOnce` catch now logs at WARN

## Test plan
- [x] `deno task test tests/tools/skills/` — 54 passed
- [x] `deno task lint` — 0 errors
- [x] `deno task check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)