### PR TITLE
fix: remove memory_save/memory_delete from BUILTIN_TOOL_CLASSIFICATIONS

### DIFF
--- a/src/agent/orchestrator/orchestrator_types.ts
+++ b/src/agent/orchestrator/orchestrator_types.ts
@@ -173,9 +173,13 @@ export interface ClassificationMapConfig {
  * RESTRICTED — owner-only operations, never reachable by non-owners
  */
 const BUILTIN_TOOL_CLASSIFICATIONS: ReadonlyArray<readonly [string, ClassificationLevel]> = [
-  // Memory — specific names before group prefix
-  ["memory_save", "RESTRICTED"],
-  ["memory_delete", "RESTRICTED"],
+  // Memory — read tools are PUBLIC; save/delete are intentionally absent.
+  // memory_save and memory_delete operate at the current session taint level
+  // (the memory executor forces classification to sessionTaint). They must
+  // not appear here because: (1) prefix-based taint escalation would
+  // incorrectly escalate the session, and (2) the write-down check would
+  // block higher-tainted sessions from saving. Non-owner blocking is
+  // handled by enforceNonOwnerToolCeiling (unmatched tools → denied).
   ["memory_search", "PUBLIC"],
   ["memory_get", "PUBLIC"],
   ["memory_list", "PUBLIC"],

--- a/tests/agent/orchestrator_role_test.ts
+++ b/tests/agent/orchestrator_role_test.ts
@@ -1,14 +1,16 @@
 /**
- * Tests for orchestrator-level role enforcement.
+ * Tests for orchestrator-level role enforcement and tool classification.
  *
- * Verifies that resolveActiveToolList applies the filterTools callback
- * and that enforceNonOwnerToolCeiling works correctly with built-in
- * tool classifications from mapToolPrefixClassifications.
+ * Verifies that resolveActiveToolList applies the filterTools callback,
+ * that enforceNonOwnerToolCeiling works correctly with built-in
+ * tool classifications, and that memory_save/memory_delete do not
+ * trigger taint escalation (they operate at session taint level).
  */
 import { assertEquals, assert } from "@std/assert";
 import { resolveActiveToolList } from "../../src/agent/loop/loop_types.ts";
 import {
   enforceNonOwnerToolCeiling,
+  escalateToolPrefixTaint,
 } from "../../src/agent/dispatch/access_control.ts";
 import {
   mapToolPrefixClassifications,
@@ -115,11 +117,13 @@ Deno.test("resolveActiveToolList: filterTools applies to extra tools too", () =>
 
 Deno.test("mapToolPrefixClassifications: includes built-in tool classifications", () => {
   const map = mapToolPrefixClassifications({});
-  // Should have built-in entries for memory, browser, web, etc.
-  assert(map.has("memory_save"), "Should have memory_save entry");
+  // Should have built-in entries for memory read tools, browser, web, etc.
   assert(map.has("memory_search"), "Should have memory_search entry");
   assert(map.has("browser_"), "Should have browser_ prefix entry");
   assert(map.has("web_"), "Should have web_ prefix entry");
+  // memory_save and memory_delete are intentionally absent
+  assert(!map.has("memory_save"), "memory_save must not be in classification map");
+  assert(!map.has("memory_delete"), "memory_delete must not be in classification map");
 });
 
 Deno.test("mapToolPrefixClassifications: memory_search classified PUBLIC", () => {
@@ -127,9 +131,14 @@ Deno.test("mapToolPrefixClassifications: memory_search classified PUBLIC", () =>
   assertEquals(map.get("memory_search"), "PUBLIC");
 });
 
-Deno.test("mapToolPrefixClassifications: memory_save classified RESTRICTED", () => {
+Deno.test("mapToolPrefixClassifications: memory_save absent (operates at session taint)", () => {
   const map = mapToolPrefixClassifications({});
-  assertEquals(map.get("memory_save"), "RESTRICTED");
+  assertEquals(map.has("memory_save"), false, "memory_save must not be in classification map");
+});
+
+Deno.test("mapToolPrefixClassifications: memory_delete absent (operates at session taint)", () => {
+  const map = mapToolPrefixClassifications({});
+  assertEquals(map.has("memory_delete"), false, "memory_delete must not be in classification map");
 });
 
 Deno.test("mapToolPrefixClassifications: browser_ classified RESTRICTED", () => {
@@ -194,14 +203,15 @@ Deno.test("enforceNonOwnerToolCeiling: non-owner with PUBLIC ceiling can use web
   assertEquals(err, null, "web_search (PUBLIC) should be allowed for PUBLIC ceiling");
 });
 
-Deno.test("enforceNonOwnerToolCeiling: non-owner with PUBLIC ceiling blocks memory_save", () => {
+Deno.test("enforceNonOwnerToolCeiling: non-owner with PUBLIC ceiling blocks memory_save (unmatched)", () => {
   const map = mapToolPrefixClassifications({});
   const err = enforceNonOwnerToolCeiling(
     "memory_save",
     "PUBLIC" as ClassificationLevel,
     map,
   );
-  assert(err !== null, "memory_save (RESTRICTED) should be blocked for PUBLIC ceiling");
+  assert(err !== null, "memory_save (unmatched) should be blocked for non-owners");
+  assert(err!.includes("not available"), "Unmatched tool should report 'not available'");
 });
 
 Deno.test("enforceNonOwnerToolCeiling: non-owner with null ceiling blocks all tools", () => {
@@ -213,4 +223,71 @@ Deno.test("enforceNonOwnerToolCeiling: non-owner with null ceiling blocks all to
   );
   assert(err !== null, "null ceiling should block all tool calls");
   assert(err!.includes("not available"), "Error should state tools not available");
+});
+
+// ─── memory_save / memory_delete do NOT escalate taint ─────────────────────
+
+Deno.test("escalateToolPrefixTaint: memory_save does not escalate at PUBLIC", () => {
+  const map = mapToolPrefixClassifications({});
+  let escalated = false;
+  escalateToolPrefixTaint("memory_save", map, (_level: ClassificationLevel, _reason: string) => {
+    escalated = true;
+  });
+  assertEquals(escalated, false, "memory_save must not trigger taint escalation");
+});
+
+Deno.test("escalateToolPrefixTaint: memory_save does not escalate at INTERNAL", () => {
+  const map = mapToolPrefixClassifications({});
+  let escalated = false;
+  escalateToolPrefixTaint("memory_save", map, (_level: ClassificationLevel, _reason: string) => {
+    escalated = true;
+  });
+  assertEquals(escalated, false, "memory_save must not trigger taint escalation");
+});
+
+Deno.test("escalateToolPrefixTaint: memory_save does not escalate at CONFIDENTIAL", () => {
+  const map = mapToolPrefixClassifications({});
+  let escalated = false;
+  escalateToolPrefixTaint("memory_save", map, (_level: ClassificationLevel, _reason: string) => {
+    escalated = true;
+  });
+  assertEquals(escalated, false, "memory_save must not trigger taint escalation");
+});
+
+Deno.test("escalateToolPrefixTaint: memory_save does not escalate at RESTRICTED", () => {
+  const map = mapToolPrefixClassifications({});
+  let escalated = false;
+  escalateToolPrefixTaint("memory_save", map, (_level: ClassificationLevel, _reason: string) => {
+    escalated = true;
+  });
+  assertEquals(escalated, false, "memory_save must not trigger taint escalation");
+});
+
+Deno.test("escalateToolPrefixTaint: memory_delete does not escalate", () => {
+  const map = mapToolPrefixClassifications({});
+  let escalated = false;
+  escalateToolPrefixTaint("memory_delete", map, (_level: ClassificationLevel, _reason: string) => {
+    escalated = true;
+  });
+  assertEquals(escalated, false, "memory_delete must not trigger taint escalation");
+});
+
+Deno.test("escalateToolPrefixTaint: memory read tools do not escalate", () => {
+  const map = mapToolPrefixClassifications({});
+  for (const tool of ["memory_get", "memory_search", "memory_list"]) {
+    let escalatedLevel: ClassificationLevel | null = null;
+    escalateToolPrefixTaint(tool, map, (level: ClassificationLevel, _reason: string) => {
+      escalatedLevel = level;
+    });
+    assertEquals(escalatedLevel, "PUBLIC", `${tool} should escalate to PUBLIC (its classification)`);
+  }
+});
+
+Deno.test("escalateToolPrefixTaint: write_file still escalates to RESTRICTED", () => {
+  const map = mapToolPrefixClassifications({});
+  let escalatedLevel: ClassificationLevel | null = null;
+  escalateToolPrefixTaint("write_file", map, (level: ClassificationLevel, _reason: string) => {
+    escalatedLevel = level;
+  });
+  assertEquals(escalatedLevel, "RESTRICTED", "write_file must still escalate to RESTRICTED");
 });

--- a/tests/e2e/resource_classification_test.ts
+++ b/tests/e2e/resource_classification_test.ts
@@ -693,9 +693,9 @@ Deno.test("resource-classification: read_file on INTERNAL path escalates via res
   assert(escalations[0].reason.includes("read_file"), "Escalation reason should mention read_file");
 });
 
-// --- Test: non-resource tool (memory_save) still escalates via prefix ---
+// --- Test: memory_save does NOT escalate taint (operates at session taint) ---
 
-Deno.test("resource-classification: non-resource tool escalates via prefix classification", async () => {
+Deno.test("resource-classification: memory_save does not escalate session taint", async () => {
   const hookRunner = makeHookRunner();
   const toolClassifications = mapToolPrefixClassifications({});
 
@@ -732,9 +732,10 @@ Deno.test("resource-classification: non-resource tool escalates via prefix class
   });
 
   assertEquals(result.ok, true);
-  // memory_save has RESTRICTED prefix classification — should escalate via prefix
-  assertEquals(sessionTaint, "RESTRICTED", "Session taint should escalate to RESTRICTED from memory_save prefix classification");
-  assert(escalations.length >= 1, "Should have at least one escalation");
+  // memory_save is intentionally absent from BUILTIN_TOOL_CLASSIFICATIONS —
+  // it operates at the current session taint level and must not escalate.
+  assertEquals(sessionTaint, "PUBLIC", "Session taint must remain PUBLIC — memory_save does not escalate");
+  assertEquals(escalations.length, 0, "No taint escalations should occur for memory_save");
 });
 
 // --- Test: list_directory and search_files on PUBLIC path do NOT escalate ---


### PR DESCRIPTION
Fixes #171

`memory_save` and `memory_delete` are not RESTRICTED tools. They operate at every classification level — the memory executor forces classification to `ctx.sessionTaint`. Having them in `BUILTIN_TOOL_CLASSIFICATIONS` as RESTRICTED caused `escalateToolPrefixTaint` to incorrectly escalate the session to RESTRICTED on every memory save/delete.

Removes both entries from the classification map and updates all tests.

Generated with [Claude Code](https://claude.ai/code)