### PR TITLE
feat: shared memory namespace for trigger sessions

### DIFF
--- a/src/agent/dispatch/response_handling.ts
+++ b/src/agent/dispatch/response_handling.ts
@@ -21,10 +21,11 @@ import type { OrchestratorState, TokenAccumulator } from "../orchestrator/orches
 
 /**
  * Pattern matching echoed tool-call placeholder text.
- * Some models parrot back the assistant history entry instead of continuing work.
+ * Some models parrot back the assistant history entry instead of continuing
+ * work, or narrate "N tool calls pending/queued" instead of invoking them.
  */
 const ECHOED_TOOL_PLACEHOLDER =
-  /^\[Used tools:.*\]$|^\(\d+ tool call\(s\) executed/;
+  /^\[Used tools:.*\]$|^\(\d+ tool call(?:\(s\))? (?:executed|pending|queued|in progress)/;
 
 /** Minimum phrase length to consider for repetition detection. */
 const MIN_REPEAT_PHRASE_LEN = 60;

--- a/src/core/types/mod.ts
+++ b/src/core/types/mod.ts
@@ -30,6 +30,7 @@ export type {
 export {
   canOutput,
   createSession,
+  OWNER_MEMORY_AGENT_ID,
   resetSession,
   updateTaint,
 } from "./session.ts";

--- a/src/core/types/session.ts
+++ b/src/core/types/session.ts
@@ -14,6 +14,14 @@ import { createLogger } from "../logger/logger.ts";
 
 const log = createLogger("session");
 
+/**
+ * Stable memory namespace for the owner's agent.
+ *
+ * Trigger sessions share this namespace so they can read/write
+ * the same memories as the main interactive session.
+ */
+export const OWNER_MEMORY_AGENT_ID = "main-session";
+
 /** Branded type for session identifiers. */
 export type SessionId = string & { readonly __brand: unique symbol };
 

--- a/src/gateway/startup/factory/orchestrator_factory.ts
+++ b/src/gateway/startup/factory/orchestrator_factory.ts
@@ -10,7 +10,11 @@
 import { join } from "@std/path";
 import type { TriggerFishConfig } from "../../../core/config.ts";
 import type { ClassificationLevel } from "../../../core/types/classification.ts";
-import { createSession, updateTaint } from "../../../core/types/session.ts";
+import {
+  createSession,
+  OWNER_MEMORY_AGENT_ID,
+  updateTaint,
+} from "../../../core/types/session.ts";
 import type { ChannelId, UserId } from "../../../core/types/session.ts";
 import { createProviderRegistry } from "../../../agent/llm.ts";
 import {
@@ -209,6 +213,7 @@ export function createOrchestratorFactory(
         githubExecutor,
         skillContextTracker,
         getSessionTaint: () => session.taint,
+        memoryAgentId: isTrigger ? OWNER_MEMORY_AGENT_ID : undefined,
       });
 
       const toolProfile = isTrigger ? "triggerSession" : "cronJob";
@@ -259,7 +264,7 @@ export function createOrchestratorFactory(
           : {}),
       });
 
-      return { orchestrator, session };
+      return { orchestrator, session, toolExecutor };
     },
   };
 }

--- a/src/gateway/startup/infra/workspace_init.ts
+++ b/src/gateway/startup/infra/workspace_init.ts
@@ -12,6 +12,9 @@ import type { ClassificationLevel } from "../../../core/types/classification.ts"
 import { createWorkspace } from "../../../exec/workspace.ts";
 import { createPathClassifier } from "../../../core/security/path_classification.ts";
 import { createSqliteStorage } from "../../../core/storage/sqlite.ts";
