### PR TITLE
Add OpenGraph and Twitter Card meta tags

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -8,11 +8,24 @@ export default defineConfig({
 
   head: [
     ['link', { rel: 'icon', type: 'image/png', href: '/triggerfish.png' }],
-    ['meta', { property: 'og:title', content: 'Triggerfish' }],
-    ['meta', { property: 'og:description', content: 'Secure AI agents. Every channel. No exceptions.' }],
+
+    // OpenGraph
+    ['meta', { property: 'og:title', content: 'Triggerfish — Secure AI Agents' }],
+    ['meta', { property: 'og:description', content: 'A secure, multi-channel AI agent platform with deterministic policy enforcement below the LLM layer. Every channel. No exceptions.' }],
     ['meta', { property: 'og:type', content: 'website' }],
     ['meta', { property: 'og:url', content: 'https://trigger.fish' }],
+    ['meta', { property: 'og:site_name', content: 'Triggerfish' }],
+    ['meta', { property: 'og:image', content: 'https://trigger.fish/triggerfish.png' }],
+    ['meta', { property: 'og:image:alt', content: 'Triggerfish — secure AI agent platform' }],
+    ['meta', { property: 'og:image:width', content: '1024' }],
+    ['meta', { property: 'og:image:height', content: '1024' }],
+
+    // Twitter Card
     ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
+    ['meta', { name: 'twitter:title', content: 'Triggerfish — Secure AI Agents' }],
+    ['meta', { name: 'twitter:description', content: 'A secure, multi-channel AI agent platform with deterministic policy enforcement below the LLM layer. Every channel. No exceptions.' }],
+    ['meta', { name: 'twitter:image', content: 'https://trigger.fish/triggerfish.png' }],
+    ['meta', { name: 'twitter:image:alt', content: 'Triggerfish — secure AI agent platform' }],
   ],
 
   themeConfig: {


### PR DESCRIPTION
## Summary
- Adds complete OpenGraph meta tags (`og:image`, `og:site_name`, `og:image:alt`, dimensions) to fill gaps in existing partial tags
- Adds Twitter Card tags (`twitter:title`, `twitter:description`, `twitter:image`, `twitter:image:alt`) so link previews render properly
- Uses the existing `triggerfish.png` (1024x1024) already in `docs/public/`

## Test plan
- [ ] Deploy preview and validate with [opengraph.xyz](https://opengraph.xyz)
- [ ] Check Twitter card with [Twitter Card Validator](https://cards-dev.twitter.com/validator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)