### PR TITLE
feat: thread sessionId through LLM provider options

### DIFF
--- a/src/agent/loop/loop_iteration.ts
+++ b/src/agent/loop/loop_iteration.ts
@@ -135,6 +135,7 @@ async function runLlmProviderCall(
     : [];
   const completion = await provider.complete(messages, nativeTools, {
     ...(ctx.signal ? { signal: ctx.signal } : {}),
+    sessionId: ctx.sessionKey,
   });
   return { completion, tools };
 }


### PR DESCRIPTION
## Summary

- Passes `sessionId` (from `AgentLoopContext.sessionKey`) into the LLM provider `options` bag at the call site in `loop_iteration.ts`
- Enables providers to use session identity for affinity routing, tracing, or logging
- No interface changes — `options: Record<string, unknown>` already accommodates arbitrary keys; providers that don't need sessionId simply ignore it

## Context

Fireworks AI's prompt caching benefits from `x-session-affinity` header to route same-session requests to the same replica. This PR adds the infrastructure (sessionId in options). The Fireworks provider that consumes it is in #PR_FIREWORKS (feat/fireworks-provider).

Other providers (Anthropic, OpenAI, Google, etc.) use content-hash-based caching and don't need session affinity.

## Test plan

- [x] `deno task lint` — 759 files, zero errors
- [x] `deno task check` — type check passes
- [x] `deno task test tests/agent/` — 190 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)