### PR TITLE
feat: rename GitHub tools to verb-first + add 11 CRUD tools

### DIFF
--- a/src/integrations/github/actions/client_workflows.ts
+++ b/src/integrations/github/actions/client_workflows.ts
@@ -86,6 +86,35 @@ export async function fetchRepoWorkflowRuns(
   return { ok: true, value: runs };
 }
 
+/** Cancel a workflow run on a GitHub repo. */
+export async function cancelRepoWorkflowRun(
+  apiRequest: ApiRequestFn,
+  classifyRepo: ClassifyRepoFn,
+  owner: string,
+  repo: string,
+  runId: number,
+): Promise<
+  Result<
+    {
+      readonly cancelled: boolean;
+      readonly classification: ClassificationLevel;
+    },
+    GitHubError
+  >
+> {
+  const path = `${buildRepoPath(owner, repo)}/actions/runs/${runId}/cancel`;
+  const result = await apiRequest<undefined>(path, { method: "POST" });
+  if (!result.ok) return result;
+
+  const classification = await fetchRepoClassification(
+    apiRequest,
+    classifyRepo,
+    owner,
+    repo,
+  );
+  return { ok: true, value: { cancelled: true, classification } };
+}
+
 /** Trigger a workflow dispatch on a GitHub repo. */
 export async function dispatchRepoWorkflow(
   apiRequest: ApiRequestFn,

--- a/src/integrations/github/actions/mod.ts
+++ b/src/integrations/github/actions/mod.ts
@@ -6,14 +6,16 @@
 
 export {
   fetchRepoWorkflowRuns,
+  cancelRepoWorkflowRun,
   dispatchRepoWorkflow,
   searchGitHubCode,
   searchGitHubIssues,
 } from "./client_workflows.ts";
 
 export {
-  executeActionsRuns,
-  executeActionsTrigger,
+  executeListRuns,
+  executeTriggerWorkflow,
+  executeCancelRun,
 } from "./tools_actions.ts";
 
 export {
@@ -22,8 +24,9 @@ export {
 } from "./tools_search.ts";
 
 export {
-  buildActionsRunsDef,
-  buildActionsTriggerDef,
+  buildListRunsDef,
+  buildCancelRunDef,
+  buildTriggerWorkflowDef,
   buildSearchCodeDef,
   buildSearchIssuesDef,
 } from "./tools_defs_actions.ts";

--- a/src/integrations/github/actions/tools_actions.ts
+++ b/src/integrations/github/actions/tools_actions.ts
@@ -1,5 +1,5 @@
 /**
- * GitHub Actions tool handlers — workflow runs, trigger.
+ * GitHub Actions tool handlers — workflow runs, trigger, cancel.
  *
  * Each handler validates inputs, calls the GitHubClient, and
  * formats the response as a JSON string for the agent.
@@ -12,12 +12,12 @@ import { validateRepoInput, formatGitHubError } from "../tools_shared.ts";
 
 // ─── List Workflow Runs ──────────────────────────────────────────────────────
 
-/** Handle the github_actions_runs tool invocation. */
-export async function executeActionsRuns(
+/** Handle the github_list_runs tool invocation. */
+export async function executeListRuns(
   client: GitHubClient,
   input: Record<string, unknown>,
 ): Promise<string> {
-  const repoResult = validateRepoInput(input, "github_actions_runs");
+  const repoResult = validateRepoInput(input, "github_list_runs");
   if (typeof repoResult === "string") return repoResult;
 
   const workflow = typeof input.workflow === "string" ? input.workflow : undefined;
@@ -40,21 +40,21 @@ export async function executeActionsRuns(
 
 // ─── Trigger Workflow ────────────────────────────────────────────────────────
 
-/** Handle the github_actions_trigger tool invocation. */
-export async function executeActionsTrigger(
+/** Handle the github_trigger_workflow tool invocation. */
+export async function executeTriggerWorkflow(
   client: GitHubClient,
   input: Record<string, unknown>,
 ): Promise<string> {
-  const repoResult = validateRepoInput(input, "github_actions_trigger");
+  const repoResult = validateRepoInput(input, "github_trigger_workflow");
   if (typeof repoResult === "string") return repoResult;
 
   const workflow = input.workflow;
   if (typeof workflow !== "string" || workflow.length === 0) {
-    return "Error: github_actions_trigger requires a 'workflow' argument.";
+    return "Error: github_trigger_workflow requires a 'workflow' argument.";
   }
   const ref = input.ref;
   if (typeof ref !== "string" || ref.length === 0) {
-    return "Error: github_actions_trigger requires a 'ref' argument.";
+    return "Error: github_trigger_workflow requires a 'ref' argument.";
   }
   const inputs = (input.inputs && typeof input.inputs === "object" && !Array.isArray(input.inputs))
     ? input.inputs as Readonly<Record<string, string>>
@@ -64,6 +64,29 @@ export async function executeActionsTrigger(
   if (!result.ok) return formatGitHubError(result.error);
   return JSON.stringify({
     triggered: result.value.triggered,
+    _classification: result.value.classification,
+  });
+}
+
+// ─── Cancel Workflow Run ──────────────────────────────────────────────────────
+
+/** Handle the github_cancel_run tool invocation. */
+export async function executeCancelRun(
+  client: GitHubClient,
+  input: Record<string, unknown>,
+): Promise<string> {
+  const repoResult = validateRepoInput(input, "github_cancel_run");
+  if (typeof repoResult === "string") return repoResult;
+
+  const runId = input.run_id;
+  if (typeof runId !== "number" || !Number.isInteger(runId)) {
+    return "Error: github_cancel_run requires a numeric 'run_id' argument.";
+  }
+
+  const result = await client.cancelRun(repoResult.owner, repoResult.name, runId);
+  if (!result.ok) return formatGitHubError(result.error);
+  return JSON.stringify({
+    cancelled: result.value.cancelled,
     _classification: result.value.classification,
   });
 }

--- a/src/integrations/github/actions/tools_defs_actions.ts
+++ b/src/integrations/github/actions/tools_defs_actions.ts
@@ -9,10 +9,10 @@
 
 import type { ToolDefinition } from "../../../core/types/tool.ts";
 
-/** Build the github_actions_runs tool definition. */
-export function buildActionsRunsDef(): ToolDefinition {
+/** Build the github_list_runs tool definition. */
+export function buildListRunsDef(): ToolDefinition {
   return {
-    name: "github_actions_runs",
+    name: "github_list_runs",
     description: "List recent GitHub Actions workflow runs for a repository.",
     parameters: {
       repo: {
@@ -58,13 +58,34 @@ function buildActionsTriggerParams(): ToolDefinition["parameters"] {
   };
 }
 
-/** Build the github_actions_trigger tool definition. */
-export function buildActionsTriggerDef(): ToolDefinition {
+/** Build the github_trigger_workflow tool definition. */
+export function buildTriggerWorkflowDef(): ToolDefinition {
   return {
-    name: "github_actions_trigger",
+    name: "github_trigger_workflow",
     description:
       "Trigger a GitHub Actions workflow via workflow_dispatch event.",
     parameters: buildActionsTriggerParams(),
+  };
+}
+
+/** Build the github_cancel_run tool definition. */
+export function buildCancelRunDef(): ToolDefinition {
+  return {
+    name: "github_cancel_run",
+    description:
+      "Cancel a GitHub Actions workflow run. Returns whether the cancellation was accepted.",
+    parameters: {
+      repo: {
+        type: "string",
+        description: 'Repository in "owner/name" format',
+        required: true,
+      },
+      run_id: {
+        type: "number",
+        description: "The workflow run ID to cancel",
+        required: true,
+      },
+    },
   };
 }
 

--- a/src/integrations/github/client.ts
+++ b/src/integrations/github/client.ts
@@ -12,15 +12,20 @@ import type {
   ClassificationLevel,
 } from "../../core/types/classification.ts";
 import type {
+  GitHubBranch,
   GitHubClassificationConfig,
   GitHubCodeSearchItem,
+  GitHubComment,
   GitHubCommit,
   GitHubError,
   GitHubFileContent,
   GitHubIssue,
   GitHubIssueSearchItem,
   GitHubPull,
+  GitHubPullDetail,
+  GitHubPullFile,
   GitHubRepo,
+  GitHubRepoDetail,
   GitHubWorkflowRun,
   RepoVisibility,
 } from "./types.ts";
@@ -28,20 +33,35 @@ import type { Result } from "../../core/types/classification.ts";
 import type { ApiRequestFn, ClassifyRepoFn } from "./client_http.ts";
 import { sendGitHubApiRequest } from "./client_http.ts";
 import type { GitHubApiContext } from "./client_http.ts";
-import { fetchUserRepos, fetchRepoFile, fetchRepoCommits } from "./repos/mod.ts";
+import {
+  fetchRepo,
+  fetchUserRepos,
+  fetchRepoFile,
+  fetchRepoCommits,
+  fetchRepoBranches,
+  createRepoBranch,
+  deleteRepoBranch,
+} from "./repos/mod.ts";
 import {
   fetchRepoPulls,
+  fetchRepoPull,
+  updateRepoPull,
+  fetchPullFiles,
   submitRepoPullRequest,
   submitPullRequestReview,
   mergeRepoPullRequest,
 } from "./pulls/mod.ts";
 import {
   fetchRepoIssues,
+  fetchRepoIssue,
+  updateRepoIssue,
+  fetchIssueComments,
   submitRepoIssue,
   submitIssueComment,
 } from "./issues/mod.ts";
 import {
   fetchRepoWorkflowRuns,
+  cancelRepoWorkflowRun,
   dispatchRepoWorkflow,
   searchGitHubCode,
   searchGitHubIssues,
@@ -60,6 +80,10 @@ export interface GitHubClient {
   readonly listRepos: (
     opts?: { readonly page?: number; readonly perPage?: number },
   ) => Promise<Result<readonly GitHubRepo[], GitHubError>>;
+  readonly getRepo: (
+    owner: string,
+    repo: string,
+  ) => Promise<Result<GitHubRepoDetail, GitHubError>>;
   readonly readFile: (
     owner: string,
     repo: string,
@@ -71,6 +95,39 @@ export interface GitHubClient {
     repo: string,
     opts?: { readonly sha?: string; readonly perPage?: number },
   ) => Promise<Result<readonly GitHubCommit[], GitHubError>>;
+  readonly listBranches: (
+    owner: string,
+    repo: string,
+    opts?: { readonly perPage?: number },
+  ) => Promise<Result<readonly GitHubBranch[], GitHubError>>;
+  readonly createBranch: (
+    owner: string,
+    repo: string,
+    branchName: string,
+    sha: string,
+  ) => Promise<
+    Result<
+      {
+        readonly ref: string;
+        readonly sha: string;
+        readonly classification: ClassificationLevel;
+      },
+      GitHubError
+    >
+  >;
+  readonly deleteBranch: (
+    owner: string,
+    repo: string,
+    branchName: string,
+  ) => Promise<
+    Result<
+      {
+        readonly deleted: boolean;
+        readonly classification: ClassificationLevel;
+      },
+      GitHubError
+    >
+  >;
   readonly listPulls: (
     owner: string,
     repo: string,
@@ -115,6 +172,28 @@ export interface GitHubClient {
       GitHubError
     >
   >;
+  readonly getPull: (
+    owner: string,
+    repo: string,
+    prNumber: number,
+  ) => Promise<Result<GitHubPullDetail, GitHubError>>;
+  readonly updatePull: (
+    owner: string,
+    repo: string,
+    prNumber: number,
+    fields: {
+      readonly title?: string;
+      readonly body?: string;
+      readonly base?: string;
+      readonly state?: string;
+    },
+  ) => Promise<Result<GitHubPullDetail, GitHubError>>;
+  readonly listPullFiles: (
+    owner: string,
+    repo: string,
+    prNumber: number,
+    opts?: { readonly perPage?: number },
+  ) => Promise<Result<readonly GitHubPullFile[], GitHubError>>;
   readonly listIssues: (
     owner: string,
     repo: string,
@@ -146,6 +225,29 @@ export interface GitHubClient {
       GitHubError
     >
   >;
+  readonly getIssue: (
+    owner: string,
+    repo: string,
+    issueNumber: number,
+  ) => Promise<Result<GitHubIssue, GitHubError>>;
+  readonly updateIssue: (
+    owner: string,
+    repo: string,
+    issueNumber: number,
+    fields: {
+      readonly title?: string;
+      readonly body?: string;
+      readonly state?: string;
+      readonly labels?: readonly string[];
+      readonly assignees?: readonly string[];
+    },
+  ) => Promise<Result<GitHubIssue, GitHubError>>;
+  readonly listComments: (
+    owner: string,
+    repo: string,
+    issueNumber: number,
+    opts?: { readonly perPage?: number },
+  ) => Promise<Result<readonly GitHubComment[], GitHubError>>;
   readonly listWorkflowRuns: (
     owner: string,
     repo: string,
@@ -155,6 +257,19 @@ export interface GitHubClient {
       readonly perPage?: number;
     },
   ) => Promise<Result<readonly GitHubWorkflowRun[], GitHubError>>;
+  readonly cancelRun: (
+    owner: string,
+    repo: string,
+    runId: number,
+  ) => Promise<
+    Result<
+      {
+        readonly cancelled: boolean;
+        readonly classification: ClassificationLevel;
+      },
+      GitHubError
+    >
+  >;
   readonly triggerWorkflow: (
     owner: string,
     repo: string,
@@ -239,10 +354,18 @@ export function createGitHubClient(config: GitHubClientConfig): GitHubClient {
 
   return {
     listRepos: (opts) => fetchUserRepos(apiRequest, classifyRepo, opts),
+    getRepo: (owner, repo) =>
+      fetchRepo(apiRequest, classifyRepo, owner, repo),
     readFile: (owner, repo, path, ref) =>
       fetchRepoFile(apiRequest, classifyRepo, owner, repo, path, ref),
     listCommits: (owner, repo, opts) =>
       fetchRepoCommits(apiRequest, classifyRepo, owner, repo, opts),
+    listBranches: (owner, repo, opts) =>
+      fetchRepoBranches(apiRequest, classifyRepo, owner, repo, opts),
+    createBranch: (owner, repo, branchName, sha) =>
+      createRepoBranch(apiRequest, classifyRepo, owner, repo, branchName, sha),
+    deleteBranch: (owner, repo, branchName) =>
+      deleteRepoBranch(apiRequest, classifyRepo, owner, repo, branchName),
     listPulls: (owner, repo, opts) =>
       fetchRepoPulls(apiRequest, classifyRepo, owner, repo, opts),
     createPull: (owner, repo, title, head, base, body) =>
@@ -275,6 +398,12 @@ export function createGitHubClient(config: GitHubClientConfig): GitHubClient {
         prNumber,
         opts,
       ),
+    getPull: (owner, repo, prNumber) =>
+      fetchRepoPull(apiRequest, classifyRepo, owner, repo, prNumber),
+    updatePull: (owner, repo, prNumber, fields) =>
+      updateRepoPull(apiRequest, classifyRepo, owner, repo, prNumber, fields),
+    listPullFiles: (owner, repo, prNumber, opts) =>
+      fetchPullFiles(apiRequest, classifyRepo, owner, repo, prNumber, opts),
     listIssues: (owner, repo, opts) =>
       fetchRepoIssues(apiRequest, classifyRepo, owner, repo, opts),
     createIssue: (owner, repo, title, body, labels) =>
@@ -296,8 +425,30 @@ export function createGitHubClient(config: GitHubClientConfig): GitHubClient {
         issueNumber,
         body,
       ),
+    getIssue: (owner, repo, issueNumber) =>
+      fetchRepoIssue(apiRequest, classifyRepo, owner, repo, issueNumber),
+    updateIssue: (owner, repo, issueNumber, fields) =>
+      updateRepoIssue(
+        apiRequest,
+        classifyRepo,
+        owner,
+        repo,
+        issueNumber,
+        fields,
+      ),
+    listComments: (owner, repo, issueNumber, opts) =>
+      fetchIssueComments(
+        apiRequest,
+        classifyRepo,
+        owner,
+        repo,
+        issueNumber,
+        opts,
+      ),
     listWorkflowRuns: (owner, repo, opts) =>
       fetchRepoWorkflowRuns(apiRequest, classifyRepo, owner, repo, opts),
+    cancelRun: (owner, repo, runId) =>
+      cancelRepoWorkflowRun(apiRequest, classifyRepo, owner, repo, runId),
     triggerWorkflow: (owner, repo, workflow, ref, inputs) =>
       dispatchRepoWorkflow(
         apiRequest,

--- a/src/integrations/github/client_http.ts
+++ b/src/integrations/github/client_http.ts
@@ -60,6 +60,11 @@ export interface RawCommit {
   readonly html_url: string;
 }
 
+export interface RawBranch {
+  readonly name: string;
+  readonly protected: boolean;
+}
+
 export interface RawPull {
   readonly number: number;
   readonly title: string;
@@ -69,6 +74,38 @@ export interface RawPull {
   readonly base: { readonly ref: string };
   readonly html_url: string;
   readonly created_at: string;
+}
+
+export interface RawPullDetail {
+  readonly number: number;
+  readonly title: string;
+  readonly state: string;
+  readonly user?: { readonly login?: string };
+  readonly body?: string | null;
+  readonly head: { readonly ref: string };
+  readonly base: { readonly ref: string };
+  readonly html_url: string;
+  readonly created_at: string;
+  readonly additions: number;
+  readonly deletions: number;
+  readonly changed_files: number;
+  readonly mergeable?: boolean | null;
+}
+
+export interface RawPullFile {
+  readonly filename: string;
+  readonly status: string;
+  readonly additions: number;
+  readonly deletions: number;
+  readonly changes: number;
+}
+
+export interface RawComment {
+  readonly id: number;
+  readonly user?: { readonly login?: string };
+  readonly body: string;
+  readonly created_at: string;
+  readonly html_url: string;
 }
 
 export interface RawIssue {

--- a/src/integrations/github/issues/client_issues.ts
+++ b/src/integrations/github/issues/client_issues.ts
@@ -5,8 +5,8 @@
  */
 
 import type { ClassificationLevel, Result } from "../../../core/types/classification.ts";
-import type { GitHubError, GitHubIssue } from "../types.ts";
-import type { ApiRequestFn, ClassifyRepoFn, RawIssue } from "../client_http.ts";
+import type { GitHubComment, GitHubError, GitHubIssue } from "../types.ts";
+import type { ApiRequestFn, ClassifyRepoFn, RawComment, RawIssue } from "../client_http.ts";
 import { buildRepoPath, fetchRepoClassification } from "../client_http.ts";
 
 /** Extract label names from raw issue label data. */
@@ -32,6 +32,108 @@ function mapRawIssueToGitHubIssue(
     labels: extractIssueLabels(i.labels),
     classification,
   };
+}
+
+/** Fetch a single issue from a GitHub repo. */
+export async function fetchRepoIssue(
+  apiRequest: ApiRequestFn,
+  classifyRepo: ClassifyRepoFn,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+): Promise<Result<GitHubIssue, GitHubError>> {
+  const result = await apiRequest<RawIssue>(
+    `${buildRepoPath(owner, repo)}/issues/${issueNumber}`,
+  );
+  if (!result.ok) return result;
+
+  const classification = await fetchRepoClassification(
+    apiRequest,
+    classifyRepo,
+    owner,
+    repo,
+  );
+  return {
+    ok: true,
+    value: mapRawIssueToGitHubIssue(result.value.data, classification),
+  };
+}
+
+/** Update an issue on a GitHub repo. */
+export async function updateRepoIssue(
+  apiRequest: ApiRequestFn,
+  classifyRepo: ClassifyRepoFn,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  fields: {
+    readonly title?: string;
+    readonly body?: string;
+    readonly state?: string;
+    readonly labels?: readonly string[];
+    readonly assignees?: readonly string[];
+  },
+): Promise<Result<GitHubIssue, GitHubError>> {
+  const result = await apiRequest<RawIssue>(
+    `${buildRepoPath(owner, repo)}/issues/${issueNumber}`,
+    { method: "PATCH", body: fields },
+  );
+  if (!result.ok) return result;
+
+  const classification = await fetchRepoClassification(
+    apiRequest,
+    classifyRepo,
+    owner,
+    repo,
+  );
+  return {
+    ok: true,
+    value: mapRawIssueToGitHubIssue(result.value.data, classification),
+  };
+}
+
+/** Map a raw comment to a GitHubComment domain type. */
+function mapRawCommentToGitHubComment(
+  c: RawComment,
+  classification: ClassificationLevel,
+): GitHubComment {
+  return {
+    id: c.id,
+    author: c.user?.login ?? "unknown",
+    body: c.body,
+    createdAt: c.created_at,
+    htmlUrl: c.html_url,
+    classification,
+  };
+}
+
+/** Fetch comments on an issue or pull request. */
+export async function fetchIssueComments(
+  apiRequest: ApiRequestFn,
+  classifyRepo: ClassifyRepoFn,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  opts?: { readonly perPage?: number },
+): Promise<Result<readonly GitHubComment[], GitHubError>> {
+  const params = new URLSearchParams();
+  params.set("per_page", String(opts?.perPage ?? 30));
+
+  const result = await apiRequest<readonly RawComment[]>(
+    `${buildRepoPath(owner, repo)}/issues/${issueNumber}/comments?${params.toString()}`,
+  );
+  if (!result.ok) return result;
+
+  const classification = await fetchRepoClassification(
+    apiRequest,
+    classifyRepo,
+    owner,
+    repo,
+  );
+  const comments = result.value.data.map((c) =>
+    mapRawCommentToGitHubComment(c, classification)
+  );
+  return { ok: true, value: comments };
 }
 
 /** Fetch issues from a GitHub repo. */

--- a/src/integrations/github/issues/mod.ts
+++ b/src/integrations/github/issues/mod.ts
@@ -6,18 +6,27 @@
 
 export {
   fetchRepoIssues,
+  fetchRepoIssue,
+  updateRepoIssue,
+  fetchIssueComments,
   submitRepoIssue,
   submitIssueComment,
 } from "./client_issues.ts";
 
 export {
-  executeIssuesList,
-  executeIssuesCreate,
-  executeIssuesComment,
+  executeListIssues,
+  executeGetIssue,
+  executeCreateIssue,
+  executeUpdateIssue,
+  executeListComments,
+  executeAddComment,
 } from "./tools_issues.ts";
 
 export {
-  buildIssuesListDef,
-  buildIssuesCreateDef,
-  buildIssuesCommentDef,
+  buildListIssuesDef,
+  buildGetIssueDef,
+  buildCreateIssueDef,
+  buildUpdateIssueDef,
+  buildListCommentsDef,
+  buildAddCommentDef,
 } from "./tools_defs_issues.ts";

--- a/src/integrations/github/issues/tools_defs_issues.ts
+++ b/src/integrations/github/issues/tools_defs_issues.ts
@@ -1,7 +1,7 @@
 /**
  * GitHub issue tool definitions.
  *
- * Defines the 3 issue tool schemas: list, create, comment.
+ * Defines the 6 issue tool schemas: list, get, create, update, comment, list_comments.
  *
  * @module
  */
@@ -32,20 +32,41 @@ function buildIssuesListParams(): ToolDefinition["parameters"] {
   };
 }
 
-/** Build the github_issues_list tool definition. */
-export function buildIssuesListDef(): ToolDefinition {
+/** Build the github_list_issues tool definition. */
+export function buildListIssuesDef(): ToolDefinition {
   return {
-    name: "github_issues_list",
+    name: "github_list_issues",
     description:
       "List issues for a repository. Returns issue number, title, state, labels, and author.",
     parameters: buildIssuesListParams(),
   };
 }
 
-/** Build the github_issues_create tool definition. */
-export function buildIssuesCreateDef(): ToolDefinition {
+/** Build the github_get_issue tool definition. */
+export function buildGetIssueDef(): ToolDefinition {
   return {
-    name: "github_issues_create",
+    name: "github_get_issue",
+    description:
+      "Get a single issue by number. Returns full details including body, assignees, milestone, and labels.",
+    parameters: {
+      repo: {
+        type: "string",
+        description: 'Repository in "owner/name" format',
+        required: true,
+      },
+      number: {
+        type: "number",
+        description: "Issue number",
+        required: true,
+      },
+    },
+  };
+}
+
+/** Build the github_create_issue tool definition. */
+export function buildCreateIssueDef(): ToolDefinition {
+  return {
+    name: "github_create_issue",
     description:
       "Create a new issue in a repository. Returns the created issue details.",
     parameters: {
@@ -64,10 +85,70 @@ export function buildIssuesCreateDef(): ToolDefinition {
   };
 }
 
-/** Build the github_issues_comment tool definition. */
-export function buildIssuesCommentDef(): ToolDefinition {
+/** Build the github_update_issue tool definition. */
+export function buildUpdateIssueDef(): ToolDefinition {
   return {
-    name: "github_issues_comment",
+    name: "github_update_issue",
+    description:
+      "Update an existing issue. Can change title, body, state, labels, and assignees.",
+    parameters: {
+      repo: {
+        type: "string",
+        description: 'Repository in "owner/name" format',
+        required: true,
+      },
+      number: {
+        type: "number",
+        description: "Issue number",
+        required: true,
+      },
+      title: { type: "string", description: "New issue title" },
+      body: { type: "string", description: "New issue body (markdown)" },
+      state: {
+        type: "string",
+        description: 'Set state: "open" or "closed"',
+      },
+      labels: {
+        type: "string",
+        description: "Comma-separated list of label names (replaces existing)",
+      },
+      assignees: {
+        type: "string",
+        description: "Comma-separated list of GitHub usernames to assign",
+      },
+    },
+  };
+}
+
+/** Build the github_list_comments tool definition. */
+export function buildListCommentsDef(): ToolDefinition {
+  return {
+    name: "github_list_comments",
+    description:
+      "List comments on an issue or pull request. Returns comment author, body, and date.",
+    parameters: {
+      repo: {
+        type: "string",
+        description: 'Repository in "owner/name" format',
+        required: true,
+      },
+      number: {
+        type: "number",
+        description: "Issue or PR number",
+        required: true,
+      },
+      per_page: {
+        type: "number",
+        description: "Number of comments to return (default: 30)",
+      },
+    },
+  };
+}
+
+/** Build the github_add_comment tool definition. */
+export function buildAddCommentDef(): ToolDefinition {
+  return {
+    name: "github_add_comment",
     description: "Add a comment to an issue or pull request.",
     parameters: {
       repo: {

--- a/src/integrations/github/issues/tools_issues.ts
+++ b/src/integrations/github/issues/tools_issues.ts
@@ -1,5 +1,5 @@
 /**
- * GitHub issues tool handlers — list, create, comment.
+ * GitHub issues tool handlers — list, get, create, update, comment, list_comments.
  *
  * Each handler validates inputs, calls the GitHubClient, and
  * formats the response as a JSON string for the agent.
@@ -12,12 +12,12 @@ import { validateRepoInput, formatGitHubError } from "../tools_shared.ts";
 
 // ─── List Issues ─────────────────────────────────────────────────────────────
 
-/** Handle the github_issues_list tool invocation. */
-export async function executeIssuesList(
+/** Handle the github_list_issues tool invocation. */
+export async function executeListIssues(
   client: GitHubClient,
   input: Record<string, unknown>,
 ): Promise<string> {
-  const repoResult = validateRepoInput(input, "github_issues_list");
+  const repoResult = validateRepoInput(input, "github_list_issues");
   if (typeof repoResult === "string") return repoResult;
 
   const state = typeof input.state === "string" ? input.state : undefined;
@@ -38,19 +38,49 @@ export async function executeIssuesList(
   });
 }
 
-// ─── Create Issue ────────────────────────────────────────────────────────────
+// ─── Get Issue ──────────────────────────────────────────────────────────────
 
-/** Handle the github_issues_create tool invocation. */
-export async function executeIssuesCreate(
+/** Handle the github_get_issue tool invocation. */
+export async function executeGetIssue(
   client: GitHubClient,
   input: Record<string, unknown>,
 ): Promise<string> {
-  const repoResult = validateRepoInput(input, "github_issues_create");
+  const repoResult = validateRepoInput(input, "github_get_issue");
+  if (typeof repoResult === "string") return repoResult;
+
+  const number = input.number;
+  if (typeof number !== "number") {
+    return "Error: github_get_issue requires a 'number' argument (number).";
+  }
+
+  const result = await client.getIssue(repoResult.owner, repoResult.name, number);
+  if (!result.ok) return formatGitHubError(result.error);
+  return JSON.stringify({
+    number: result.value.number,
+    title: result.value.title,
+    state: result.value.state,
+    author: result.value.author,
+    body: result.value.body,
+    labels: result.value.labels,
+    created_at: result.value.createdAt,
+    url: result.value.htmlUrl,
+    _classification: result.value.classification,
+  });
+}
+
+// ─── Create Issue ────────────────────────────────────────────────────────────
+
+/** Handle the github_create_issue tool invocation. */
+export async function executeCreateIssue(
+  client: GitHubClient,
+  input: Record<string, unknown>,
+): Promise<string> {
+  const repoResult = validateRepoInput(input, "github_create_issue");
   if (typeof repoResult === "string") return repoResult;
 
   const title = input.title;
   if (typeof title !== "string" || title.length === 0) {
-    return "Error: github_issues_create requires a 'title' argument.";
+    return "Error: github_create_issue requires a 'title' argument.";
   }
   const body = typeof input.body === "string" ? input.body : undefined;
   const labels = typeof input.labels === "string"
@@ -67,23 +97,95 @@ export async function executeIssuesCreate(
   });
 }
 
-// ─── Comment on Issue ────────────────────────────────────────────────────────
+// ─── Update Issue ───────────────────────────────────────────────────────────
 
-/** Handle the github_issues_comment tool invocation. */
-export async function executeIssuesComment(
+/** Build the update fields from the input. */
+function buildIssueUpdateFields(input: Record<string, unknown>): Record<string, unknown> {
+  const fields: Record<string, unknown> = {};
+  if (typeof input.title === "string") fields.title = input.title;
+  if (typeof input.body === "string") fields.body = input.body;
+  if (typeof input.state === "string") fields.state = input.state;
+  if (typeof input.labels === "string") {
+    fields.labels = (input.labels as string).split(",").map((l) => l.trim());
+  }
+  if (typeof input.assignees === "string") {
+    fields.assignees = (input.assignees as string).split(",").map((a) => a.trim());
+  }
+  return fields;
+}
+
+/** Handle the github_update_issue tool invocation. */
+export async function executeUpdateIssue(
   client: GitHubClient,
   input: Record<string, unknown>,
 ): Promise<string> {
-  const repoResult = validateRepoInput(input, "github_issues_comment");
+  const repoResult = validateRepoInput(input, "github_update_issue");
   if (typeof repoResult === "string") return repoResult;
 
   const number = input.number;
   if (typeof number !== "number") {
-    return "Error: github_issues_comment requires a 'number' argument (number).";
+    return "Error: github_update_issue requires a 'number' argument (number).";
+  }
+
+  const fields = buildIssueUpdateFields(input);
+  const result = await client.updateIssue(repoResult.owner, repoResult.name, number, fields);
+  if (!result.ok) return formatGitHubError(result.error);
+  return JSON.stringify({
+    number: result.value.number,
+    title: result.value.title,
+    state: result.value.state,
+    url: result.value.htmlUrl,
+    _classification: result.value.classification,
+  });
+}
+
+// ─── List Comments ──────────────────────────────────────────────────────────
+
+/** Handle the github_list_comments tool invocation. */
+export async function executeListComments(
+  client: GitHubClient,
+  input: Record<string, unknown>,
+): Promise<string> {
+  const repoResult = validateRepoInput(input, "github_list_comments");
+  if (typeof repoResult === "string") return repoResult;
+
+  const number = input.number;
+  if (typeof number !== "number") {
+    return "Error: github_list_comments requires a 'number' argument (number).";
+  }
+  const perPage = typeof input.per_page === "number" ? input.per_page : undefined;
+
+  const result = await client.listComments(repoResult.owner, repoResult.name, number, { perPage });
+  if (!result.ok) return formatGitHubError(result.error);
+  return JSON.stringify({
+    comments: result.value.map((c) => ({
+      id: c.id,
+      author: c.author,
+      body: c.body,
+      created_at: c.createdAt,
+      url: c.htmlUrl,
+      _classification: c.classification,
+    })),
+  });
+}
+
+// ─── Comment on Issue ────────────────────────────────────────────────────────
+
+/** Handle the github_add_comment tool invocation. */
+export async function executeAddComment(
+  client: GitHubClient,
+  input: Record<string, unknown>,
+): Promise<string> {
+  const repoResult = validateRepoInput(input, "github_add_comment");
+  if (typeof repoResult === "string") return repoResult;
+
+  const number = input.number;
+  if (typeof number !== "number") {
+    return "Error: github_add_comment requires a 'number' argument (number).";
   }
   const body = input.body;
   if (typeof body !== "string" || body.length === 0) {
-    return "Error: github_issues_comment requires a 'body' argument.";
+    return "Error: github_add_comment requires a 'body' argument.";
   }
 
   const result = await client.createComment(repoResult.owner, repoResult.name, number, body);

--- a/src/integrations/github/mod.ts
+++ b/src/integrations/github/mod.ts
@@ -9,10 +9,15 @@
  */
 
 export type {
+  GitHubBranch,
+  GitHubComment,
   GitHubRepo,
+  GitHubRepoDetail,
   GitHubFileContent,
   GitHubCommit,
   GitHubPull,
+  GitHubPullDetail,
+  GitHubPullFile,
   GitHubIssue,
   GitHubWorkflowRun,
   GitHubCodeSearchItem,

--- a/src/integrations/github/pulls/client_pulls.ts
+++ b/src/integrations/github/pulls/client_pulls.ts
@@ -5,8 +5,14 @@
  */
 
 import type { ClassificationLevel, Result } from "../../../core/types/classification.ts";
-import type { GitHubError, GitHubPull } from "../types.ts";
-import type { ApiRequestFn, ClassifyRepoFn, RawPull } from "../client_http.ts";
+import type { GitHubError, GitHubPull, GitHubPullDetail, GitHubPullFile } from "../types.ts";
+import type {
+  ApiRequestFn,
+  ClassifyRepoFn,
+  RawPull,
+  RawPullDetail,
+  RawPullFile,
+} from "../client_http.ts";
 import { buildRepoPath, fetchRepoClassification } from "../client_http.ts";
 
 /** Map a raw pull request to a GitHubPull domain type. */
@@ -25,6 +31,120 @@ function mapRawPullToGitHubPull(
     createdAt: p.created_at,
     classification,
   };
+}
+
+/** Map a raw pull detail to a GitHubPullDetail domain type. */
+function mapRawPullDetailToGitHubPullDetail(
+  p: RawPullDetail,
+  classification: ClassificationLevel,
+): GitHubPullDetail {
+  return {
+    number: p.number,
+    title: p.title,
+    state: p.state,
+    author: p.user?.login ?? "unknown",
+    body: p.body ?? null,
+    headRef: p.head.ref,
+    baseRef: p.base.ref,
+    htmlUrl: p.html_url,
+    createdAt: p.created_at,
+    additions: p.additions,
+    deletions: p.deletions,
+    changedFiles: p.changed_files,
+    mergeable: p.mergeable ?? null,
+    classification,
+  };
+}
+
+/** Fetch a single pull request from a GitHub repo. */
+export async function fetchRepoPull(
+  apiRequest: ApiRequestFn,
+  classifyRepo: ClassifyRepoFn,
+  owner: string,
+  repo: string,
+  prNumber: number,
+): Promise<Result<GitHubPullDetail, GitHubError>> {
+  const result = await apiRequest<RawPullDetail>(
+    `${buildRepoPath(owner, repo)}/pulls/${prNumber}`,
+  );
+  if (!result.ok) return result;
+
+  const classification = await fetchRepoClassification(
+    apiRequest,
+    classifyRepo,
+    owner,
+    repo,
+  );
+  return {
+    ok: true,
+    value: mapRawPullDetailToGitHubPullDetail(result.value.data, classification),
+  };
+}
+
+/** Update a pull request on a GitHub repo. */
+export async function updateRepoPull(
+  apiRequest: ApiRequestFn,
+  classifyRepo: ClassifyRepoFn,
+  owner: string,
+  repo: string,
+  prNumber: number,
+  fields: {
+    readonly title?: string;
+    readonly body?: string;
+    readonly base?: string;
+    readonly state?: string;
+  },
+): Promise<Result<GitHubPullDetail, GitHubError>> {
+  const result = await apiRequest<RawPullDetail>(
+    `${buildRepoPath(owner, repo)}/pulls/${prNumber}`,
+    { method: "PATCH", body: fields },
+  );
+  if (!result.ok) return result;
+
+  const classification = await fetchRepoClassification(
+    apiRequest,
+    classifyRepo,
+    owner,
+    repo,
+  );
+  return {
+    ok: true,
+    value: mapRawPullDetailToGitHubPullDetail(result.value.data, classification),
+  };
+}
+
+/** Fetch files changed in a pull request. */
+export async function fetchPullFiles(
+  apiRequest: ApiRequestFn,
+  classifyRepo: ClassifyRepoFn,
+  owner: string,
+  repo: string,
+  prNumber: number,
+  opts?: { readonly perPage?: number },
+): Promise<Result<readonly GitHubPullFile[], GitHubError>> {
+  const params = new URLSearchParams();
+  params.set("per_page", String(opts?.perPage ?? 30));
+
+  const result = await apiRequest<readonly RawPullFile[]>(
+    `${buildRepoPath(owner, repo)}/pulls/${prNumber}/files?${params.toString()}`,
+  );
+  if (!result.ok) return result;
+
+  const classification = await fetchRepoClassification(
+    apiRequest,
+    classifyRepo,
+    owner,
+    repo,
+  );
+  const files: readonly GitHubPullFile[] = result.value.data.map((f) => ({
+    filename: f.filename,
+    status: f.status,
+    additions: f.additions,
+    deletions: f.deletions,
+    changes: f.changes,
+    classification,
+  }));
+  return { ok: true, value: files };
 }
 
 /** Fetch pull requests from a GitHub repo. */

--- a/src/integrations/github/pulls/mod.ts
+++ b/src/integrations/github/pulls/mod.ts
@@ -6,21 +6,30 @@
 
 export {
   fetchRepoPulls,
+  fetchRepoPull,
+  updateRepoPull,
+  fetchPullFiles,
   submitRepoPullRequest,
   submitPullRequestReview,
   mergeRepoPullRequest,
 } from "./client_pulls.ts";
 
 export {
-  executePullsList,
-  executePullsCreate,
-  executePullsReview,
-  executePullsMerge,
+  executeListPulls,
+  executeGetPull,
+  executeCreatePull,
+  executeUpdatePull,
+  executeListPullFiles,
+  executeReviewPull,
+  executeMergePull,
 } from "./tools_pulls.ts";
 
 export {
-  buildPullsListDef,
-  buildPullsCreateDef,
-  buildPullsReviewDef,
-  buildPullsMergeDef,
+  buildListPullsDef,
+  buildGetPullDef,
+  buildCreatePullDef,
+  buildUpdatePullDef,
+  buildListPullFilesDef,
+  buildReviewPullDef,
+  buildMergePullDef,
 } from "./tools_defs_pulls.ts";

--- a/src/integrations/github/pulls/tools_defs_pulls.ts
+++ b/src/integrations/github/pulls/tools_defs_pulls.ts
@@ -1,17 +1,17 @@
 /**
  * GitHub pull request tool definitions.
  *
- * Defines the 4 pull request tool schemas: list, create, review, merge.
+ * Defines the 7 pull request tool schemas: list, get, create, update, review, merge, list_files.
  *
  * @module
  */
 
 import type { ToolDefinition } from "../../../core/types/tool.ts";
 
-/** Build the github_pulls_list tool definition. */
-export function buildPullsListDef(): ToolDefinition {
+/** Build the github_list_pulls tool definition. */
+export function buildListPullsDef(): ToolDefinition {
   return {
-    name: "github_pulls_list",
+    name: "github_list_pulls",
     description:
       "List pull requests for a repository. Returns PR number, title, state, author, and branches.",
     parameters: {
@@ -33,10 +33,31 @@ export function buildPullsListDef(): ToolDefinition {
   };
 }
 
-/** Build the github_pulls_create tool definition. */
-export function buildPullsCreateDef(): ToolDefinition {
+/** Build the github_get_pull tool definition. */
+export function buildGetPullDef(): ToolDefinition {
   return {
-    name: "github_pulls_create",
+    name: "github_get_pull",
+    description:
+      "Get a single pull request by number. Returns full details including body, diff stats, and mergeable state.",
+    parameters: {
+      repo: {
+        type: "string",
+        description: 'Repository in "owner/name" format',
+        required: true,
+      },
+      pr_number: {
+        type: "number",
+        description: "Pull request number",
+        required: true,
+      },
+    },
+  };
+}
+
+/** Build the github_create_pull tool definition. */
+export function buildCreatePullDef(): ToolDefinition {
+  return {
+    name: "github_create_pull",
     description: "Create a new pull request. Returns the created PR details.",
     parameters: {
       repo: {
@@ -56,6 +77,59 @@ export function buildPullsCreateDef(): ToolDefinition {
         required: true,
       },
       body: { type: "string", description: "PR description (markdown)" },
+    },
+  };
+}
+
+/** Build the github_update_pull tool definition. */
+export function buildUpdatePullDef(): ToolDefinition {
+  return {
+    name: "github_update_pull",
+    description:
+      "Update a pull request. Can change title, body, base branch, or state.",
+    parameters: {
+      repo: {
+        type: "string",
+        description: 'Repository in "owner/name" format',
+        required: true,
+      },
+      pr_number: {
+        type: "number",
+        description: "Pull request number",
+        required: true,
+      },
+      title: { type: "string", description: "New PR title" },
+      body: { type: "string", description: "New PR description (markdown)" },
+      base: { type: "string", description: "New base branch" },
+      state: {
+        type: "string",
+        description: 'Set state: "open" or "closed"',
+      },
+    },
+  };
+}
+
+/** Build the github_list_pull_files tool definition. */
+export function buildListPullFilesDef(): ToolDefinition {
+  return {
+    name: "github_list_pull_files",
+    description:
+      "List files changed in a pull request. Returns filename, status, additions, and deletions.",
+    parameters: {
+      repo: {
+        type: "string",
+        description: 'Repository in "owner/name" format',
+        required: true,
+      },
+      pr_number: {
+        type: "number",
+        description: "Pull request number",
+        required: true,
+      },
+      per_page: {
+        type: "number",
+        description: "Number of files to return (default: 30)",
+      },
     },
   };
 }
@@ -86,10 +160,10 @@ function buildPullsReviewParams(): ToolDefinition["parameters"] {
   };
 }
 
-/** Build the github_pulls_review tool definition. */
-export function buildPullsReviewDef(): ToolDefinition {
+/** Build the github_review_pull tool definition. */
+export function buildReviewPullDef(): ToolDefinition {
   return {
-    name: "github_pulls_review",
+    name: "github_review_pull",
     description:
       "Submit a review on a pull request. Events: APPROVE, REQUEST_CHANGES, COMMENT.",
     parameters: buildPullsReviewParams(),
@@ -121,10 +195,10 @@ function buildPullsMergeParams(): ToolDefinition["parameters"] {
   };
 }
 
-/** Build the github_pulls_merge tool definition. */
-export function buildPullsMergeDef(): ToolDefinition {
+/** Build the github_merge_pull tool definition. */
+export function buildMergePullDef(): ToolDefinition {
   return {
-    name: "github_pulls_merge",
+    name: "github_merge_pull",
     description:
       "Merge a pull request. Supports merge, squash, or rebase methods.",
     parameters: buildPullsMergeParams(),

--- a/src/integrations/github/pulls/tools_pulls.ts
+++ b/src/integrations/github/pulls/tools_pulls.ts
@@ -1,5 +1,5 @@
 /**
- * GitHub pull request tool handlers — list, create, review, merge.
+ * GitHub pull request tool handlers — list, get, create, update, review, merge, list_files.
  *
  * Each handler validates inputs, calls the GitHubClient, and
  * formats the response as a JSON string for the agent.
@@ -12,12 +12,12 @@ import { validateRepoInput, formatGitHubError } from "../tools_shared.ts";
 
 // ─── List Pulls ──────────────────────────────────────────────────────────────
 
-/** Handle the github_pulls_list tool invocation. */
-export async function executePullsList(
+/** Handle the github_list_pulls tool invocation. */
+export async function executeListPulls(
   client: GitHubClient,
   input: Record<string, unknown>,
 ): Promise<string> {
-  const repoResult = validateRepoInput(input, "github_pulls_list");
+  const repoResult = validateRepoInput(input, "github_list_pulls");
   if (typeof repoResult === "string") return repoResult;
 
   const state = typeof input.state === "string" ? input.state : undefined;
@@ -38,6 +38,41 @@ export async function executePullsList(
   });
 }
 
+// ─── Get Pull ───────────────────────────────────────────────────────────────
+
+/** Handle the github_get_pull tool invocation. */
+export async function executeGetPull(
+  client: GitHubClient,
+  input: Record<string, unknown>,
+): Promise<string> {
+  const repoResult = validateRepoInput(input, "github_get_pull");
+  if (typeof repoResult === "string") return repoResult;
+
+  const prNumber = input.pr_number;
+  if (typeof prNumber !== "number") {
+    return "Error: github_get_pull requires a 'pr_number' argument (number).";
+  }
+
+  const result = await client.getPull(repoResult.owner, repoResult.name, prNumber);
+  if (!result.ok) return formatGitHubError(result.error);
+  return JSON.stringify({
+    number: result.value.number,
+    title: result.value.title,
+    state: result.value.state,
+    author: result.value.author,
+    body: result.value.body,
+    head: result.value.headRef,
+    base: result.value.baseRef,
+    additions: result.value.additions,
+    deletions: result.value.deletions,
+    changed_files: result.value.changedFiles,
+    mergeable: result.value.mergeable,
+    created_at: result.value.createdAt,
+    url: result.value.htmlUrl,
+    _classification: result.value.classification,
+  });
+}
+
 // ─── Create Pull ─────────────────────────────────────────────────────────────
 
 /** Validate the required string fields for pull creation. */
@@ -48,25 +83,25 @@ function validatePullCreateFields(input: Record<string, unknown>): {
 } | string {
   const title = input.title;
   if (typeof title !== "string" || title.length === 0) {
-    return "Error: github_pulls_create requires a 'title' argument.";
+    return "Error: github_create_pull requires a 'title' argument.";
   }
   const head = input.head;
   if (typeof head !== "string" || head.length === 0) {
-    return "Error: github_pulls_create requires a 'head' argument.";
+    return "Error: github_create_pull requires a 'head' argument.";
   }
   const base = input.base;
   if (typeof base !== "string" || base.length === 0) {
-    return "Error: github_pulls_create requires a 'base' argument.";
+    return "Error: github_create_pull requires a 'base' argument.";
   }
   return { title, head, base };
 }
 
-/** Handle the github_pulls_create tool invocation. */
-export async function executePullsCreate(
+/** Handle the github_create_pull tool invocation. */
+export async function executeCreatePull(
   client: GitHubClient,
   input: Record<string, unknown>,
 ): Promise<string> {
-  const repoResult = validateRepoInput(input, "github_pulls_create");
+  const repoResult = validateRepoInput(input, "github_create_pull");
   if (typeof repoResult === "string") return repoResult;
 
   const fields = validatePullCreateFields(input);
@@ -90,27 +125,89 @@ export async function executePullsCreate(
   });
 }
 
-// ─── Submit Review ───────────────────────────────────────────────────────────
+// ─── Update Pull ────────────────────────────────────────────────────────────
 
-/** Handle the github_pulls_review tool invocation. */
-export async function executePullsReview(
+/** Handle the github_update_pull tool invocation. */
+export async function executeUpdatePull(
   client: GitHubClient,
   input: Record<string, unknown>,
 ): Promise<string> {
-  const repoResult = validateRepoInput(input, "github_pulls_review");
+  const repoResult = validateRepoInput(input, "github_update_pull");
   if (typeof repoResult === "string") return repoResult;
 
   const prNumber = input.pr_number;
   if (typeof prNumber !== "number") {
-    return "Error: github_pulls_review requires a 'pr_number' argument (number).";
+    return "Error: github_update_pull requires a 'pr_number' argument (number).";
+  }
+
+  const fields: Record<string, unknown> = {};
+  if (typeof input.title === "string") fields.title = input.title;
+  if (typeof input.body === "string") fields.body = input.body;
+  if (typeof input.base === "string") fields.base = input.base;
+  if (typeof input.state === "string") fields.state = input.state;
+
+  const result = await client.updatePull(repoResult.owner, repoResult.name, prNumber, fields);
+  if (!result.ok) return formatGitHubError(result.error);
+  return JSON.stringify({
+    number: result.value.number,
+    title: result.value.title,
+    state: result.value.state,
+    url: result.value.htmlUrl,
+    _classification: result.value.classification,
+  });
+}
+
+// ─── List Pull Files ────────────────────────────────────────────────────────
+
+/** Handle the github_list_pull_files tool invocation. */
+export async function executeListPullFiles(
+  client: GitHubClient,
+  input: Record<string, unknown>,
+): Promise<string> {
+  const repoResult = validateRepoInput(input, "github_list_pull_files");
+  if (typeof repoResult === "string") return repoResult;
+
+  const prNumber = input.pr_number;
+  if (typeof prNumber !== "number") {
+    return "Error: github_list_pull_files requires a 'pr_number' argument (number).";
+  }
+  const perPage = typeof input.per_page === "number" ? input.per_page : undefined;
+
+  const result = await client.listPullFiles(repoResult.owner, repoResult.name, prNumber, { perPage });
+  if (!result.ok) return formatGitHubError(result.error);
+  return JSON.stringify({
+    files: result.value.map((f) => ({
+      filename: f.filename,
+      status: f.status,
+      additions: f.additions,
+      deletions: f.deletions,
+      changes: f.changes,
+      _classification: f.classification,
+    })),
+  });
+}
+
+// ─── Submit Review ───────────────────────────────────────────────────────────
+
+/** Handle the github_review_pull tool invocation. */
+export async function executeReviewPull(
+  client: GitHubClient,
+  input: Record<string, unknown>,
+): Promise<string> {
+  const repoResult = validateRepoInput(input, "github_review_pull");
+  if (typeof repoResult === "string") return repoResult;
+
+  const prNumber = input.pr_number;
+  if (typeof prNumber !== "number") {
+    return "Error: github_review_pull requires a 'pr_number' argument (number).";
   }
   const event = input.event;
   if (typeof event !== "string" || event.length === 0) {
-    return "Error: github_pulls_review requires an 'event' argument (APPROVE, REQUEST_CHANGES, or COMMENT).";
+    return "Error: github_review_pull requires an 'event' argument (APPROVE, REQUEST_CHANGES, or COMMENT).";
   }
   const body = input.body;
   if (typeof body !== "string" || body.length === 0) {
-    return "Error: github_pulls_review requires a 'body' argument.";
+    return "Error: github_review_pull requires a 'body' argument.";
   }
 
   const result = await client.submitReview(repoResult.owner, repoResult.name, prNumber, event, body);
@@ -124,17 +221,17 @@ export async function executePullsReview(
 
 // ─── Merge Pull ──────────────────────────────────────────────────────────────
 
-/** Handle the github_pulls_merge tool invocation. */
-export async function executePullsMerge(
+/** Handle the github_merge_pull tool invocation. */
+export async function executeMergePull(
   client: GitHubClient,
   input: Record<string, unknown>,
 ): Promise<string> {
-  const repoResult = validateRepoInput(input, "github_pulls_merge");
+  const repoResult = validateRepoInput(input, "github_merge_pull");
   if (typeof repoResult === "string") return repoResult;
 
   const prNumber = input.pr_number;
   if (typeof prNumber !== "number") {
-    return "Error: github_pulls_merge requires a 'pr_number' argument (number).";
+    return "Error: github_merge_pull requires a 'pr_number' argument (number).";
   }
   const method = typeof input.method === "string" ? input.method : undefined;
   const commitTitle = typeof input.commit_title === "string" ? input.commit_title : undefined;

--- a/src/integrations/github/repos/client_repos.ts
+++ b/src/integrations/github/repos/client_repos.ts
@@ -6,10 +6,12 @@
 
 import type { ClassificationLevel, Result } from "../../../core/types/classification.ts";
 import type {
+  GitHubBranch,
   GitHubCommit,
   GitHubError,
   GitHubFileContent,
   GitHubRepo,
+  GitHubRepoDetail,
   RepoVisibility,
 } from "../types.ts";
 import type { ApiRequestFn, ClassifyRepoFn } from "../client_http.ts";
@@ -18,7 +20,7 @@ import {
   extractRepoVisibility,
   fetchRepoClassification,
 } from "../client_http.ts";
-import type { RawCommit, RawContent, RawRepo } from "../client_http.ts";
+import type { RawBranch, RawCommit, RawContent, RawRepo } from "../client_http.ts";
 
 /** Maximum file size (1 MB) for github_repos_read_file. */
 const MAX_FILE_SIZE = 1_048_576;
@@ -38,6 +40,152 @@ function mapRawRepoToGitHubRepo(
     htmlUrl: r.html_url,
     classification: classifyRepo(visibility, r.full_name),
   };
+}
+
+/** Raw repo detail shape from GitHub API (extends RawRepo with extra fields). */
+interface RawRepoDetail extends RawRepo {
+  readonly clone_url: string;
+  readonly ssh_url: string;
+  readonly language?: string | null;
+  readonly stargazers_count: number;
+  readonly forks_count: number;
+  readonly topics?: readonly string[];
+}
+
+/** Fetch a single repo from the GitHub API. */
+export async function fetchRepo(
+  apiRequest: ApiRequestFn,
+  classifyRepo: ClassifyRepoFn,
+  owner: string,
+  repo: string,
+): Promise<Result<GitHubRepoDetail, GitHubError>> {
+  const result = await apiRequest<RawRepoDetail>(buildRepoPath(owner, repo));
+  if (!result.ok) return result;
+
+  const raw = result.value.data;
+  const visibility = extractRepoVisibility(raw);
+  return {
+    ok: true,
+    value: {
+      id: raw.id,
+      fullName: raw.full_name,
+      description: raw.description ?? null,
+      visibility: visibility as RepoVisibility,
+      defaultBranch: raw.default_branch,
+      htmlUrl: raw.html_url,
+      cloneUrl: raw.clone_url,
+      sshUrl: raw.ssh_url,
+      language: raw.language ?? null,
+      stargazersCount: raw.stargazers_count,
+      forksCount: raw.forks_count,
+      topics: raw.topics ?? [],
+      classification: classifyRepo(visibility, raw.full_name),
+    },
+  };
+}
+
+/** Fetch branches from a GitHub repo. */
+export async function fetchRepoBranches(
+  apiRequest: ApiRequestFn,
+  classifyRepo: ClassifyRepoFn,
+  owner: string,
+  repo: string,
+  opts?: { readonly perPage?: number },
+): Promise<Result<readonly GitHubBranch[], GitHubError>> {
+  const params = new URLSearchParams();
+  params.set("per_page", String(opts?.perPage ?? 30));
+
+  const result = await apiRequest<readonly RawBranch[]>(
+    `${buildRepoPath(owner, repo)}/branches?${params.toString()}`,
+  );
+  if (!result.ok) return result;
+
+  const classification = await fetchRepoClassification(
+    apiRequest,
+    classifyRepo,
+    owner,
+    repo,
+  );
+  const branches: readonly GitHubBranch[] = result.value.data.map((b) => ({
+    name: b.name,
+    protected: b.protected,
+    classification,
+  }));
+  return { ok: true, value: branches };
+}
+
+/** Create a branch on a GitHub repo via git refs API. */
+export async function createRepoBranch(
+  apiRequest: ApiRequestFn,
+  classifyRepo: ClassifyRepoFn,
+  owner: string,
+  repo: string,
+  branchName: string,
+  sha: string,
+): Promise<
+  Result<
+    {
+      readonly ref: string;
+      readonly sha: string;
+      readonly classification: ClassificationLevel;
+    },
+    GitHubError
+  >
+> {
+  const result = await apiRequest<{
+    ref: string;
+    object: { sha: string };
+  }>(
+    `${buildRepoPath(owner, repo)}/git/refs`,
+    { method: "POST", body: { ref: `refs/heads/${branchName}`, sha } },
+  );
+  if (!result.ok) return result;
+
+  const classification = await fetchRepoClassification(
+    apiRequest,
+    classifyRepo,
+    owner,
+    repo,
+  );
+  return {
+    ok: true,
+    value: {
+      ref: result.value.data.ref,
+      sha: result.value.data.object.sha,
+      classification,
+    },
+  };
+}
+
+/** Delete a branch on a GitHub repo via git refs API. */
+export async function deleteRepoBranch(
+  apiRequest: ApiRequestFn,
+  classifyRepo: ClassifyRepoFn,
+  owner: string,
+  repo: string,
+  branchName: string,
+): Promise<
+  Result<
+    {
+      readonly deleted: boolean;
+      readonly classification: ClassificationLevel;
+    },
+    GitHubError
+  >
+> {
+  const result = await apiRequest<undefined>(
+    `${buildRepoPath(owner, repo)}/git/refs/heads/${encodeURIComponent(branchName)}`,
+    { method: "DELETE" },
+  );
+  if (!result.ok) return result;
+
+  const classification = await fetchRepoClassification(
+    apiRequest,
+    classifyRepo,
+    owner,
+    repo,
+  );
+  return { ok: true, value: { deleted: true, classification } };
 }
 
 /** Fetch user repos from the GitHub API. */

--- a/src/integrations/github/repos/mod.ts
+++ b/src/integrations/github/repos/mod.ts
@@ -5,19 +5,31 @@
  */
 
 export {
+  fetchRepo,
   fetchUserRepos,
   fetchRepoFile,
   fetchRepoCommits,
+  fetchRepoBranches,
+  createRepoBranch,
+  deleteRepoBranch,
 } from "./client_repos.ts";
 
 export {
-  executeReposList,
-  executeReposReadFile,
-  executeReposCommits,
+  executeListRepos,
+  executeGetRepo,
+  executeReadFile,
+  executeListCommits,
+  executeListBranches,
+  executeCreateBranch,
+  executeDeleteBranch,
 } from "./tools_repos.ts";
 
 export {
-  buildReposListDef,
-  buildReposReadFileDef,
-  buildReposCommitsDef,
+  buildListReposDef,
+  buildGetRepoDef,
+  buildReadFileDef,
+  buildListCommitsDef,
+  buildListBranchesDef,
+  buildCreateBranchDef,
+  buildDeleteBranchDef,
 } from "./tools_defs_repos.ts";

--- a/src/integrations/github/repos/tools_defs_repos.ts
+++ b/src/integrations/github/repos/tools_defs_repos.ts
@@ -1,17 +1,17 @@
 /**
  * GitHub repository tool definitions.
  *
- * Defines the 3 repository tool schemas: list, read_file, commits.
+ * Defines the 7 repository tool schemas: list, get, read_file, commits, branches, create_branch, delete_branch.
  *
  * @module
  */
 
 import type { ToolDefinition } from "../../../core/types/tool.ts";
 
-/** Build the github_repos_list tool definition. */
-export function buildReposListDef(): ToolDefinition {
+/** Build the github_list_repos tool definition. */
+export function buildListReposDef(): ToolDefinition {
   return {
-    name: "github_repos_list",
+    name: "github_list_repos",
     description:
       "List your GitHub repositories, sorted by recently updated. Returns repo name, visibility, description, and default branch.",
     parameters: {
@@ -27,10 +27,26 @@ export function buildReposListDef(): ToolDefinition {
   };
 }
 
-/** Build the github_repos_read_file tool definition. */
-export function buildReposReadFileDef(): ToolDefinition {
+/** Build the github_get_repo tool definition. */
+export function buildGetRepoDef(): ToolDefinition {
   return {
-    name: "github_repos_read_file",
+    name: "github_get_repo",
+    description:
+      "Get detailed info about a repository. Returns description, language, clone URLs, stars, forks, and topics.",
+    parameters: {
+      repo: {
+        type: "string",
+        description: 'Repository in "owner/name" format',
+        required: true,
+      },
+    },
+  };
+}
+
+/** Build the github_read_file tool definition. */
+export function buildReadFileDef(): ToolDefinition {
+  return {
+    name: "github_read_file",
     description:
       "Read the contents of a file from a GitHub repository. Returns the file text (max 1 MB). Use for reading source code, configs, docs.",
     parameters: {
@@ -53,10 +69,10 @@ export function buildReposReadFileDef(): ToolDefinition {
   };
 }
 
-/** Build the github_repos_commits tool definition. */
-export function buildReposCommitsDef(): ToolDefinition {
+/** Build the github_list_commits tool definition. */
+export function buildListCommitsDef(): ToolDefinition {
   return {
-    name: "github_repos_commits",
+    name: "github_list_commits",
     description:
       "List recent commits for a repository. Returns SHA, message, author, and date.",
     parameters: {
@@ -72,6 +88,73 @@ export function buildReposCommitsDef(): ToolDefinition {
       per_page: {
         type: "number",
         description: "Number of commits to return (default: 20)",
+      },
+    },
+  };
+}
+
+/** Build the github_list_branches tool definition. */
+export function buildListBranchesDef(): ToolDefinition {
+  return {
+    name: "github_list_branches",
+    description:
+      "List branches for a repository. Returns branch name and protection status.",
+    parameters: {
+      repo: {
+        type: "string",
+        description: 'Repository in "owner/name" format',
+        required: true,
+      },
+      per_page: {
+        type: "number",
+        description: "Number of branches to return (default: 30)",
+      },
+    },
+  };
+}
+
+/** Build the github_create_branch tool definition. */
+export function buildCreateBranchDef(): ToolDefinition {
+  return {
+    name: "github_create_branch",
+    description:
+      "Create a new branch from a specific commit SHA.",
+    parameters: {
+      repo: {
+        type: "string",
+        description: 'Repository in "owner/name" format',
+        required: true,
+      },
+      branch: {
+        type: "string",
+        description: "New branch name",
+        required: true,
+      },
+      sha: {
+        type: "string",
+        description: "Commit SHA to branch from",
+        required: true,
+      },
+    },
+  };
+}
+
+/** Build the github_delete_branch tool definition. */
+export function buildDeleteBranchDef(): ToolDefinition {
+  return {
+    name: "github_delete_branch",
+    description:
+      "Delete a branch from a repository.",
+    parameters: {
+      repo: {
+        type: "string",
+        description: 'Repository in "owner/name" format',
+        required: true,
+      },
+      branch: {
+        type: "string",
+        description: "Branch name to delete",
+        required: true,
       },
     },
   };

--- a/src/integrations/github/repos/tools_repos.ts
+++ b/src/integrations/github/repos/tools_repos.ts
@@ -1,5 +1,5 @@
 /**
- * GitHub repos tool handlers — list, read file, commits.
+ * GitHub repos tool handlers — list, get, read file, commits, branches, create/delete branch.
  *
  * Each handler validates inputs, calls the GitHubClient, and
  * formats the response as a JSON string for the agent.
@@ -12,8 +12,8 @@ import { validateRepoInput, formatGitHubError } from "../tools_shared.ts";
 
 // ─── List Repos ──────────────────────────────────────────────────────────────
 
-/** Handle the github_repos_list tool invocation. */
-export async function executeReposList(
+/** Handle the github_list_repos tool invocation. */
+export async function executeListRepos(
   client: GitHubClient,
   input: Record<string, unknown>,
 ): Promise<string> {
@@ -33,19 +33,47 @@ export async function executeReposList(
   });
 }
 
-// ─── Read File ───────────────────────────────────────────────────────────────
+// ─── Get Repo ───────────────────────────────────────────────────────────────
 
-/** Handle the github_repos_read_file tool invocation. */
-export async function executeReposReadFile(
+/** Handle the github_get_repo tool invocation. */
+export async function executeGetRepo(
   client: GitHubClient,
   input: Record<string, unknown>,
 ): Promise<string> {
-  const repoResult = validateRepoInput(input, "github_repos_read_file");
+  const repoResult = validateRepoInput(input, "github_get_repo");
+  if (typeof repoResult === "string") return repoResult;
+
+  const result = await client.getRepo(repoResult.owner, repoResult.name);
+  if (!result.ok) return formatGitHubError(result.error);
+  return JSON.stringify({
+    name: result.value.fullName,
+    description: result.value.description,
+    visibility: result.value.visibility,
+    default_branch: result.value.defaultBranch,
+    language: result.value.language,
+    stars: result.value.stargazersCount,
+    forks: result.value.forksCount,
+    topics: result.value.topics,
+    clone_url: result.value.cloneUrl,
+    ssh_url: result.value.sshUrl,
+    url: result.value.htmlUrl,
+    _classification: result.value.classification,
+  });
+}
+
+// ─── Read File ───────────────────────────────────────────────────────────────
+
+/** Handle the github_read_file tool invocation. */
+export async function executeReadFile(
+  client: GitHubClient,
+  input: Record<string, unknown>,
+): Promise<string> {
+  const repoResult = validateRepoInput(input, "github_read_file");
   if (typeof repoResult === "string") return repoResult;
 
   const path = input.path;
   if (typeof path !== "string" || path.length === 0) {
-    return "Error: github_repos_read_file requires a 'path' argument.";
+    return "Error: github_read_file requires a 'path' argument.";
   }
 
   const ref = typeof input.ref === "string" ? input.ref : undefined;
@@ -63,12 +91,12 @@ export async function executeReposReadFile(
 
 // ─── List Commits ────────────────────────────────────────────────────────────
 
-/** Handle the github_repos_commits tool invocation. */
-export async function executeReposCommits(
+/** Handle the github_list_commits tool invocation. */
+export async function executeListCommits(
   client: GitHubClient,
   input: Record<string, unknown>,
 ): Promise<string> {
-  const repoResult = validateRepoInput(input, "github_repos_commits");
+  const repoResult = validateRepoInput(input, "github_list_commits");
   if (typeof repoResult === "string") return repoResult;
 
   const sha = typeof input.sha === "string" ? input.sha : undefined;
@@ -84,5 +112,78 @@ export async function executeReposCommits(
       url: c.htmlUrl,
       _classification: c.classification,
     })),
+  });
+}
+
+// ─── List Branches ──────────────────────────────────────────────────────────
+
+/** Handle the github_list_branches tool invocation. */
+export async function executeListBranches(
+  client: GitHubClient,
+  input: Record<string, unknown>,
+): Promise<string> {
+  const repoResult = validateRepoInput(input, "github_list_branches");
+  if (typeof repoResult === "string") return repoResult;
+
+  const perPage = typeof input.per_page === "number" ? input.per_page : undefined;
+  const result = await client.listBranches(repoResult.owner, repoResult.name, { perPage });
+  if (!result.ok) return formatGitHubError(result.error);
+  return JSON.stringify({
+    branches: result.value.map((b) => ({
+      name: b.name,
+      protected: b.protected,
+      _classification: b.classification,
+    })),
+  });
+}
+
+// ─── Create Branch ──────────────────────────────────────────────────────────
+
+/** Handle the github_create_branch tool invocation. */
+export async function executeCreateBranch(
+  client: GitHubClient,
+  input: Record<string, unknown>,
+): Promise<string> {
+  const repoResult = validateRepoInput(input, "github_create_branch");
+  if (typeof repoResult === "string") return repoResult;
+
+  const branch = input.branch;
+  if (typeof branch !== "string" || branch.length === 0) {
+    return "Error: github_create_branch requires a 'branch' argument.";
+  }
+  const sha = input.sha;
+  if (typeof sha !== "string" || sha.length === 0) {
+    return "Error: github_create_branch requires a 'sha' argument.";
+  }
+
+  const result = await client.createBranch(repoResult.owner, repoResult.name, branch, sha);
+  if (!result.ok) return formatGitHubError(result.error);
+  return JSON.stringify({
+    ref: result.value.ref,
+    sha: result.value.sha,
+    _classification: result.value.classification,
+  });
+}
+
+// ─── Delete Branch ──────────────────────────────────────────────────────────
+
+/** Handle the github_delete_branch tool invocation. */
+export async function executeDeleteBranch(
+  client: GitHubClient,
+  input: Record<string, unknown>,
+): Promise<string> {
+  const repoResult = validateRepoInput(input, "github_delete_branch");
+  if (typeof repoResult === "string") return repoResult;
+
+  const branch = input.branch;
+  if (typeof branch !== "string" || branch.length === 0) {
+    return "Error: github_delete_branch requires a 'branch' argument.";
+  }
+
+  const result = await client.deleteBranch(repoResult.owner, repoResult.name, branch);
+  if (!result.ok) return formatGitHubError(result.error);
+  return JSON.stringify({
+    deleted: result.value.deleted,
+    _classification: result.value.classification,
   });
 }

--- a/src/integrations/github/tools.ts
+++ b/src/integrations/github/tools.ts
@@ -1,7 +1,7 @@
 /**
  * GitHub tool executor for the agent.
  *
- * Creates a chain-compatible executor for the 14 `github_*` tools.
+ * Creates a chain-compatible executor for the 25 `github_*` tools.
  * Tool definitions live in `tools_defs.ts`; domain-specific handlers
  * live in `tools_repos.ts`, `tools_pulls.ts`, `tools_issues.ts`,
  * `tools_actions.ts`, and `tools_search.ts`.
@@ -10,10 +10,33 @@
  */
 
 import type { GitHubToolContext } from "./tools_shared.ts";
-import { executeReposList, executeReposReadFile, executeReposCommits } from "./repos/mod.ts";
-import { executePullsList, executePullsCreate, executePullsReview, executePullsMerge } from "./pulls/mod.ts";
-import { executeIssuesList, executeIssuesCreate, executeIssuesComment } from "./issues/mod.ts";
-import { executeActionsRuns, executeActionsTrigger } from "./actions/mod.ts";
+import {
+  executeListRepos,
+  executeGetRepo,
+  executeReadFile,
+  executeListCommits,
+  executeListBranches,
+  executeCreateBranch,
+  executeDeleteBranch,
+} from "./repos/mod.ts";
+import {
+  executeListPulls,
+  executeGetPull,
+  executeCreatePull,
+  executeUpdatePull,
+  executeListPullFiles,
+  executeReviewPull,
+  executeMergePull,
+} from "./pulls/mod.ts";
+import {
+  executeListIssues,
+  executeGetIssue,
+  executeCreateIssue,
+  executeUpdateIssue,
+  executeListComments,
+  executeAddComment,
+} from "./issues/mod.ts";
+import { executeListRuns, executeCancelRun, executeTriggerWorkflow } from "./actions/mod.ts";
 import { executeSearchCode, executeSearchIssues } from "./actions/mod.ts";
 
 // ─── Re-exports ──────────────────────────────────────────────────────────────
@@ -31,18 +54,29 @@ type ToolHandler = (
 
 /** Registry mapping each github_* tool name to its handler. */
 const TOOL_HANDLERS: Readonly<Record<string, ToolHandler>> = {
-  github_repos_list: executeReposList,
-  github_repos_read_file: executeReposReadFile,
-  github_repos_commits: executeReposCommits,
-  github_pulls_list: executePullsList,
-  github_pulls_create: executePullsCreate,
-  github_pulls_review: executePullsReview,
-  github_pulls_merge: executePullsMerge,
-  github_issues_list: executeIssuesList,
-  github_issues_create: executeIssuesCreate,
-  github_issues_comment: executeIssuesComment,
-  github_actions_runs: executeActionsRuns,
-  github_actions_trigger: executeActionsTrigger,
+  github_list_repos: executeListRepos,
+  github_get_repo: executeGetRepo,
+  github_read_file: executeReadFile,
+  github_list_commits: executeListCommits,
+  github_list_branches: executeListBranches,
+  github_create_branch: executeCreateBranch,
+  github_delete_branch: executeDeleteBranch,
+  github_list_pulls: executeListPulls,
+  github_get_pull: executeGetPull,
+  github_create_pull: executeCreatePull,
+  github_update_pull: executeUpdatePull,
+  github_list_pull_files: executeListPullFiles,
+  github_review_pull: executeReviewPull,
+  github_merge_pull: executeMergePull,
+  github_list_issues: executeListIssues,
+  github_get_issue: executeGetIssue,
+  github_create_issue: executeCreateIssue,
+  github_update_issue: executeUpdateIssue,
+  github_list_comments: executeListComments,
+  github_add_comment: executeAddComment,
+  github_list_runs: executeListRuns,
+  github_cancel_run: executeCancelRun,
+  github_trigger_workflow: executeTriggerWorkflow,
   github_search_code: executeSearchCode,
   github_search_issues: executeSearchIssues,
 };

--- a/src/integrations/github/tools_defs.ts
+++ b/src/integrations/github/tools_defs.ts
@@ -1,7 +1,7 @@
 /**
  * GitHub tool definitions and system prompt for the agent.
  *
- * Barrel that re-exports the 14 tool schemas across repos, pulls,
+ * Barrel that re-exports the 25 tool schemas across repos, pulls,
  * issues, actions, and search from their dedicated per-domain modules.
  *
  * @module
@@ -10,48 +10,70 @@
 import type { ToolDefinition } from "../../core/types/tool.ts";
 
 import {
-  buildReposListDef,
-  buildReposReadFileDef,
-  buildReposCommitsDef,
+  buildListReposDef,
+  buildGetRepoDef,
+  buildReadFileDef,
+  buildListCommitsDef,
+  buildListBranchesDef,
+  buildCreateBranchDef,
+  buildDeleteBranchDef,
 } from "./repos/mod.ts";
 
 import {
-  buildPullsListDef,
-  buildPullsCreateDef,
-  buildPullsReviewDef,
-  buildPullsMergeDef,
+  buildListPullsDef,
+  buildGetPullDef,
+  buildCreatePullDef,
+  buildUpdatePullDef,
+  buildListPullFilesDef,
+  buildReviewPullDef,
+  buildMergePullDef,
 } from "./pulls/mod.ts";
 
 import {
-  buildIssuesListDef,
-  buildIssuesCreateDef,
-  buildIssuesCommentDef,
+  buildListIssuesDef,
+  buildGetIssueDef,
+  buildCreateIssueDef,
+  buildUpdateIssueDef,
+  buildListCommentsDef,
+  buildAddCommentDef,
 } from "./issues/mod.ts";
 
 import {
-  buildActionsRunsDef,
-  buildActionsTriggerDef,
+  buildListRunsDef,
+  buildCancelRunDef,
+  buildTriggerWorkflowDef,
   buildSearchCodeDef,
   buildSearchIssuesDef,
 } from "./actions/mod.ts";
 
 // ── Public API ──
 
-/** Get all 14 GitHub tool definitions. */
+/** Get all 25 GitHub tool definitions. */
 export function getGitHubToolDefinitions(): readonly ToolDefinition[] {
   return [
-    buildReposListDef(),
-    buildReposReadFileDef(),
-    buildReposCommitsDef(),
-    buildPullsListDef(),
-    buildPullsCreateDef(),
-    buildPullsReviewDef(),
-    buildPullsMergeDef(),
-    buildIssuesListDef(),
-    buildIssuesCreateDef(),
-    buildIssuesCommentDef(),
-    buildActionsRunsDef(),
-    buildActionsTriggerDef(),
+    buildListReposDef(),
+    buildGetRepoDef(),
+    buildReadFileDef(),
+    buildListCommitsDef(),
+    buildListBranchesDef(),
+    buildCreateBranchDef(),
+    buildDeleteBranchDef(),
+    buildListPullsDef(),
+    buildGetPullDef(),
+    buildCreatePullDef(),
+    buildUpdatePullDef(),
+    buildListPullFilesDef(),
+    buildReviewPullDef(),
+    buildMergePullDef(),
+    buildListIssuesDef(),
+    buildGetIssueDef(),
+    buildCreateIssueDef(),
+    buildUpdateIssueDef(),
+    buildListCommentsDef(),
+    buildAddCommentDef(),
+    buildListRunsDef(),
+    buildCancelRunDef(),
+    buildTriggerWorkflowDef(),
     buildSearchCodeDef(),
     buildSearchIssuesDef(),
   ];
@@ -60,8 +82,9 @@ export function getGitHubToolDefinitions(): readonly ToolDefinition[] {
 /** System prompt section explaining GitHub tools to the LLM. */
 export const GITHUB_TOOLS_SYSTEM_PROMPT = `## GitHub Access
 
-You have access to GitHub via 14 github_* tools: repos, PRs, issues, Actions, and search.
+You have access to GitHub via 25 github_* tools: repos, PRs, issues, Actions, and search.
 
+- All tool names follow the github_verb_noun pattern (e.g. github_list_repos, github_create_pull).
 - The \`repo\` parameter always uses "owner/name" format (e.g. "octocat/Hello-World").
 - Repository visibility determines security classification: public→PUBLIC, private→CONFIDENTIAL, internal→INTERNAL.
 - Accessing private repos escalates session taint — be mindful of classification boundaries.

--- a/src/integrations/github/types.ts
+++ b/src/integrations/github/types.ts
@@ -43,6 +43,30 @@ export interface GitHubCommit {
   readonly classification: ClassificationLevel;
 }
 
+/** Detailed GitHub repository info (from GET /repos/{o}/{r}). */
+export interface GitHubRepoDetail {
+  readonly id: number;
+  readonly fullName: string;
+  readonly description: string | null;
+  readonly visibility: RepoVisibility;
+  readonly defaultBranch: string;
+  readonly htmlUrl: string;
+  readonly cloneUrl: string;
+  readonly sshUrl: string;
+  readonly language: string | null;
+  readonly stargazersCount: number;
+  readonly forksCount: number;
+  readonly topics: readonly string[];
+  readonly classification: ClassificationLevel;
+}
+
+/** A GitHub branch. */
+export interface GitHubBranch {
+  readonly name: string;
+  readonly protected: boolean;
+  readonly classification: ClassificationLevel;
+}
+
 /** A GitHub pull request. */
 export interface GitHubPull {
   readonly number: number;
@@ -56,6 +80,34 @@ export interface GitHubPull {
   readonly classification: ClassificationLevel;
 }
 
+/** Detailed GitHub pull request (from GET /repos/{o}/{r}/pulls/{n}). */
+export interface GitHubPullDetail {
+  readonly number: number;
+  readonly title: string;
+  readonly state: string;
+  readonly author: string;
+  readonly body: string | null;
+  readonly headRef: string;
+  readonly baseRef: string;
+  readonly htmlUrl: string;
+  readonly createdAt: string;
+  readonly additions: number;
+  readonly deletions: number;
+  readonly changedFiles: number;
+  readonly mergeable: boolean | null;
+  readonly classification: ClassificationLevel;
+}
+
+/** A file changed in a pull request. */
+export interface GitHubPullFile {
+  readonly filename: string;
+  readonly status: string;
+  readonly additions: number;
+  readonly deletions: number;
+  readonly changes: number;
+  readonly classification: ClassificationLevel;
+}
+
 /** A GitHub issue. */
 export interface GitHubIssue {
   readonly number: number;
@@ -66,6 +118,16 @@ export interface GitHubIssue {
   readonly htmlUrl: string;
   readonly createdAt: string;
   readonly labels: readonly string[];
+  readonly classification: ClassificationLevel;
+}
+
+/** A comment on a GitHub issue or pull request. */
+export interface GitHubComment {
+  readonly id: number;
+  readonly author: string;
+  readonly body: string;
+  readonly createdAt: string;
+  readonly htmlUrl: string;
   readonly classification: ClassificationLevel;
 }
 

--- a/src/skills/bundled/git-branch-management/SKILL.md
+++ b/src/skills/bundled/git-branch-management/SKILL.md
@@ -11,6 +11,7 @@ description: >
 classification_ceiling: INTERNAL
 requires_tools:
   - exec
+  - github
 network_domains:
   - github.com
   - api.github.com
@@ -18,7 +19,7 @@ network_domains:
 
 # Git Branch Management
 
-Manage git branches, commits, PRs, and code review feedback when doing development work in the exec environment. All git and GitHub CLI operations use `exec.run`.
+Manage git branches, commits, PRs, and code review feedback when doing development work in the exec environment. Git operations use `exec.run`. When the `github` skill is also active, prefer the native GitHub tools (`github_create_pull`, `github_get_pull`, `github_list_comments`, `github_add_comment`, `github_create_branch`, `github_delete_branch`) over shelling out to `gh` CLI via `exec.run`.
 
 ## When to Use
 

--- a/src/skills/bundled/github/SKILL.md
+++ b/src/skills/bundled/github/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github
-version: 1.0.0
+version: 2.0.0
 description: >
   GitHub integration for managing repositories, pull requests, issues,
   Actions workflows, and code search via the GitHub REST API. Authenticates
@@ -26,37 +26,50 @@ Setup: `triggerfish connect github`
 
 ## Tools
 
+All tool names follow the `github_verb_noun` pattern.
+
 ### Repositories
 
 | Tool | Description | Parameters |
 |------|-------------|------------|
-| `github_repos_list` | List your repos (sorted by updated) | `page`, `per_page` |
-| `github_repos_read_file` | Read a file from a repo (max 1 MB) | `repo`*, `path`*, `ref` |
-| `github_repos_commits` | List recent commits | `repo`*, `sha`, `per_page` |
+| `github_list_repos` | List your repos (sorted by updated) | `page`, `per_page` |
+| `github_get_repo` | Get repo details (description, language, clone URLs, stars) | `repo`* |
+| `github_read_file` | Read a file from a repo (max 1 MB) | `repo`*, `path`*, `ref` |
+| `github_list_commits` | List recent commits | `repo`*, `sha`, `per_page` |
+| `github_list_branches` | List branches with protection status | `repo`*, `per_page` |
+| `github_create_branch` | Create a branch from a SHA | `repo`*, `branch`*, `sha`* |
+| `github_delete_branch` | Delete a branch | `repo`*, `branch`* |
 
 ### Pull Requests
 
 | Tool | Description | Parameters |
 |------|-------------|------------|
-| `github_pulls_list` | List PRs | `repo`*, `state`, `per_page` |
-| `github_pulls_create` | Create a PR | `repo`*, `title`*, `head`*, `base`*, `body` |
-| `github_pulls_review` | Submit a review | `repo`*, `pr_number`*, `event`*, `body`* |
-| `github_pulls_merge` | Merge a PR | `repo`*, `pr_number`*, `method`, `commit_title` |
+| `github_list_pulls` | List PRs | `repo`*, `state`, `per_page` |
+| `github_get_pull` | Get PR details (body, diff stats, mergeable) | `repo`*, `pr_number`* |
+| `github_create_pull` | Create a PR | `repo`*, `title`*, `head`*, `base`*, `body` |
+| `github_update_pull` | Update a PR (title, body, base, state) | `repo`*, `pr_number`*, `title`, `body`, `base`, `state` |
+| `github_list_pull_files` | List changed files in a PR | `repo`*, `pr_number`*, `per_page` |
+| `github_review_pull` | Submit a review | `repo`*, `pr_number`*, `event`*, `body`* |
+| `github_merge_pull` | Merge a PR | `repo`*, `pr_number`*, `method`, `commit_title` |
 
 ### Issues
 
 | Tool | Description | Parameters |
 |------|-------------|------------|
-| `github_issues_list` | List issues | `repo`*, `state`, `labels`, `per_page` |
-| `github_issues_create` | Create an issue | `repo`*, `title`*, `body`, `labels` |
-| `github_issues_comment` | Comment on issue/PR | `repo`*, `number`*, `body`* |
+| `github_list_issues` | List issues | `repo`*, `state`, `labels`, `per_page` |
+| `github_get_issue` | Get issue details (body, assignees, labels) | `repo`*, `number`* |
+| `github_create_issue` | Create an issue | `repo`*, `title`*, `body`, `labels` |
+| `github_update_issue` | Update an issue (title, body, state, labels, assignees) | `repo`*, `number`*, `title`, `body`, `state`, `labels`, `assignees` |
+| `github_list_comments` | List comments on issue/PR | `repo`*, `number`*, `per_page` |
+| `github_add_comment` | Comment on issue/PR | `repo`*, `number`*, `body`* |
 
 ### Actions
 
 | Tool | Description | Parameters |
 |------|-------------|------------|
-| `github_actions_runs` | List workflow runs | `repo`*, `workflow`, `branch`, `per_page` |
-| `github_actions_trigger` | Trigger a workflow | `repo`*, `workflow`*, `ref`*, `inputs` |
+| `github_list_runs` | List workflow runs | `repo`*, `workflow`, `branch`, `per_page` |
+| `github_cancel_run` | Cancel a workflow run | `repo`*, `run_id`* |
+| `github_trigger_workflow` | Trigger a workflow | `repo`*, `workflow`*, `ref`*, `inputs` |
 
 ### Search
 

--- a/tests/integrations/github/tools_test.ts
+++ b/tests/integrations/github/tools_test.ts
@@ -1,7 +1,7 @@
 /**
  * GitHub tools tests.
  *
- * Tests all 14 tool definitions, parameter validation,
+ * Tests all 25 tool definitions, parameter validation,
  * response formatting, null fallthrough, and graceful error handling.
  */
 import { assertEquals } from "@std/assert";
@@ -17,9 +17,9 @@ import type { Result } from "../../../src/core/types/classification.ts";
 
 // ─── Tool Definitions ────────────────────────────────────────────────────────
 
-Deno.test("getGitHubToolDefinitions: returns 14 tool definitions", () => {
+Deno.test("getGitHubToolDefinitions: returns 25 tool definitions", () => {
   const defs = getGitHubToolDefinitions();
-  assertEquals(defs.length, 14);
+  assertEquals(defs.length, 25);
 });
 
 Deno.test("getGitHubToolDefinitions: all tools have github_ prefix", () => {
@@ -37,22 +37,47 @@ Deno.test("getGitHubToolDefinitions: all tools have descriptions", () => {
   }
 });
 
+Deno.test("getGitHubToolDefinitions: all tool names follow verb-first pattern", () => {
+  const defs = getGitHubToolDefinitions();
+  const verbs = ["list", "get", "read", "create", "update", "delete", "review", "merge", "trigger", "cancel", "add", "search"];
+  for (const def of defs) {
+    const afterPrefix = def.name.replace("github_", "");
+    const firstWord = afterPrefix.split("_")[0];
+    assertEquals(
+      verbs.includes(firstWord),
+      true,
+      `${def.name} does not start with a known verb (got "${firstWord}")`,
+    );
+  }
+});
+
 Deno.test("getGitHubToolDefinitions: expected tool names present", () => {
   const defs = getGitHubToolDefinitions();
   const names = new Set(defs.map((d) => d.name));
   const expected = [
-    "github_repos_list",
-    "github_repos_read_file",
-    "github_repos_commits",
-    "github_pulls_list",
-    "github_pulls_create",
-    "github_pulls_review",
-    "github_pulls_merge",
-    "github_issues_list",
-    "github_issues_create",
-    "github_issues_comment",
-    "github_actions_runs",
-    "github_actions_trigger",
+    "github_list_repos",
+    "github_get_repo",
+    "github_read_file",
+    "github_list_commits",
+    "github_list_branches",
+    "github_create_branch",
+    "github_delete_branch",
+    "github_list_pulls",
+    "github_get_pull",
+    "github_create_pull",
+    "github_update_pull",
+    "github_list_pull_files",
+    "github_review_pull",
+    "github_merge_pull",
+    "github_list_issues",
+    "github_get_issue",
+    "github_create_issue",
+    "github_update_issue",
+    "github_list_comments",
+    "github_add_comment",
+    "github_list_runs",
+    "github_cancel_run",
+    "github_trigger_workflow",
     "github_search_code",
     "github_search_issues",
   ];
@@ -66,6 +91,10 @@ Deno.test("getGitHubToolDefinitions: expected tool names present", () => {
 Deno.test("GITHUB_TOOLS_SYSTEM_PROMPT: is a non-empty string", () => {
   assertEquals(typeof GITHUB_TOOLS_SYSTEM_PROMPT, "string");
   assertEquals(GITHUB_TOOLS_SYSTEM_PROMPT.length > 0, true);
+});
+
+Deno.test("GITHUB_TOOLS_SYSTEM_PROMPT: mentions 25 tools", () => {
+  assertEquals(GITHUB_TOOLS_SYSTEM_PROMPT.includes("25"), true);
 });
 
 // ─── Fallthrough ─────────────────────────────────────────────────────────────
@@ -87,38 +116,38 @@ Deno.test("createGitHubToolExecutor: returns null for unknown github_ tool", asy
 
 Deno.test("createGitHubToolExecutor: returns error when not configured", async () => {
   const executor = createGitHubToolExecutor(undefined);
-  const result = await executor("github_repos_list", {});
+  const result = await executor("github_list_repos", {});
   assertEquals(typeof result, "string");
   assertEquals(result!.includes("not configured"), true);
 });
 
 // ─── Parameter Validation ────────────────────────────────────────────────────
 
-Deno.test("executor: github_repos_read_file requires repo param", async () => {
+Deno.test("executor: github_read_file requires repo param", async () => {
   const ctx = createMockContext();
   const executor = createGitHubToolExecutor(ctx);
-  const result = await executor("github_repos_read_file", { path: "README.md" });
+  const result = await executor("github_read_file", { path: "README.md" });
   assertEquals(result!.includes("Error"), true);
 });
 
-Deno.test("executor: github_repos_read_file requires path param", async () => {
+Deno.test("executor: github_read_file requires path param", async () => {
   const ctx = createMockContext();
   const executor = createGitHubToolExecutor(ctx);
-  const result = await executor("github_repos_read_file", { repo: "o/r" });
+  const result = await executor("github_read_file", { repo: "o/r" });
   assertEquals(result!.includes("Error"), true);
 });
 
 Deno.test('executor: rejects invalid repo format (no slash)', async () => {
   const ctx = createMockContext();
   const executor = createGitHubToolExecutor(ctx);
-  const result = await executor("github_repos_read_file", { repo: "invalid", path: "f" });
+  const result = await executor("github_read_file", { repo: "invalid", path: "f" });
   assertEquals(result!.includes("owner/name"), true);
 });
 
-Deno.test("executor: github_pulls_create requires title", async () => {
+Deno.test("executor: github_create_pull requires title", async () => {
   const ctx = createMockContext();
   const executor = createGitHubToolExecutor(ctx);
-  const result = await executor("github_pulls_create", { repo: "o/r", head: "feature", base: "main" });
+  const result = await executor("github_create_pull", { repo: "o/r", head: "feature", base: "main" });
   assertEquals(result!.includes("Error"), true);
   assertEquals(result!.includes("title"), true);
 });
@@ -131,17 +160,60 @@ Deno.test("executor: github_search_code requires query", async () => {
   assertEquals(result!.includes("query"), true);
 });
 
-Deno.test("executor: github_issues_comment requires number", async () => {
+Deno.test("executor: github_add_comment requires number", async () => {
   const ctx = createMockContext();
   const executor = createGitHubToolExecutor(ctx);
-  const result = await executor("github_issues_comment", { repo: "o/r", body: "hi" });
+  const result = await executor("github_add_comment", { repo: "o/r", body: "hi" });
   assertEquals(result!.includes("Error"), true);
   assertEquals(result!.includes("number"), true);
 });
 
+Deno.test("executor: github_get_issue requires number", async () => {
+  const ctx = createMockContext();
+  const executor = createGitHubToolExecutor(ctx);
+  const result = await executor("github_get_issue", { repo: "o/r" });
+  assertEquals(result!.includes("Error"), true);
+  assertEquals(result!.includes("number"), true);
+});
+
+Deno.test("executor: github_get_pull requires pr_number", async () => {
+  const ctx = createMockContext();
+  const executor = createGitHubToolExecutor(ctx);
+  const result = await executor("github_get_pull", { repo: "o/r" });
+  assertEquals(result!.includes("Error"), true);
+  assertEquals(result!.includes("pr_number"), true);
+});
+
+Deno.test("executor: github_create_branch requires branch and sha", async () => {
+  const ctx = createMockContext();
+  const executor = createGitHubToolExecutor(ctx);
+  const result1 = await executor("github_create_branch", { repo: "o/r", sha: "abc" });
+  assertEquals(result1!.includes("Error"), true);
+  assertEquals(result1!.includes("branch"), true);
+  const result2 = await executor("github_create_branch", { repo: "o/r", branch: "feat" });
+  assertEquals(result2!.includes("Error"), true);
+  assertEquals(result2!.includes("sha"), true);
+});
+
+Deno.test("executor: github_delete_branch requires branch", async () => {
+  const ctx = createMockContext();
+  const executor = createGitHubToolExecutor(ctx);
+  const result = await executor("github_delete_branch", { repo: "o/r" });
+  assertEquals(result!.includes("Error"), true);
+  assertEquals(result!.includes("branch"), true);
+});
+
+Deno.test("executor: github_cancel_run requires run_id", async () => {
+  const ctx = createMockContext();
+  const executor = createGitHubToolExecutor(ctx);
+  const result = await executor("github_cancel_run", { repo: "o/r" });
+  assertEquals(result!.includes("Error"), true);
+  assertEquals(result!.includes("run_id"), true);
+});
+
 // ─── Response Formatting ─────────────────────────────────────────────────────
 
-Deno.test("executor: github_repos_list returns JSON with _classification", async () => {
+Deno.test("executor: github_list_repos returns JSON with _classification", async () => {
   const ctx = createMockContext({
     listRepos: () => Promise.resolve({
       ok: true as const,
@@ -157,7 +229,7 @@ Deno.test("executor: github_repos_list returns JSON with _classification", async
     }),
   });
   const executor = createGitHubToolExecutor(ctx);
-  const result = await executor("github_repos_list", {});
+  const result = await executor("github_list_repos", {});
 
   const parsed = JSON.parse(result!);
   assertEquals(parsed.repos.length, 1);
@@ -185,7 +257,7 @@ Deno.test("executor: github_search_code returns JSON with results", async () => 
   assertEquals(parsed.results[0]._classification, "CONFIDENTIAL");
 });
 
-Deno.test("executor: github_issues_create returns created issue JSON", async () => {
+Deno.test("executor: github_create_issue returns created issue JSON", async () => {
   const ctx = createMockContext({
     createIssue: () => Promise.resolve({
       ok: true as const,
@@ -203,11 +275,63 @@ Deno.test("executor: github_issues_create returns created issue JSON", async () 
     }),
   });
   const executor = createGitHubToolExecutor(ctx);
-  const result = await executor("github_issues_create", { repo: "o/r", title: "New issue" });
+  const result = await executor("github_create_issue", { repo: "o/r", title: "New issue" });
 
   const parsed = JSON.parse(result!);
   assertEquals(parsed.number, 5);
   assertEquals(parsed._classification, "PUBLIC");
+});
+
+Deno.test("executor: github_get_repo returns repo detail JSON", async () => {
+  const ctx = createMockContext({
+    getRepo: () => Promise.resolve({
+      ok: true as const,
+      value: {
+        id: 1,
+        fullName: "o/r",
+        description: "test",
+        visibility: "public" as const,
+        defaultBranch: "main",
+        htmlUrl: "https://github.com/o/r",
+        cloneUrl: "https://github.com/o/r.git",
+        sshUrl: "git@github.com:o/r.git",
+        language: "TypeScript",
+        stargazersCount: 42,
+        forksCount: 5,
+        topics: ["deno"],
+        classification: "PUBLIC" as const,
+      },
+    }),
+  });
+  const executor = createGitHubToolExecutor(ctx);
+  const result = await executor("github_get_repo", { repo: "o/r" });
+
+  const parsed = JSON.parse(result!);
+  assertEquals(parsed.language, "TypeScript");
+  assertEquals(parsed.stars, 42);
+  assertEquals(parsed._classification, "PUBLIC");
+});
+
+Deno.test("executor: github_list_comments returns comments JSON", async () => {
+  const ctx = createMockContext({
+    listComments: () => Promise.resolve({
+      ok: true as const,
+      value: [{
+        id: 1,
+        author: "alice",
+        body: "LGTM",
+        createdAt: "2024-01-01T00:00:00Z",
+        htmlUrl: "https://github.com/o/r/issues/1#issuecomment-1",
+        classification: "PUBLIC" as const,
+      }],
+    }),
+  });
+  const executor = createGitHubToolExecutor(ctx);
+  const result = await executor("github_list_comments", { repo: "o/r", number: 1 });
+
+  const parsed = JSON.parse(result!);
+  assertEquals(parsed.comments.length, 1);
+  assertEquals(parsed.comments[0].author, "alice");
 });
 
 // ─── Error Formatting ────────────────────────────────────────────────────────
@@ -220,7 +344,7 @@ Deno.test("executor: formats API error correctly", async () => {
     }),
   });
   const executor = createGitHubToolExecutor(ctx);
-  const result = await executor("github_repos_list", {});
+  const result = await executor("github_list_repos", {});
   assertEquals(result!.includes("401"), true);
   assertEquals(result!.includes("Bad credentials"), true);
 });
@@ -233,7 +357,7 @@ Deno.test("executor: formats rate limit error", async () => {
     }),
   });
   const executor = createGitHubToolExecutor(ctx);
-  const result = await executor("github_repos_list", {});
+  const result = await executor("github_list_repos", {});
   assertEquals(result!.includes("rate limit exceeded"), true);
 });
 
@@ -251,16 +375,27 @@ function createMockContext(
 
   const client: GitHubClient = {
     listRepos: overrides?.listRepos as GitHubClient["listRepos"] ?? defaultMethod as unknown as GitHubClient["listRepos"],
+    getRepo: overrides?.getRepo as GitHubClient["getRepo"] ?? defaultMethod as unknown as GitHubClient["getRepo"],
     readFile: overrides?.readFile as GitHubClient["readFile"] ?? defaultMethod as unknown as GitHubClient["readFile"],
     listCommits: overrides?.listCommits as GitHubClient["listCommits"] ?? defaultMethod as unknown as GitHubClient["listCommits"],
+    listBranches: overrides?.listBranches as GitHubClient["listBranches"] ?? defaultMethod as unknown as GitHubClient["listBranches"],
+    createBranch: overrides?.createBranch as GitHubClient["createBranch"] ?? defaultMethod as unknown as GitHubClient["createBranch"],
+    deleteBranch: overrides?.deleteBranch as GitHubClient["deleteBranch"] ?? defaultMethod as unknown as GitHubClient["deleteBranch"],
     listPulls: overrides?.listPulls as GitHubClient["listPulls"] ?? defaultMethod as unknown as GitHubClient["listPulls"],
+    getPull: overrides?.getPull as GitHubClient["getPull"] ?? defaultMethod as unknown as GitHubClient["getPull"],
     createPull: overrides?.createPull as GitHubClient["createPull"] ?? defaultMethod as unknown as GitHubClient["createPull"],
+    updatePull: overrides?.updatePull as GitHubClient["updatePull"] ?? defaultMethod as unknown as GitHubClient["updatePull"],
+    listPullFiles: overrides?.listPullFiles as GitHubClient["listPullFiles"] ?? defaultMethod as unknown as GitHubClient["listPullFiles"],
     submitReview: overrides?.submitReview as GitHubClient["submitReview"] ?? defaultMethod as unknown as GitHubClient["submitReview"],
     mergePull: overrides?.mergePull as GitHubClient["mergePull"] ?? defaultMethod as unknown as GitHubClient["mergePull"],
     listIssues: overrides?.listIssues as GitHubClient["listIssues"] ?? defaultMethod as unknown as GitHubClient["listIssues"],
+    getIssue: overrides?.getIssue as GitHubClient["getIssue"] ?? defaultMethod as unknown as GitHubClient["getIssue"],
     createIssue: overrides?.createIssue as GitHubClient["createIssue"] ?? defaultMethod as unknown as GitHubClient["createIssue"],
+    updateIssue: overrides?.updateIssue as GitHubClient["updateIssue"] ?? defaultMethod as unknown as GitHubClient["updateIssue"],
+    listComments: overrides?.listComments as GitHubClient["listComments"] ?? defaultMethod as unknown as GitHubClient["listComments"],
     createComment: overrides?.createComment as GitHubClient["createComment"] ?? defaultMethod as unknown as GitHubClient["createComment"],
     listWorkflowRuns: overrides?.listWorkflowRuns as GitHubClient["listWorkflowRuns"] ?? defaultMethod as unknown as GitHubClient["listWorkflowRuns"],
+    cancelRun: overrides?.cancelRun as GitHubClient["cancelRun"] ?? defaultMethod as unknown as GitHubClient["cancelRun"],
     triggerWorkflow: overrides?.triggerWorkflow as GitHubClient["triggerWorkflow"] ?? defaultMethod as unknown as GitHubClient["triggerWorkflow"],
     searchCode: overrides?.searchCode as GitHubClient["searchCode"] ?? defaultMethod as unknown as GitHubClient["searchCode"],
     searchIssues: overrides?.searchIssues as GitHubClient["searchIssues"] ?? defaultMethod as unknown as GitHubClient["searchIssues"],


### PR DESCRIPTION
## Summary

- Rename 12 existing GitHub tools from domain-first (`github_repos_list`) to verb-first (`github_list_repos`) naming convention for consistency
- Add 11 new CRUD tools across repos, pulls, issues, and actions domains:
  - **Repos (4):** `github_get_repo`, `github_list_branches`, `github_create_branch`, `github_delete_branch`
  - **Pulls (3):** `github_get_pull`, `github_update_pull`, `github_list_pull_files`
  - **Issues (3):** `github_get_issue`, `github_update_issue`, `github_list_comments`
  - **Actions (1):** `github_cancel_run`
- Total tool count: 14 → 25
- New domain types: `GitHubRepoDetail`, `GitHubBranch`, `GitHubPullDetail`, `GitHubPullFile`, `GitHubComment`
- SKILL.md files updated to v2.0.0 with full tool tables

## Test plan

- [x] `deno task check` — zero type errors
- [x] `deno task lint` — zero lint errors (789 files)
- [x] `deno task test tests/integrations/github/` — 64/64 tests pass
- [x] Tool count verified: `getGitHubToolDefinitions().length === 25`
- [x] All tool names follow `github_verb_noun` pattern (tested)
- [x] Parameter validation tests for new tools (run_id, branch, sha, pr_number, number)
- [x] Response formatting tests for new tools (get_repo, list_comments)
- [x] Mock context covers all 25 client methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)