+import {
+  OWNER_MEMORY_AGENT_ID,
+} from "../../../core/types/session.ts";
 import type { createSession } from "../../../core/types/session.ts";
 import {
   createFts5SearchProvider,
@@ -25,7 +28,7 @@ export async function initializeMainWorkspace(
 ) {
   const spinePath = join(baseDir, "SPINE.md");
   const mainWorkspace = await createWorkspace({
-    agentId: "main-session",
+    agentId: OWNER_MEMORY_AGENT_ID,
     basePath: join(baseDir, "workspaces"),
   });
   try {
@@ -73,7 +76,7 @@ export async function initializeMemorySystem(
   const memoryExecutor = createMemoryToolExecutor({
     store: memoryStore,
     searchProvider: memorySearchProvider,
-    agentId: "main-session",
+    agentId: OWNER_MEMORY_AGENT_ID,
     sessionTaint: session.taint,
     sourceSessionId: session.id,
   });

--- a/src/gateway/startup/tools/scheduler_tool_assembly.ts
+++ b/src/gateway/startup/tools/scheduler_tool_assembly.ts
@@ -170,13 +170,15 @@ export function assembleSchedulerToolExecutor(opts: {
   readonly skillContextTracker?: SkillContextTracker;
   /** Live getter for session taint, used for taint-aware command cwd. */
   readonly getSessionTaint?: () => ClassificationLevel;
+  /** Override memory namespace (e.g. triggers share the owner namespace). */
+  readonly memoryAgentId?: string;
 }) {
   const { infra, session, workspace, agentId, storage } = opts;
 
   const memoryExecutor = storage
     ? buildSchedulerMemoryExecutor({
       storage,
-      agentId,
+      agentId: opts.memoryAgentId ?? agentId,
       sessionTaint: session.taint,
       sourceSessionId: session.id,
     })

--- a/src/gateway/tools/trigger/trigger_tools_defs.ts
+++ b/src/gateway/tools/trigger/trigger_tools_defs.ts
@@ -103,6 +103,10 @@ Your output is stored in the trigger store and stamped with your final session t
 
 If you skip classification ordering and call a higher-classified tool before a lower one, subsequent lower-classified calls will be blocked by write-down enforcement. Always call \`get_tool_classification\` first.
 
+**Deduplication — CRITICAL:**
+
+Your prior trigger run results (if any) are injected at the top of your instructions under "Prior Trigger Results". You MUST NOT repeat findings that already appear there. Only report NEW or CHANGED information since the last run. If a PR was already reported, a calendar event was already mentioned, or an email was already summarized in prior results — skip it. The owner has already seen it.
+
 **Notification policy — CRITICAL:**
 
 You are a background process. The owner does NOT want to hear from you unless you found something worth reporting. After checking the items in your instructions:

--- a/src/scheduler/service_output.ts
+++ b/src/scheduler/service_output.ts
@@ -93,7 +93,7 @@ export async function deliverSchedulerOutput(options: DeliverOutputOptions): Pro
     return;
   }
   const outputOpts: SourcedOutputOptions = { config, source, text, classification: sessionTaint };
-  if (text.trim() === "NO_ACTION") {
+  if (text.trim().startsWith("NO_ACTION")) {
     log.debug(`[${source}] LLM returned NO_ACTION — nothing to report`);
     await persistTriggerResult(outputOpts);
     return;

--- a/src/scheduler/service_trigger.ts
+++ b/src/scheduler/service_trigger.ts
@@ -2,15 +2,27 @@
  * Scheduler trigger execution — loads TRIGGER.md and runs it
  * in an isolated orchestrator session.
  *
+ * Before each run, prior trigger results are loaded from memory via
+ * `memory_search` and injected into the prompt so the agent avoids
+ * repeating the same findings. After each run, the result is persisted
+ * via `memory_save` for future runs.
+ *
  * @module
  */
 
+import type { ToolExecutor } from "../core/types/tool.ts";
 import type { SchedulerServiceConfig } from "./service_types.ts";
 import { createLogger } from "../core/logger/mod.ts";
 import { deliverSchedulerOutput } from "./service_output.ts";
 import { logSchedulerTokenUsage } from "./service_cron.ts";
 
 const log = createLogger("scheduler");
+
+/** Memory key used to persist trigger run history. */
+const TRIGGER_HISTORY_MEMORY_KEY = "trigger:run-history";
+
+/** Maximum number of prior results to keep in memory. */
+const MAX_HISTORY_ENTRIES = 2;
 
 /** Load TRIGGER.md content, returning null if not found. */
 async function loadTriggerMd(path: string): Promise<string | null> {
@@ -21,16 +33,106 @@ async function loadTriggerMd(path: string): Promise<string | null> {
   }
 }
 
+/** Load prior trigger results from memory via the tool executor. */
+async function loadTriggerHistory(
+  toolExecutor: ToolExecutor,
+): Promise<string | null> {
+  try {
+    const raw = await toolExecutor("memory_get", {
+      key: TRIGGER_HISTORY_MEMORY_KEY,
+    });
+    const parsed: { found: boolean; content?: string } = JSON.parse(raw);
+    if (!parsed.found || !parsed.content || parsed.content.trim().length === 0) {
+      return null;
+    }
+    return parsed.content;
+  } catch (err) {
+    log.debug("No prior trigger history found in memory", {
+      operation: "loadTriggerHistory",
+      err,
+    });
+    return null;
+  }
+}
+
+/** Build a history block to inject into the trigger prompt. */
+function buildHistoryContext(historyContent: string): string {
+  return `## Prior Trigger Results
+
+The following are your most recent trigger run results. Do NOT repeat findings that are already listed here. Only report NEW or CHANGED information.
+
+${historyContent}
+
+---
+`;
+}
+
+/** Persist the trigger result to memory, rolling off old entries. */
+async function persistTriggerHistory(
+  toolExecutor: ToolExecutor,
+  resultText: string,
+  existingHistory: string | null,
+): Promise<void> {
+  const timestamp = new Date().toISOString();
+  const newEntry = `### Run at ${timestamp}\n${resultText}`;
+
+  let entries: string[];
+  if (existingHistory) {
+    entries = existingHistory
+      .split(/^### Run at /m)
+      .filter((e) => e.trim().length > 0)
+      .map((e) => `### Run at ${e}`);
+  } else {
+    entries = [];
+  }
+
+  entries.push(newEntry);
+  if (entries.length > MAX_HISTORY_ENTRIES) {
+    entries = entries.slice(entries.length - MAX_HISTORY_ENTRIES);
+  }
+
+  const content = entries.join("\n\n");
+  try {
+    await toolExecutor("memory_save", {
+      key: TRIGGER_HISTORY_MEMORY_KEY,
+      content,
+      tags: ["trigger", "history"],
+    });
+    log.info("Trigger history persisted to memory", {
+      operation: "persistTriggerHistory",
+      entryCount: entries.length,
+    });
+  } catch (err) {
+    log.error("Trigger history memory_save failed", {
+      operation: "persistTriggerHistory",
+      err,
+    });
+  }
+}
+
 /** Execute the trigger orchestrator with the given TRIGGER.md content. */
 async function executeTriggerSession(
   config: SchedulerServiceConfig,
-  message: string,
+  triggerMdContent: string,
 ): Promise<void> {
   log.info("Creating trigger orchestrator session");
-  const { orchestrator, session } = await config.orchestratorFactory.create(
-    "trigger",
-    { isTrigger: true, ceiling: config.trigger.classificationCeiling },
-  );
+  const { orchestrator, session, toolExecutor } =
+    await config.orchestratorFactory.create(
+      "trigger",
+      { isTrigger: true, ceiling: config.trigger.classificationCeiling },
+    );
+
+  const existingHistory = await loadTriggerHistory(toolExecutor);
+  log.info("Trigger history loaded from memory", {
+    operation: "executeTriggerSession",
+    hasHistory: existingHistory !== null,
+  });
+
+  const historyContext = existingHistory
+    ? buildHistoryContext(existingHistory)
+    : "";
+  const message = historyContext + triggerMdContent;
+
   log.info("Trigger orchestrator processing TRIGGER.md");
   const result = await orchestrator.executeAgentTurn({
     session,
@@ -39,6 +141,12 @@ async function executeTriggerSession(
   });
   log.info(`Trigger completed (ok: ${result.ok}, taint: ${session.taint})`);
   logSchedulerTokenUsage("trigger", result);
+
+  const resultText = result.ok ? result.value.response : result.error;
+  if (resultText && resultText.trim().length > 0) {
+    await persistTriggerHistory(toolExecutor, resultText, existingHistory);
+  }
+
   await deliverSchedulerOutput({
     config,
     result,

--- a/src/scheduler/service_types.ts
+++ b/src/scheduler/service_types.ts
@@ -12,6 +12,7 @@ import type { ClassificationLevel, Result } from "../core/types/classification.t
 import type { UserId } from "../core/types/session.ts";
 import type { Orchestrator } from "../core/types/orchestrator.ts";
 import type { SessionState } from "../core/types/session.ts";
+import type { ToolExecutor } from "../core/types/tool.ts";
 import type { NotificationService } from "../core/types/notification.ts";
 import type { CronManager } from "./cron/parser.ts";
 import type { WebhookHandler } from "./webhooks/webhooks.ts";
@@ -41,10 +42,11 @@ export interface OrchestratorCreateOptions {
  * and orchestrator for each call.
  */
 export interface OrchestratorFactory {
-  /** Create a new orchestrator and session for a scheduled task. */
+  /** Create a new orchestrator, session, and tool executor for a scheduled task. */
   create(channelId: string, options?: OrchestratorCreateOptions): Promise<{
     readonly orchestrator: Orchestrator;
     readonly session: SessionState;
+    readonly toolExecutor: ToolExecutor;
   }>;
 }
 


### PR DESCRIPTION
## Summary

- Trigger sessions now share the `main-session` memory namespace with the main interactive session, so triggers can read/write the same memories and avoid repeating findings across runs
- Prior trigger results are injected into the prompt (rolling window of 2) for deduplication
- Fixed NO_ACTION detection to use `startsWith` (LLM appends context after the token)
- Expanded junk-response detection to catch "N tool calls pending/queued" narration from weaker models

## Test plan

- [x] `deno task lint` — clean (792 files)
- [x] `deno task check` — clean
- [x] `deno task test tests/scheduler/` — 64 passed
- [x] `deno task test tests/tools/memory/` — 49 passed
- [x] `deno task test tests/agent/` — 211 passed
- [x] `deno task test tests/gateway/trigger_tools_test.ts` — 21 passed
- [x] Manual: triggers fire, load history (`hasHistory:true`), persist with rolling window (`entryCount:2`), correctly return NO_ACTION when nothing new

🤖 Generated with [Claude Code](https://claude.com/claude-code)