### PR TITLE
refactor: consolidate CRUD-pattern tool groups (109→64 tools)

### DIFF
--- a/src/agent/dispatch/response_cap.ts
+++ b/src/agent/dispatch/response_cap.ts
@@ -23,7 +23,7 @@ export const MAX_CACHE_ENTRIES = 10;
 /** Per-tool character budget overrides. */
 export const TOOL_RESPONSE_BUDGETS: ReadonlyMap<string, number> = new Map([
   ["read_file", 20_000],
-  ["github_list_comments", 6_000],
+  ["github_issues", 6_000],
   ["browser_snapshot", 8_000],
   ["run_command", 16_000],
 ]);

--- a/src/agent/dispatch/tool_dispatch.ts
+++ b/src/agent/dispatch/tool_dispatch.ts
@@ -36,10 +36,10 @@ async function executePlanModeToolCall(
   sessionKey: string,
   call: ParsedToolCall,
 ): Promise<{ resultText: string | undefined; blocked: boolean }> {
-  if (planManager.isToolBlocked(sessionKey, call.name)) {
+  if (planManager.isToolBlocked(sessionKey, call.name, call.args)) {
     return {
       resultText: `Tool "${call.name}" is blocked in plan mode. ` +
-        `Use plan.exit to present your implementation plan first.`,
+        `Use plan_manage(action: "exit") to present your implementation plan first.`,
       blocked: true,
     };
   }

--- a/src/agent/orchestrator/orchestrator_types.ts
+++ b/src/agent/orchestrator/orchestrator_types.ts
@@ -235,7 +235,7 @@ const BUILTIN_TOOL_CLASSIFICATIONS: ReadonlyArray<
   // Prefix-based taint escalation and write-down checks must not apply to them;
   // non-owner blocking is handled by enforceNonOwnerToolCeiling.
   ["secret_list", "PUBLIC"],
-  ["cron_", "PUBLIC"],
+  ["cron", "PUBLIC"],
   ["trigger_", "PUBLIC"],
   // Skills — read_skill is read-only, works at all classification levels
   ["read_skill", "PUBLIC"],
@@ -244,8 +244,6 @@ const BUILTIN_TOOL_CLASSIFICATIONS: ReadonlyArray<
   ["agents_", "PUBLIC"],
   ["claude_", "PUBLIC"],
   ["sessions_", "PUBLIC"],
-  ["session_", "PUBLIC"],
-  ["message", "PUBLIC"],
   ["signal_", "PUBLIC"],
   ["channels_", "PUBLIC"],
   // Plan mode — owner-only

--- a/src/agent/plan/executor.ts
+++ b/src/agent/plan/executor.ts
@@ -2,38 +2,41 @@
  * Plan tool executor — routes plan_* tool calls to PlanManager.
  *
  * Validates untrusted LLM input for implementation plans and dispatches
- * plan_enter, plan_exit, plan_status, plan_approve, plan_reject,
- * plan_step_complete, plan_complete, and plan_modify to the PlanManager.
+ * plan_manage (with action parameter), plan_step_complete, and plan_status
+ * to the PlanManager.
  *
  * @module
  */
 
 import type { ImplementationPlan, PlanComplexity, PlanStep } from "./types.ts";
 import type { PlanManager } from "./plan_types.ts";
+import { createLogger } from "../../core/logger/mod.ts";
 
-// ─── Executor Helpers ──────────────────────────────────────────────────────────
+const log = createLogger("plan-executor");
 
-function executePlanEnter(
+// ─── Action Handlers for plan_manage ─────────────────────────────────────────
+
+function executeActionEnter(
   manager: PlanManager,
   sessionId: string,
   input: Record<string, unknown>,
 ): string {
   const goal = input.goal;
   if (typeof goal !== "string" || goal.length === 0) {
-    return "Error: plan_enter requires a 'goal' argument (string).";
+    return "Error: plan_manage(action: 'enter') requires a 'goal' argument (string).";
   }
   const scope = typeof input.scope === "string" ? input.scope : undefined;
   return manager.enter(sessionId, goal, scope);
 }
 
-async function executePlanExit(
+async function executeActionExit(
   manager: PlanManager,
   sessionId: string,
   input: Record<string, unknown>,
 ): Promise<string> {
   const planObj = input.plan;
   if (!planObj || typeof planObj !== "object") {
-    return "Error: plan_exit requires a 'plan' argument (object).";
+    return "Error: plan_manage(action: 'exit') requires a 'plan' argument (object).";
   }
   const validated = validateImplementationPlan(
     planObj as Record<string, unknown>,
@@ -53,11 +56,16 @@ async function executePlanExit(
       result.markdown
     );
   } catch (err) {
+    log.error("Plan exit failed during persistence", {
+      operation: "executeActionExit",
+      sessionId,
+      err,
+    });
     return `Error: ${err instanceof Error ? err.message : String(err)}`;
   }
 }
 
-function executePlanApprove(
+function executeActionApprove(
   manager: PlanManager,
   sessionId: string,
 ): string {
@@ -72,30 +80,14 @@ function executePlanApprove(
   });
 }
 
-function executePlanStepComplete(
-  manager: PlanManager,
-  sessionId: string,
-  input: Record<string, unknown>,
-): string {
-  const stepId = input.step_id;
-  const verificationResult = input.verification_result;
-  if (typeof stepId !== "number") {
-    return "Error: plan_step_complete requires a 'step_id' argument (number).";
-  }
-  if (typeof verificationResult !== "string") {
-    return "Error: plan_step_complete requires a 'verification_result' argument (string).";
-  }
-  return manager.stepComplete(sessionId, stepId, verificationResult);
-}
-
-function executePlanComplete(
+function executeActionComplete(
   manager: PlanManager,
   sessionId: string,
   input: Record<string, unknown>,
 ): string {
   const summary = input.summary;
   if (typeof summary !== "string" || summary.length === 0) {
-    return "Error: plan_complete requires a 'summary' argument (string).";
+    return "Error: plan_manage(action: 'complete') requires a 'summary' argument (string).";
   }
   const deviations = Array.isArray(input.deviations)
     ? (input.deviations as string[])
@@ -103,7 +95,7 @@ function executePlanComplete(
   return manager.complete(sessionId, summary, deviations);
 }
 
-function executePlanModify(
+function executeActionModify(
   manager: PlanManager,
   sessionId: string,
   input: Record<string, unknown>,
@@ -112,13 +104,13 @@ function executePlanModify(
   const reason = input.reason;
   const newDescription = input.new_description;
   if (typeof stepId !== "number") {
-    return "Error: plan_modify requires 'step_id' (number).";
+    return "Error: plan_manage(action: 'modify') requires 'step_id' (number).";
   }
   if (typeof reason !== "string") {
-    return "Error: plan_modify requires 'reason' (string).";
+    return "Error: plan_manage(action: 'modify') requires 'reason' (string).";
   }
   if (typeof newDescription !== "string") {
-    return "Error: plan_modify requires 'new_description' (string).";
+    return "Error: plan_manage(action: 'modify') requires 'new_description' (string).";
   }
   const newFiles = Array.isArray(input.new_files)
     ? (input.new_files as string[])
@@ -136,12 +128,61 @@ function executePlanModify(
   );
 }
 
+// ─── plan_manage dispatcher ──────────────────────────────────────────────────
+
+async function dispatchPlanManage(
+  manager: PlanManager,
+  sessionId: string,
+  input: Record<string, unknown>,
+): Promise<string> {
+  const action = input.action;
+  if (typeof action !== "string" || action.length === 0) {
+    return "Error: plan_manage requires an 'action' parameter (string).";
+  }
+
+  switch (action) {
+    case "enter":
+      return executeActionEnter(manager, sessionId, input);
+    case "exit":
+      return await executeActionExit(manager, sessionId, input);
+    case "approve":
+      return executeActionApprove(manager, sessionId);
+    case "reject":
+      return manager.reject(sessionId);
+    case "complete":
+      return executeActionComplete(manager, sessionId, input);
+    case "modify":
+      return executeActionModify(manager, sessionId, input);
+    default:
+      return `Error: unknown action "${action}" for plan_manage. Valid actions: enter, exit, approve, reject, complete, modify`;
+  }
+}
+
+// ─── plan_step_complete handler ──────────────────────────────────────────────
+
+function executePlanStepComplete(
+  manager: PlanManager,
+  sessionId: string,
+  input: Record<string, unknown>,
+): string {
+  const stepId = input.step_id;
+  const verificationResult = input.verification_result;
+  if (typeof stepId !== "number") {
+    return "Error: plan_step_complete requires a 'step_id' argument (number).";
+  }
+  if (typeof verificationResult !== "string") {
+    return "Error: plan_step_complete requires a 'verification_result' argument (string).";
+  }
+  return manager.stepComplete(sessionId, stepId, verificationResult);
+}
+
+// ─── Public Executor ─────────────────────────────────────────────────────────
+
 /**
  * Create a tool executor for plan operations.
  *
  * Returns a handler that accepts tool name + args and returns a result string,
  * or `null` if the tool name is not a plan tool (so callers can fall through).
- * This follows the same pattern as `createTodoToolExecutor`.
  *
  * @param manager - The PlanManager instance
  * @param sessionId - The session to operate on
@@ -157,22 +198,12 @@ export function createPlanToolExecutor(
     input: Record<string, unknown>,
   ): Promise<string | null> => {
     switch (name) {
-      case "plan_enter":
-        return executePlanEnter(manager, sessionId, input);
-      case "plan_exit":
-        return executePlanExit(manager, sessionId, input);
-      case "plan_status":
-        return manager.status(sessionId);
-      case "plan_approve":
-        return executePlanApprove(manager, sessionId);
-      case "plan_reject":
-        return manager.reject(sessionId);
+      case "plan_manage":
+        return dispatchPlanManage(manager, sessionId, input);
       case "plan_step_complete":
         return executePlanStepComplete(manager, sessionId, input);
-      case "plan_complete":
-        return executePlanComplete(manager, sessionId, input);
-      case "plan_modify":
-        return executePlanModify(manager, sessionId, input);
+      case "plan_status":
+        return manager.status(sessionId);
       default:
         return null;
     }

--- a/src/agent/plan/mod.ts
+++ b/src/agent/plan/mod.ts
@@ -24,6 +24,7 @@ export type {
 export {
   DEFAULT_PLAN_STATE,
   PLAN_ALLOWED_TOOLS,
+  PLAN_BLOCKED_CRON_ACTIONS,
   PLAN_BLOCKED_TOOLS,
 } from "./types.ts";
 

--- a/src/agent/plan/plan.ts
+++ b/src/agent/plan/plan.ts
@@ -15,7 +15,11 @@
  */
 
 import type { PlanModeState } from "./types.ts";
-import { DEFAULT_PLAN_STATE, PLAN_BLOCKED_TOOLS } from "./types.ts";
+import {
+  DEFAULT_PLAN_STATE,
+  PLAN_BLOCKED_CRON_ACTIONS,
+  PLAN_BLOCKED_TOOLS,
+} from "./types.ts";
 import type {
   PendingPlan,
   PlanManager,
@@ -159,7 +163,17 @@ function assembleManagerMethods(cfg: ManagerConfig): PlanManager {
         newFiles: files,
         newVerification: verif,
       }),
-    isToolBlocked: (sid, toolName) =>
-      gs(sid).mode === "plan" && PLAN_BLOCKED_TOOLS.includes(toolName),
+    isToolBlocked: (sid, toolName, args?) => {
+      if (gs(sid).mode !== "plan") return false;
+      if (PLAN_BLOCKED_TOOLS.includes(toolName)) return true;
+      // Action-level blocking for consolidated tools
+      if (
+        toolName === "cron" && typeof args?.action === "string" &&
+        PLAN_BLOCKED_CRON_ACTIONS.includes(args.action as string)
+      ) {
+        return true;
+      }
+      return false;
+    },
   };
 }

--- a/src/agent/plan/plan_types.ts
+++ b/src/agent/plan/plan_types.ts
@@ -63,7 +63,11 @@ export interface PlanManager {
   ): string;
 
   /** Check if a tool is blocked for a session in plan mode. */
-  isToolBlocked(sessionId: string, toolName: string): boolean;
+  isToolBlocked(
+    sessionId: string,
+    toolName: string,
+    args?: Record<string, unknown>,
+  ): boolean;
 }
 
 /** Pending plan awaiting user approval. */

--- a/src/agent/plan/prompt.ts
+++ b/src/agent/plan/prompt.ts
@@ -27,11 +27,11 @@ on specific concerns).`;
 function buildPlanModeRestrictions(): string {
   return `You MUST NOT:
 - Write or edit any files (write_file is blocked)
-- Create or delete cron jobs (cron_create, cron_delete are blocked)
+- Create or delete cron jobs (cron create/delete actions are blocked)
 - Make any changes to the codebase
 - Skip exploration and jump to a plan without evidence
 
-When you have a complete plan, call plan_exit with your implementation plan.
+When you have a complete plan, call plan_manage(action: "exit", plan: {...}) with your implementation plan.
 If you need clarification from the user, ask before finalizing.`;
 }
 
@@ -61,9 +61,9 @@ ${buildPlanModeRestrictions()}`;
 export function buildAwaitingApprovalPrompt(): string {
   return `A plan is awaiting user approval. The user's message is their response to the plan you presented.
 
-- If they approve, call plan_approve to begin execution.
-- If they want changes, discuss modifications and call plan_enter to re-plan if needed.
-- If they reject, call plan_reject to return to normal mode.`;
+- If they approve, call plan_manage(action: "approve") to begin execution.
+- If they want changes, discuss modifications and call plan_manage(action: "enter") to re-plan if needed.
+- If they reject, call plan_manage(action: "reject") to return to normal mode.`;
 }
 
 /** Format a single plan step for the execution prompt. */
@@ -108,9 +108,9 @@ Rules:
 - Execute ONE step at a time
 - After each step, run the verification command specified in the plan
 - If verification fails, fix before moving to the next step
-- If you discover the plan needs modification, call plan_modify and explain why
+- If you discover the plan needs modification, call plan_manage(action: "modify") and explain why
 - Check off completed steps by calling plan_step_complete
-- When all steps are done, call plan_complete`;
+- When all steps are done, call plan_manage(action: "complete")`;
 }
 
 /**

--- a/src/agent/plan/tools.ts
+++ b/src/agent/plan/tools.ts
@@ -1,81 +1,92 @@
 /**
  * Plan mode tool definitions.
  *
- * Defines the 8 plan tools available to the agent and the platform-level
+ * Defines the 3 plan tools available to the agent and the platform-level
  * system prompt section that introduces plan mode capabilities.
+ *
+ * Consolidated from 8 tools:
+ * - plan_manage (action: enter, exit, approve, reject, complete, modify)
+ * - plan_step_complete (kept separate — called frequently mid-plan)
+ * - plan_status (kept separate — lightweight status check)
  *
  * @module
  */
 
 import type { ToolDefinition } from "../../core/types/tool.ts";
 
-function buildPlanEnterDef(): ToolDefinition {
+function buildPlanManageDef(): ToolDefinition {
   return {
-    name: "plan_enter",
+    name: "plan_manage",
     description:
-      "Enter plan mode. Constrains the agent to read-only exploration and planning. " +
-      "write_file and cron_create/cron_delete are blocked until plan_exit is called.",
+      "Plan lifecycle management. Actions: enter, exit, approve, reject, complete, modify.\n" +
+      "- enter: enter plan mode. Params: goal (required), scope?\n" +
+      "- exit: present plan for approval. Params: plan (required, object)\n" +
+      "- approve: approve pending plan. No extra params.\n" +
+      "- reject: reject pending plan. No extra params.\n" +
+      "- complete: mark plan as complete. Params: summary (required), deviations?\n" +
+      "- modify: modify a plan step. Params: step_id (required), reason (required), new_description (required), new_files?, new_verification?",
     parameters: {
+      action: {
+        type: "string",
+        description:
+          "The operation: enter, exit, approve, reject, complete, modify",
+        required: true,
+      },
       goal: {
         type: "string",
-        description: "What the agent is planning to build/change",
-        required: true,
+        description: "What the agent is planning to build/change (enter)",
+        required: false,
       },
       scope: {
         type: "string",
         description:
-          "Optional: constrain exploration to specific directories or modules",
+          "Constrain exploration to specific directories or modules (enter)",
         required: false,
       },
-    },
-  };
-}
-
-function buildPlanExitDef(): ToolDefinition {
-  return {
-    name: "plan_exit",
-    description:
-      "Exit plan mode and present the implementation plan for user approval. " +
-      "Does NOT automatically begin execution — the user must approve first.",
-    parameters: {
       plan: {
         type: "object",
         description:
-          "The implementation plan object: { summary, approach, alternatives_considered, " +
-          "steps: [{ id, description, files, depends_on, verification }], risks, " +
-          "files_to_create, files_to_modify, tests_to_write, estimated_complexity }",
-        required: true,
+          "Implementation plan object with summary, approach, steps, etc. (exit)",
+        required: false,
+      },
+      summary: {
+        type: "string",
+        description: "What was accomplished (complete)",
+        required: false,
+      },
+      deviations: {
+        type: "array",
+        description: "Changes from the original plan (complete)",
+        required: false,
+        items: { type: "string" },
+      },
+      step_id: {
+        type: "number",
+        description: "Which step to modify (modify)",
+        required: false,
+      },
+      reason: {
+        type: "string",
+        description: "Why the change is needed (modify)",
+        required: false,
+      },
+      new_description: {
+        type: "string",
+        description: "Updated step description (modify)",
+        required: false,
+      },
+      new_files: {
+        type: "array",
+        description: "Updated file list (modify)",
+        required: false,
+        items: { type: "string" },
+      },
+      new_verification: {
+        type: "string",
+        description: "Updated verification command (modify)",
+        required: false,
       },
     },
-  };
-}
-
-function buildPlanStatusDef(): ToolDefinition {
-  return {
-    name: "plan_status",
-    description:
-      "Returns current plan mode state: mode, goal, active plan progress.",
-    parameters: {},
-  };
-}
-
-function buildPlanApproveDef(): ToolDefinition {
-  return {
-    name: "plan_approve",
-    description:
-      "Approve the pending plan and begin execution. Call this when the user " +
-      "approves the plan presented by plan_exit.",
-    parameters: {},
-  };
-}
-
-function buildPlanRejectDef(): ToolDefinition {
-  return {
-    name: "plan_reject",
-    description:
-      "Reject the pending plan and return to normal mode. Call this when " +
-      "the user rejects the plan or wants to start over.",
-    parameters: {},
   };
 }
 
@@ -99,78 +110,21 @@ function buildPlanStepCompleteDef(): ToolDefinition {
   };
 }
 
-function buildPlanCompleteDef(): ToolDefinition {
+function buildPlanStatusDef(): ToolDefinition {
   return {
-    name: "plan_complete",
+    name: "plan_status",
     description:
-      "Mark the entire plan as complete. Call when all steps are done.",
-    parameters: {
-      summary: {
-        type: "string",
-        description: "What was accomplished",
-        required: true,
-      },
-      deviations: {
-        type: "array",
-        description: "Any changes from the original plan",
-        required: false,
-        items: { type: "string" },
-      },
-    },
-  };
-}
-
-function buildPlanModifyParams(): ToolDefinition["parameters"] {
-  return {
-    step_id: {
-      type: "number",
-      description: "Which step needs changing",
-      required: true,
-    },
-    reason: {
-      type: "string",
-      description: "Why the change is needed",
-      required: true,
-    },
-    new_description: {
-      type: "string",
-      description: "Updated step description",
-      required: true,
-    },
-    new_files: {
-      type: "array",
-      description: "Updated file list (optional)",
-      required: false,
-      items: { type: "string" },
-    },
-    new_verification: {
-      type: "string",
-      description: "Updated verification command (optional)",
-      required: false,
-    },
-  };
-}
-
-function buildPlanModifyDef(): ToolDefinition {
-  return {
-    name: "plan_modify",
-    description:
-      "Request a modification to an approved plan step. Requires user approval.",
-    parameters: buildPlanModifyParams(),
+      "Returns current plan mode state: mode, goal, active plan progress.",
+    parameters: {},
   };
 }
 
 /** Tool definitions for plan mode tools. */
 export function getPlanToolDefinitions(): readonly ToolDefinition[] {
   return [
-    buildPlanEnterDef(),
-    buildPlanExitDef(),
-    buildPlanStatusDef(),
-    buildPlanApproveDef(),
-    buildPlanRejectDef(),
+    buildPlanManageDef(),
     buildPlanStepCompleteDef(),
-    buildPlanCompleteDef(),
-    buildPlanModifyDef(),
+    buildPlanStatusDef(),
   ];
 }
 
@@ -182,12 +136,15 @@ export function getPlanToolDefinitions(): readonly ToolDefinition[] {
  */
 export const PLAN_SYSTEM_PROMPT = `## Plan Mode
 
-You have access to plan mode (plan_enter, plan_exit, plan_status, plan_approve, plan_reject, plan_step_complete, plan_complete, plan_modify) for structured planning before implementation.
+You have access to plan mode tools for structured planning before implementation:
+- \`plan_manage\`: action = enter | exit | approve | reject | complete | modify
+- \`plan_step_complete\`: mark individual steps as done
+- \`plan_status\`: check current plan state
 
 When the user asks you to **build, implement, create, refactor, or redesign** code or infrastructure:
-- Consider entering plan mode first with plan_enter
+- Consider entering plan mode first with plan_manage(action: "enter", goal: "...")
 - Explore the codebase thoroughly before proposing changes
-- Present a concrete plan via plan_exit for user approval
+- Present a concrete plan via plan_manage(action: "exit", plan: {...}) for user approval
 - After approval, execute step by step, marking progress with plan_step_complete
 
 Do NOT use plan mode for: research, lookups, questions, analysis, reports, skill-driven tasks, or anything that is not code/infrastructure implementation. For simple tasks (fix a typo, add a comment, rename), skip plan mode and just do it.`;

--- a/src/agent/plan/types.ts
+++ b/src/agent/plan/types.ts
@@ -77,8 +77,17 @@ export const DEFAULT_PLAN_STATE: PlanModeState = {
 /** Tools blocked during plan mode. */
 export const PLAN_BLOCKED_TOOLS: readonly string[] = [
   "write_file",
-  "cron_create",
-  "cron_delete",
+];
+
+/**
+ * Cron actions blocked during plan mode.
+ *
+ * The consolidated `cron` tool uses an `action` parameter. These
+ * actions are blocked; read-only actions (list, history) are allowed.
+ */
+export const PLAN_BLOCKED_CRON_ACTIONS: readonly string[] = [
+  "create",
+  "delete",
 ];
 
 /** Tools allowed during plan mode. */
@@ -88,16 +97,10 @@ export const PLAN_ALLOWED_TOOLS: readonly string[] = [
   "run_command",
   "list_directory",
   "search_files",
-  "cron_list",
-  "cron_history",
+  "cron",
   "todo_read",
   "todo_write",
-  "plan_enter",
-  "plan_exit",
-  "plan_status",
-  "plan_approve",
-  "plan_reject",
+  "plan_manage",
   "plan_step_complete",
-  "plan_complete",
-  "plan_modify",
+  "plan_status",
 ];

--- a/src/cli/chat/events/screen_event_handler.ts
+++ b/src/cli/chat/events/screen_event_handler.ts
@@ -154,7 +154,7 @@ function handleScreenToolCall(
   event: { name: string; args: Record<string, unknown> },
 ): void {
   state.pendingToolCall = { name: event.name, args: event.args };
-  if (isTodoTool(event.name) || isPlanExitTool(event.name)) {
+  if (isTodoTool(event.name) || isPlanExitTool(event.name, event.args)) {
     // stored above — no display until result arrives
   } else if (getDisplayMode() === "compact") {
     screen.writeOutput(formatToolCompactInProgress(event.name, event.args));
@@ -178,7 +178,7 @@ function handleTodoToolResult(
   if (todos) screen.writeOutput(formatTodoListAnsi(todos) + "\n");
 }
 
-/** Handle tool_result for plan_exit tool. */
+/** Handle tool_result for plan_manage(exit) tool. */
 function handlePlanExitToolResult(
   state: ScreenHandlerState,
   screen: ScreenManager,
@@ -189,7 +189,7 @@ function handlePlanExitToolResult(
     screen.writeOutput(formatPlanMarkdown(event.result));
   } else {
     screen.writeOutput(
-      `  ${YELLOW}\u26a1${RESET} plan_exit  ${RED}\u2717${RESET} ${DIM}blocked${RESET}`,
+      `  ${YELLOW}\u26a1${RESET} plan_manage(exit)  ${RED}\u2717${RESET} ${DIM}blocked${RESET}`,
     );
   }
 }
@@ -203,7 +203,7 @@ function handleScreenToolResult(
 ): void {
   if (isTodoTool(event.name)) {
     handleTodoToolResult(state, screen, event);
-  } else if (isPlanExitTool(event.name)) {
+  } else if (isPlanExitTool(event.name, state.pendingToolCall?.args)) {
     handlePlanExitToolResult(state, screen, event);
   } else if (
     state.pendingToolCall?.name === "edit_file" &&

--- a/src/cli/chat/render/tool_display.ts
+++ b/src/cli/chat/render/tool_display.ts
@@ -25,9 +25,9 @@ export function isTodoTool(name: string): boolean {
   return name === "todo_read" || name === "todo_write";
 }
 
-/** Check whether a tool name is plan_exit (requires full display). */
-export function isPlanExitTool(name: string): boolean {
-  return name === "plan_exit";
+/** Check whether a tool call is plan exit (requires full display). */
+export function isPlanExitTool(name: string, args?: Record<string, unknown>): boolean {
+  return name === "plan_manage" && args?.action === "exit";
 }
 
 /** Human-readable display names for known tools. */
@@ -267,7 +267,7 @@ export function formatEditFileDiff(
   return parts.join("\n");
 }
 
-/** Extract the markdown body from a plan_exit tool result. */
+/** Extract the markdown body from a plan_manage(exit) tool result. */
 function extractPlanMarkdownBody(result: string): string {
   const separator = "\n\n---\n\n";
   const sepIdx = result.indexOf(separator);
@@ -295,7 +295,7 @@ function formatPlanMarkdownLine(line: string): string {
 /**
  * Format plan markdown for terminal display with ANSI colors.
  *
- * Extracts the markdown portion from a plan_exit tool result
+ * Extracts the markdown portion from a plan_manage(exit) tool result
  * (after the JSON + "---" separator) and applies ANSI formatting.
  */
 export function formatPlanMarkdown(result: string): string {

--- a/src/core/security/constants.ts
+++ b/src/core/security/constants.ts
@@ -82,10 +82,7 @@ export const URL_WRITE_TOOLS: ReadonlySet<string> = new Set([
 export const HARDCODED_TOOL_FLOORS: ReadonlyMap<string, ClassificationLevel> =
   new Map<string, ClassificationLevel>([
     // claude_* exec tools require INTERNAL (spawning sub-agents)
-    ["claude_start", "INTERNAL"],
-    ["claude_send", "INTERNAL"],
-    ["claude_stop", "INTERNAL"],
-    ["claude_status", "INTERNAL"],
+    ["claude_session", "INTERNAL"],
     ["claude_output", "INTERNAL"],
   ]);
 

--- a/src/exec/claude_tools.ts
+++ b/src/exec/claude_tools.ts
@@ -52,13 +52,13 @@ function buildSessionConfig(
   return config;
 }
 
-async function executeClaudeStart(
+async function executeActionStart(
   manager: ClaudeSessionManager,
   input: Record<string, unknown>,
 ): Promise<string> {
   const prompt = input.prompt;
   if (typeof prompt !== "string" || prompt.length === 0) {
-    return "Error: claude_start requires a 'prompt' argument (string).";
+    return "Error: claude_session(action: 'start') requires a 'prompt' argument (string).";
   }
 
   const config = buildSessionConfig(input);
@@ -72,17 +72,17 @@ async function executeClaudeStart(
   });
 }
 
-async function executeClaudeSend(
+async function executeActionSend(
   manager: ClaudeSessionManager,
   input: Record<string, unknown>,
 ): Promise<string> {
   const sessionId = input.session_id;
   const userInput = input.input;
   if (typeof sessionId !== "string" || sessionId.length === 0) {
-    return "Error: claude_send requires a 'session_id' argument (string).";
+    return "Error: claude_session(action: 'send') requires a 'session_id' argument (string).";
   }
   if (typeof userInput !== "string" || userInput.length === 0) {
-    return "Error: claude_send requires an 'input' argument (string).";
+    return "Error: claude_session(action: 'send') requires an 'input' argument (string).";
   }
 
   const result = await manager.send(sessionId, userInput);
@@ -90,27 +90,13 @@ async function executeClaudeSend(
   return result.value;
 }
 
-function executeClaudeOutput(
+function executeActionStatus(
   manager: ClaudeSessionManager,
   input: Record<string, unknown>,
 ): string {
   const sessionId = input.session_id;
   if (typeof sessionId !== "string" || sessionId.length === 0) {
-    return "Error: claude_output requires a 'session_id' argument (string).";
-  }
-
-  const result = manager.getOutput(sessionId);
-  if (!result.ok) return `Error: ${result.error}`;
-  return result.value || "(no output yet)";
-}
-
-function executeClaudeStatus(
-  manager: ClaudeSessionManager,
-  input: Record<string, unknown>,
-): string {
-  const sessionId = input.session_id;
-  if (typeof sessionId !== "string" || sessionId.length === 0) {
-    return "Error: claude_status requires a 'session_id' argument (string).";
+    return "Error: claude_session(action: 'status') requires a 'session_id' argument (string).";
   }
 
   const result = manager.status(sessionId);
@@ -127,18 +113,57 @@ function executeClaudeStatus(
   });
 }
 
-async function executeClaudeStop(
+async function executeActionStop(
   manager: ClaudeSessionManager,
   input: Record<string, unknown>,
 ): Promise<string> {
   const sessionId = input.session_id;
   if (typeof sessionId !== "string" || sessionId.length === 0) {
-    return "Error: claude_stop requires a 'session_id' argument (string).";
+    return "Error: claude_session(action: 'stop') requires a 'session_id' argument (string).";
   }
 
   const result = await manager.stop(sessionId);
   if (!result.ok) return `Error: ${result.error}`;
   return `Session ${sessionId} stopped.`;
+}
+
+function executeClaudeOutput(
+  manager: ClaudeSessionManager,
+  input: Record<string, unknown>,
+): string {
+  const sessionId = input.session_id;
+  if (typeof sessionId !== "string" || sessionId.length === 0) {
+    return "Error: claude_output requires a 'session_id' argument (string).";
+  }
+
+  const result = manager.getOutput(sessionId);
+  if (!result.ok) return `Error: ${result.error}`;
+  return result.value || "(no output yet)";
+}
+
+// ─── claude_session dispatcher ──────────────────────────────────────────────
+
+async function dispatchClaudeSession(
+  manager: ClaudeSessionManager,
+  input: Record<string, unknown>,
+): Promise<string> {
+  const action = input.action;
+  if (typeof action !== "string" || action.length === 0) {
+    return "Error: claude_session requires an 'action' parameter (string).";
+  }
+
+  switch (action) {
+    case "start":
+      return await executeActionStart(manager, input);
+    case "send":
+      return await executeActionSend(manager, input);
+    case "stop":
+      return await executeActionStop(manager, input);
+    case "status":
+      return executeActionStatus(manager, input);
+    default:
+      return `Error: unknown action "${action}" for claude_session. Valid actions: start, send, stop, status`;
+  }
 }
 
 /**
@@ -155,16 +180,10 @@ export function createClaudeToolExecutor(
     input: Record<string, unknown>,
   ): Promise<string | null> => {
     switch (name) {
-      case "claude_start":
-        return executeClaudeStart(manager, input);
-      case "claude_send":
-        return executeClaudeSend(manager, input);
+      case "claude_session":
+        return dispatchClaudeSession(manager, input);
       case "claude_output":
         return executeClaudeOutput(manager, input);
-      case "claude_status":
-        return executeClaudeStatus(manager, input);
-      case "claude_stop":
-        return executeClaudeStop(manager, input);
       default:
         return null;
     }

--- a/src/exec/claude_tools_defs.ts
+++ b/src/exec/claude_tools_defs.ts
@@ -1,84 +1,80 @@
 /**
  * Claude session tool definitions — LLM-callable schema declarations.
  *
- * Defines the parameter schemas and tool definitions for the five Claude
- * session management tools (start, send, output, status, stop) and the
- * system prompt section that describes them to the LLM.
+ * Consolidated from 5 tools to 2:
+ * - claude_session (action: start, send, stop, status)
+ * - claude_output (kept separate — read-back tool called repeatedly)
  *
  * @module
  */
 
 import type { ToolDefinition } from "../core/types/tool.ts";
 
-function buildClaudeStartParams(): ToolDefinition["parameters"] {
+function buildClaudeSessionDef(): ToolDefinition {
   return {
-    prompt: {
-      type: "string",
-      description: "Initial prompt/task for the Claude session",
-      required: true,
-    },
-    model: {
-      type: "string",
-      description: 'Model to use (e.g. "sonnet", "opus")',
-      required: false,
-    },
-    max_turns: {
-      type: "number",
-      description: "Maximum agent iteration turns",
-      required: false,
-    },
-    timeout_ms: {
-      type: "number",
-      description: "Max runtime in milliseconds (default: 300000 = 5min)",
-      required: false,
-    },
-    working_dir: {
-      type: "string",
-      description: "Working directory (must be within workspace)",
-      required: false,
-    },
-    system_prompt: {
-      type: "string",
-      description: "Custom system prompt for the session",
-      required: false,
-    },
-    allowed_tools: {
-      type: "string",
-      description: "Comma-separated tool allowlist",
-      required: false,
-    },
-    max_budget_usd: {
-      type: "number",
-      description: "Spending cap in USD",
-      required: false,
-    },
-  };
-}
-
-function buildClaudeStartDef(): ToolDefinition {
-  return {
-    name: "claude_start",
+    name: "claude_session",
     description:
-      "Start a headless Claude Code CLI session with an initial prompt. Returns the session ID for follow-up interaction.",
-    parameters: buildClaudeStartParams(),
-  };
-}
-
-function buildClaudeSendDef(): ToolDefinition {
-  return {
-    name: "claude_send",
-    description:
-      "Send a follow-up message to a running Claude session and get the response.",
+      "Claude Code CLI session management. Actions: start, send, stop, status.\n" +
+      "- start: start a new session. Params: prompt (required), model?, max_turns?, timeout_ms?, working_dir?, system_prompt?, allowed_tools?, max_budget_usd?\n" +
+      "- send: send follow-up message. Params: session_id (required), input (required)\n" +
+      "- stop: terminate session. Params: session_id (required)\n" +
+      "- status: check session status. Params: session_id (required)",
     parameters: {
+      action: {
+        type: "string",
+        description: "The operation: start, send, stop, status",
+        required: true,
+      },
       session_id: {
         type: "string",
-        description: "Session ID from claude_start",
-        required: true,
+        description: "Session ID from a previous start action",
+        required: false,
+      },
+      prompt: {
+        type: "string",
+        description: "Initial prompt/task for the session (start)",
+        required: false,
       },
       input: {
         type: "string",
-        description: "Follow-up message to send",
-        required: true,
+        description: "Follow-up message to send (send)",
+        required: false,
+      },
+      model: {
+        type: "string",
+        description: 'Model to use, e.g. "sonnet", "opus" (start)',
+        required: false,
+      },
+      max_turns: {
+        type: "number",
+        description: "Maximum agent iteration turns (start)",
+        required: false,
+      },
+      timeout_ms: {
+        type: "number",
+        description:
+          "Max runtime in milliseconds, default: 300000 = 5min (start)",
+        required: false,
+      },
+      working_dir: {
+        type: "string",
+        description: "Working directory, must be within workspace (start)",
+        required: false,
+      },
+      system_prompt: {
+        type: "string",
+        description: "Custom system prompt for the session (start)",
+        required: false,
+      },
+      allowed_tools: {
+        type: "string",
+        description: "Comma-separated tool allowlist (start)",
+        required: false,
+      },
+      max_budget_usd: {
+        type: "number",
+        description: "Spending cap in USD (start)",
+        required: false,
       },
     },
   };
@@ -92,35 +88,7 @@ function buildClaudeOutputDef(): ToolDefinition {
     parameters: {
       session_id: {
         type: "string",
-        description: "Session ID from claude_start",
-        required: true,
-      },
-    },
-  };
-}
-
-function buildClaudeStatusDef(): ToolDefinition {
-  return {
-    name: "claude_status",
-    description: "Check the status and metadata of a Claude session.",
-    parameters: {
-      session_id: {
-        type: "string",
-        description: "Session ID from claude_start",
-        required: true,
-      },
-    },
-  };
-}
-
-function buildClaudeStopDef(): ToolDefinition {
-  return {
-    name: "claude_stop",
-    description: "Terminate a running Claude session.",
-    parameters: {
-      session_id: {
-        type: "string",
-        description: "Session ID from claude_start",
+        description: "Session ID from claude_session(action: 'start')",
         required: true,
       },
     },
@@ -130,11 +98,8 @@ function buildClaudeStopDef(): ToolDefinition {
 /** Tool definitions for Claude session management. */
 export function getClaudeToolDefinitions(): readonly ToolDefinition[] {
   return [
-    buildClaudeStartDef(),
-    buildClaudeSendDef(),
+    buildClaudeSessionDef(),
     buildClaudeOutputDef(),
-    buildClaudeStatusDef(),
-    buildClaudeStopDef(),
   ];
 }
 
@@ -144,11 +109,12 @@ export const CLAUDE_SESSION_SYSTEM_PROMPT = `## Claude Session Tools
 You can spawn headless Claude Code CLI sessions for delegating complex tasks.
 Each session runs as a separate process with its own context, tools, and workspace.
 
-- \`claude_start\`: Start a new session with a prompt. Returns a session ID.
-- \`claude_send\`: Send a follow-up message to a running session.
+- \`claude_session\`: action = start | send | stop | status
+  - start: Start a new session with a prompt. Returns a session ID.
+  - send: Send a follow-up message to a running session.
+  - stop: Terminate a session.
+  - status: Check if a session is still running.
 - \`claude_output\`: Read accumulated output from a session.
-- \`claude_status\`: Check if a session is still running.
-- \`claude_stop\`: Terminate a session.
 
 Sessions are sandboxed to the agent workspace. Use these for:
 - Delegating code generation tasks

--- a/src/gateway/tools/defs/cron_tool_defs.ts
+++ b/src/gateway/tools/defs/cron_tool_defs.ts
@@ -1,83 +1,57 @@
 /**
- * Inline tool definitions for cron scheduling operations.
+ * Inline tool definition for cron scheduling operations.
  *
- * Cron create/list/delete/history are defined inline because
- * they are wired directly in the gateway executor.
+ * Consolidated 4 cron tools into 1 with action parameter dispatch.
  *
  * @module
  */
 
 import type { ToolDefinition } from "../../../core/types/tool.ts";
 
-function buildCronCreateDef(): ToolDefinition {
+function buildCronDef(): ToolDefinition {
   return {
-    name: "cron_create",
+    name: "cron",
     description:
-      "Create a scheduled cron job. The task runs on the given cron schedule.",
+      "Cron job management. Actions: create, list, delete, history.\n" +
+      "- create: create a scheduled cron job. Params: expression (required), task (required), classification?\n" +
+      "- list: list all registered cron jobs. No extra params.\n" +
+      "- delete: delete a cron job. Params: job_id (required)\n" +
+      "- history: show recent execution history. Params: job_id (required)",
     parameters: {
+      action: {
+        type: "string",
+        description: "The operation: create, list, delete, history",
+        required: true,
+      },
       expression: {
         type: "string",
-        description: "5-field cron expression (e.g. '0 9 * * *' for 9am daily)",
-        required: true,
+        description:
+          "5-field cron expression, e.g. '0 9 * * *' for 9am daily (create)",
+        required: false,
       },
       task: {
         type: "string",
-        description: "The task/prompt to execute on each trigger",
-        required: true,
+        description: "The task/prompt to execute on each trigger (create)",
+        required: false,
       },
       classification: {
         type: "string",
         description:
-          "Classification ceiling: PUBLIC, INTERNAL, CONFIDENTIAL, or RESTRICTED",
+          "Classification ceiling: PUBLIC, INTERNAL, CONFIDENTIAL, or RESTRICTED (create)",
+        required: false,
+      },
+      job_id: {
+        type: "string",
+        description: "The UUID of the cron job (delete, history)",
         required: false,
       },
     },
   };
 }
 
-function buildCronListDef(): ToolDefinition {
-  return {
-    name: "cron_list",
-    description:
-      "List all registered cron jobs with their schedules and status.",
-    parameters: {},
-  };
-}
-
-function buildCronDeleteDef(): ToolDefinition {
-  return {
-    name: "cron_delete",
-    description: "Delete a cron job by its ID.",
-    parameters: {
-      job_id: {
-        type: "string",
-        description: "The UUID of the cron job to delete",
-        required: true,
-      },
-    },
-  };
-}
-
-function buildCronHistoryDef(): ToolDefinition {
-  return {
-    name: "cron_history",
-    description: "Show recent execution history for a cron job.",
-    parameters: {
-      job_id: {
-        type: "string",
-        description: "The UUID of the cron job",
-        required: true,
-      },
-    },
-  };
-}
-
-/** Cron scheduling tools: cron_create, cron_list, cron_delete, cron_history. */
+/** Cron scheduling tool: single consolidated cron tool. */
 export function getCronInlineDefinitions(): readonly ToolDefinition[] {
   return [
-    buildCronCreateDef(),
-    buildCronListDef(),
-    buildCronDeleteDef(),
-    buildCronHistoryDef(),
+    buildCronDef(),
   ];
 }

--- a/src/gateway/tools/defs/role_filter.ts
+++ b/src/gateway/tools/defs/role_filter.ts
@@ -45,9 +45,7 @@ export const OWNER_ONLY_TOOLS: ReadonlySet<string> = new Set([
   "secret_list",
   "secret_delete",
   // Scheduling
-  "cron_create",
-  "cron_delete",
-  "cron_history",
+  "cron",
   // Trigger management
   "trigger_add_to_context",
   // Skill management
@@ -58,24 +56,14 @@ export const OWNER_ONLY_TOOLS: ReadonlySet<string> = new Set([
   // Session management (cross-session ops)
   "sessions_send",
   "sessions_spawn",
-  "session_status",
-  "message",
   "signal_generate_pairing",
   // Claude sessions
-  "claude_start",
-  "claude_send",
+  "claude_session",
   "claude_output",
-  "claude_status",
-  "claude_stop",
   // Plan mode
-  "plan_enter",
-  "plan_exit",
-  "plan_status",
-  "plan_approve",
-  "plan_reject",
+  "plan_manage",
   "plan_step_complete",
-  "plan_complete",
-  "plan_modify",
+  "plan_status",
   // Tidepool canvas
   "tidepool_render_component",
   "tidepool_render_html",

--- a/src/gateway/tools/executor/executor_cron.ts
+++ b/src/gateway/tools/executor/executor_cron.ts
@@ -1,7 +1,7 @@
 /**
- * Cron tool handlers — create, list, delete, history.
+ * Cron tool handler — dispatches on action parameter.
  *
- * Each handler delegates to CronManager and formats the result
+ * Each action delegates to CronManager and formats the result
  * as a human-readable string for the agent.
  *
  * @module
@@ -10,8 +10,8 @@
 import type { CronManager } from "../../../scheduler/cron/parser.ts";
 import type { ClassificationLevel } from "../../../core/types/classification.ts";
 
-/** Handle cron_create tool call. */
-export function executeCronCreate(
+/** Handle cron create action. */
+function executeCronCreate(
   input: Record<string, unknown>,
   cronManager: CronManager,
 ): string {
@@ -35,8 +35,8 @@ export function executeCronCreate(
   ].join("\n");
 }
 
-/** Handle cron_list tool call. */
-export function executeCronList(cronManager: CronManager): string {
+/** Handle cron list action. */
+function executeCronList(cronManager: CronManager): string {
   const jobs = cronManager.list();
   if (jobs.length === 0) return "No cron jobs registered.";
   return jobs.map((j) =>
@@ -51,8 +51,8 @@ export function executeCronList(cronManager: CronManager): string {
   ).join("\n\n");
 }
 
-/** Handle cron_delete tool call. */
-export function executeCronDelete(
+/** Handle cron delete action. */
+function executeCronDelete(
   input: Record<string, unknown>,
   cronManager: CronManager,
 ): string {
@@ -61,8 +61,8 @@ export function executeCronDelete(
   return result.ok ? `Deleted cron job ${jobId}` : `Error: ${result.error}`;
 }
 
-/** Handle cron_history tool call. */
-export function executeCronHistory(
+/** Handle cron history action. */
+function executeCronHistory(
   input: Record<string, unknown>,
   cronManager: CronManager,
 ): string {
@@ -76,23 +76,32 @@ export function executeCronHistory(
   ).join("\n");
 }
 
-/** Dispatch cron tools. Returns null if not matched. */
+/** Dispatch cron tool. Returns null if not matched. */
 export function dispatchCronTool(
   name: string,
   input: Record<string, unknown>,
   cronManager: CronManager | undefined,
 ): string | null {
+  if (name !== "cron") return null;
+
   const unavailable = "Cron management is not available in this context.";
-  switch (name) {
-    case "cron_create":
-      return cronManager ? executeCronCreate(input, cronManager) : unavailable;
-    case "cron_list":
-      return cronManager ? executeCronList(cronManager) : unavailable;
-    case "cron_delete":
-      return cronManager ? executeCronDelete(input, cronManager) : unavailable;
-    case "cron_history":
-      return cronManager ? executeCronHistory(input, cronManager) : unavailable;
+  if (!cronManager) return unavailable;
+
+  const action = input.action;
+  if (typeof action !== "string" || action.length === 0) {
+    return "Error: cron requires an 'action' parameter (string).";
+  }
+
+  switch (action) {
+    case "create":
+      return executeCronCreate(input, cronManager);
+    case "list":
+      return executeCronList(cronManager);
+    case "delete":
+      return executeCronDelete(input, cronManager);
+    case "history":
+      return executeCronHistory(input, cronManager);
     default:
-      return null;
+      return `Error: unknown action "${action}" for cron. Valid actions: create, list, delete, history`;
   }
 }

--- a/src/gateway/tools/session/channel_executors.ts
+++ b/src/gateway/tools/session/channel_executors.ts
@@ -1,8 +1,9 @@
 /**
  * Channel messaging tool handlers.
  *
- * Implements the message and channels_list handlers. Write-down enforcement
- * uses the injected context taint, not LLM arguments.
+ * Implements the channel-send path of sessions_send (when channel/recipient/text
+ * params are provided) and channels_list. Write-down enforcement uses the
+ * injected context taint, not LLM arguments.
  *
  * @module
  */
@@ -19,7 +20,7 @@ const log = createLogger("security");
 
 /** Tool names handled by this executor. */
 export const CHANNEL_TOOLS = new Set([
-  "message",
+  "sessions_send",
   "channels_list",
 ]);
 
@@ -36,16 +37,18 @@ function buildChannelSessionId(opts: {
   return `${opts.channel}-${opts.recipient}`;
 }
 
-/** Validate message tool input, returning an error string or null if valid. */
-function validateMessageInput(input: Record<string, unknown>): string | null {
+/** Validate channel-send input, returning an error string or null if valid. */
+function validateChannelSendInput(
+  input: Record<string, unknown>,
+): string | null {
   if (typeof input.channel !== "string" || input.channel.length === 0) {
-    return "Error: message requires a non-empty 'channel' argument (string).";
+    return "Error: sessions_send (channel mode) requires a non-empty 'channel' argument (string).";
   }
   if (typeof input.recipient !== "string" || input.recipient.length === 0) {
-    return "Error: message requires a non-empty 'recipient' argument (string).";
+    return "Error: sessions_send (channel mode) requires a non-empty 'recipient' argument (string).";
   }
   if (typeof input.text !== "string" || input.text.length === 0) {
-    return "Error: message requires a non-empty 'text' argument (string).";
+    return "Error: sessions_send (channel mode) requires a non-empty 'text' argument (string).";
   }
   return null;
 }
@@ -67,12 +70,22 @@ function enforceMessageWriteDown(ctx: SessionToolContext, opts: {
   return null;
 }
 
-/** Handle message: send to a connected channel with write-down enforcement. */
-async function executeMessage(
+/**
+ * Check if input has channel-send params (channel + recipient + text).
+ *
+ * When sessions_send is called with these params, it routes to channel
+ * messaging instead of session-to-session send.
+ */
+export function isChannelSendInput(input: Record<string, unknown>): boolean {
+  return typeof input.channel === "string" && input.channel.length > 0;
+}
+
+/** Handle channel-send path of sessions_send. */
+async function executeChannelSend(
   ctx: SessionToolContext,
   input: Record<string, unknown>,
 ): Promise<string> {
-  const validationErr = validateMessageInput(input);
+  const validationErr = validateChannelSendInput(input);
   if (validationErr) return validationErr;
 
   const channel = input.channel as string;
@@ -145,8 +158,12 @@ export async function dispatchChannelTool(
   input: Record<string, unknown>,
 ): Promise<string | null> {
   switch (name) {
-    case "message":
-      return executeMessage(ctx, input);
+    case "sessions_send":
+      // Only handle if input has channel params; otherwise session_executors handles it
+      if (isChannelSendInput(input)) {
+        return executeChannelSend(ctx, input);
+      }
+      return null;
     case "channels_list":
       return executeChannelsList(ctx);
     default:

--- a/src/gateway/tools/session/session_executors.ts
+++ b/src/gateway/tools/session/session_executors.ts
@@ -1,9 +1,10 @@
 /**
  * Session management tool handlers.
  *
- * Implements sessions_list, sessions_history, sessions_send,
- * sessions_spawn, and session_status handlers. All taint decisions
- * use the injected context, not LLM arguments.
+ * Implements sessions_list (with optional session_id for status),
+ * sessions_history, sessions_send (session-to-session and channel),
+ * and sessions_spawn handlers. All taint decisions use the injected
+ * context, not LLM arguments.
  *
  * @module
  */
@@ -22,7 +23,6 @@ export const SESSION_MANAGEMENT_TOOLS = new Set([
   "sessions_history",
   "sessions_send",
   "sessions_spawn",
-  "session_status",
 ]);
 
 /** Format a session record for display. */
@@ -66,8 +66,36 @@ function requireStringArg(
   return null;
 }
 
-/** Handle sessions_list: list sessions visible at the caller's taint level. */
-async function executeSessionsList(ctx: SessionToolContext): Promise<string> {
+/**
+ * Handle sessions_list: list sessions visible at the caller's taint level.
+ *
+ * If input contains session_id, returns status for that specific session
+ * (merged session_status functionality).
+ */
+async function executeSessionsList(
+  ctx: SessionToolContext,
+  input: Record<string, unknown>,
+): Promise<string> {
+  const sessionId = input.session_id;
+
+  // Single-session status mode (merged from session_status)
+  if (typeof sessionId === "string" && sessionId.length > 0) {
+    try {
+      const session = await ctx.sessionManager.get(sessionId as SessionId);
+      if (!session) return `Session not found: ${sessionId}`;
+
+      if (!canFlowTo(session.taint, ctx.callerTaint)) {
+        return `Access denied: session ${sessionId} is at ${session.taint}, your session is at ${ctx.callerTaint}.`;
+      }
+      return serializeSessionMeta(session);
+    } catch (err) {
+      return `Error reading session: ${
+        err instanceof Error ? err.message : String(err)
+      }`;
+    }
+  }
+
+  // List all sessions
   try {
     const sessions = await ctx.sessionManager.sessionsList();
     const visible = sessions.filter((s) => canFlowTo(s.taint, ctx.callerTaint));
@@ -169,30 +197,6 @@ async function executeSessionsSpawn(
   }
 }
 
-/** Handle session_status: get session metadata with taint gating. */
-async function executeSessionStatus(
-  ctx: SessionToolContext,
-  input: Record<string, unknown>,
-): Promise<string> {
-  const argErr = requireStringArg(input, "session_id", "session_status");
-  if (argErr) return argErr;
-
-  const sessionId = input.session_id as string;
-  try {
-    const session = await ctx.sessionManager.get(sessionId as SessionId);
-    if (!session) return `Session not found: ${sessionId}`;
-
-    if (!canFlowTo(session.taint, ctx.callerTaint)) {
-      return `Access denied: session ${sessionId} is at ${session.taint}, your session is at ${ctx.callerTaint}.`;
-    }
-    return serializeSessionMeta(session);
-  } catch (err) {
-    return `Error reading session: ${
-      err instanceof Error ? err.message : String(err)
-    }`;
-  }
-}
-
 /**
  * Dispatch a session management tool call.
  *
@@ -206,15 +210,13 @@ export async function dispatchSessionTool(
 ): Promise<string | null> {
   switch (name) {
     case "sessions_list":
-      return executeSessionsList(ctx);
+      return executeSessionsList(ctx, input);
     case "sessions_history":
       return executeSessionsHistory(ctx, input);
     case "sessions_send":
       return executeSessionsSend(ctx, input);
     case "sessions_spawn":
       return executeSessionsSpawn(ctx, input);
-    case "session_status":
-      return executeSessionStatus(ctx, input);
     default:
       return null;
   }

--- a/src/gateway/tools/session/session_tools.ts
+++ b/src/gateway/tools/session/session_tools.ts
@@ -15,7 +15,11 @@ import {
   dispatchSessionTool,
   SESSION_MANAGEMENT_TOOLS,
 } from "./session_executors.ts";
-import { CHANNEL_TOOLS, dispatchChannelTool } from "./channel_executors.ts";
+import {
+  CHANNEL_TOOLS,
+  dispatchChannelTool,
+  isChannelSendInput,
+} from "./channel_executors.ts";
 import { dispatchSignalTool, SIGNAL_TOOLS } from "./signal_executors.ts";
 
 import type { SessionToolContext } from "./session_tools_defs.ts";
@@ -59,6 +63,11 @@ export function createSessionToolExecutor(
 
     if (!ctx) {
       return "Session management is not available in this context.";
+    }
+
+    // For sessions_send with channel params, route to channel executor first
+    if (name === "sessions_send" && isChannelSendInput(input)) {
+      return dispatchChannelTool(ctx, name, input);
     }
 
     return (

--- a/src/gateway/tools/session/session_tools_defs.ts
+++ b/src/gateway/tools/session/session_tools_defs.ts
@@ -1,9 +1,12 @@
 /**
  * Session tool types, definitions, and system prompt.
  *
- * Defines RegisteredChannel, SessionToolContext, the 10 session/channel
- * tool schemas, and the LLM system prompt section. Separated from
- * the executor in `tools.ts` for lighter type-only imports.
+ * Consolidated from 7 to 5 tools:
+ * - sessions_list (now includes session_status via optional session_id)
+ * - sessions_history
+ * - sessions_send (now includes message functionality via optional channel/recipient/text)
+ * - sessions_spawn
+ * - channels_list
  *
  * @module
  */
@@ -50,8 +53,17 @@ export interface SessionToolContext {
 function buildSessionsListDef(): ToolDefinition {
   return {
     name: "sessions_list",
-    description: "List all active sessions visible to the current session.",
-    parameters: {},
+    description:
+      "List all active sessions visible to the current session. " +
+      "If session_id is provided, returns detailed status for that specific session.",
+    parameters: {
+      session_id: {
+        type: "string",
+        description:
+          "Optional: get status for a specific session instead of listing all",
+        required: false,
+      },
+    },
   };
 }
 
@@ -72,18 +84,39 @@ function buildSessionsHistoryDef(): ToolDefinition {
 function buildSessionsSendDef(): ToolDefinition {
   return {
     name: "sessions_send",
-    description: "Send content from the current session to another session. " +
-      "Subject to write-down enforcement.",
+    description:
+      "Send content to another session or a connected channel. " +
+      "Subject to write-down enforcement.\n" +
+      "- To send to a session: provide session_id and content.\n" +
+      "- To send to a channel: provide channel, recipient, and text. " +
+      "For Signal, the recipient is a phone number (E.164 format) or a group ID prefixed with 'group-'.",
     parameters: {
       session_id: {
         type: "string",
-        description: "Target session ID to send content to",
-        required: true,
+        description: "Target session ID (session-to-session send)",
+        required: false,
       },
       content: {
         type: "string",
-        description: "The message content to send",
-        required: true,
+        description: "Message content (session-to-session send)",
+        required: false,
+      },
+      channel: {
+        type: "string",
+        description:
+          "Target channel type, e.g. 'signal', 'telegram' (channel send). Use channels_list to see connected channels.",
+        required: false,
+      },
+      recipient: {
+        type: "string",
+        description:
+          "Recipient identifier — phone number for Signal, chat ID for Telegram, etc. (channel send)",
+        required: false,
+      },
+      text: {
+        type: "string",
+        description: "Message text (channel send)",
+        required: false,
       },
     },
   };
@@ -101,54 +134,6 @@ function buildSessionsSpawnDef(): ToolDefinition {
         required: true,
       },
     },
-  };
-}
-
-function buildSessionStatusDef(): ToolDefinition {
-  return {
-    name: "session_status",
-    description: "Get metadata and status for a specific session.",
-    parameters: {
-      session_id: {
-        type: "string",
-        description: "The session ID to check",
-        required: true,
-      },
-    },
-  };
-}
-
-/** Build the parameter schema for the message tool. */
-function buildMessageParams(): ToolDefinition["parameters"] {
-  return {
-    channel: {
-      type: "string",
-      description:
-        "Target channel type (e.g. 'signal', 'telegram'). Use channels_list to see connected channels.",
-      required: true,
-    },
-    recipient: {
-      type: "string",
-      description:
-        "Recipient identifier — phone number for Signal, chat ID for Telegram, etc.",
-      required: true,
-    },
-    text: {
-      type: "string",
-      description: "Message text to send",
-      required: true,
-    },
-  };
-}
-
-function buildMessageDef(): ToolDefinition {
-  return {
-    name: "message",
-    description:
-      "Send a message to a connected channel (signal, telegram, etc.). " +
-      "Subject to write-down enforcement: your session taint must be able to flow to the channel's classification. " +
-      "For Signal, the recipient is a phone number (E.164 format, e.g. '+15551234567') or a group ID prefixed with 'group-'.",
-    parameters: buildMessageParams(),
   };
 }
 
@@ -196,8 +181,6 @@ export function getSessionToolDefinitions(): readonly ToolDefinition[] {
     buildSessionsHistoryDef(),
     buildSessionsSendDef(),
     buildSessionsSpawnDef(),
-    buildSessionStatusDef(),
-    buildMessageDef(),
     buildChannelsListDef(),
   ];
 }
@@ -217,6 +200,9 @@ export const SESSION_TOOLS_SYSTEM_PROMPT = `## Session & Channel Management
 Write-down enforcement applies to all cross-session and cross-channel communication:
 you cannot send data to a channel or session whose classification is lower than your current session taint.
 
-Use channels_list to discover connected channels before sending messages.
-Use sessions_spawn to create background sessions for autonomous tasks (starts at PUBLIC taint).
+- \`sessions_list\`: list all sessions, or pass session_id for one session's status
+- \`sessions_send\`: send to a session (session_id + content) or channel (channel + recipient + text)
+- \`sessions_spawn\`: create background sessions for autonomous tasks (starts at PUBLIC taint)
+- \`channels_list\`: discover connected channels before sending messages
+
 For Signal: use signal_list_contacts/signal_list_groups to find recipients, signal_generate_pairing to onboard new contacts.`;

--- a/src/integrations/github/tools.ts
+++ b/src/integrations/github/tools.ts
@@ -1,10 +1,9 @@
 /**
  * GitHub tool executor for the agent.
  *
- * Creates a chain-compatible executor for the 26 `github_*` tools.
- * Tool definitions live in `tools_defs.ts`; domain-specific handlers
- * live in `tools_repos.ts`, `tools_pulls.ts`, `tools_issues.ts`,
- * `tools_actions.ts`, and `tools_search.ts`.
+ * Creates a chain-compatible executor for the 4 consolidated `github_*`
+ * tools. Each tool dispatches on the `action` parameter to the
+ * domain-specific handler from repos/, pulls/, issues/, actions/.
  *
  * @module
  */
@@ -54,57 +53,79 @@ export {
   GITHUB_TOOLS_SYSTEM_PROMPT,
 } from "./tools_defs.ts";
 
-// ─── Tool dispatch map ──────────────────────────────────────────────────────
+// ─── Tool dispatch maps ─────────────────────────────────────────────────────
 
-/** Map of tool name to handler function. */
+/** Map of action name to handler function. */
 type ToolHandler = (
   client: GitHubToolContext["client"],
   input: Record<string, unknown>,
 ) => Promise<string>;
 
-/** Registry mapping each github_* tool name to its handler. */
-const TOOL_HANDLERS: Readonly<Record<string, ToolHandler>> = {
-  github_list_repos: executeListRepos,
-  github_get_repo: executeGetRepo,
-  github_read_file: executeReadFile,
-  github_list_commits: executeListCommits,
-  github_list_branches: executeListBranches,
-  github_create_branch: executeCreateBranch,
-  github_delete_branch: executeDeleteBranch,
-  github_clone_repo: executeCloneRepo,
-  github_pull: executePullRepo,
-  github_list_pulls: executeListPulls,
-  github_get_pull: executeGetPull,
-  github_create_pull: executeCreatePull,
-  github_update_pull: executeUpdatePull,
-  github_list_pull_files: executeListPullFiles,
-  github_review_pull: executeReviewPull,
-  github_merge_pull: executeMergePull,
-  github_list_issues: executeListIssues,
-  github_get_issue: executeGetIssue,
-  github_create_issue: executeCreateIssue,
-  github_update_issue: executeUpdateIssue,
-  github_list_comments: executeListComments,
-  github_add_comment: executeAddComment,
-  github_list_runs: executeListRuns,
-  github_cancel_run: executeCancelRun,
-  github_trigger_workflow: executeTriggerWorkflow,
-  github_search_code: executeSearchCode,
-  github_search_issues: executeSearchIssues,
+/** Repos domain: action → handler. */
+const REPOS_ACTIONS: Readonly<Record<string, ToolHandler>> = {
+  list: executeListRepos,
+  get: executeGetRepo,
+  read_file: executeReadFile,
+  list_commits: executeListCommits,
+  list_branches: executeListBranches,
+  create_branch: executeCreateBranch,
+  delete_branch: executeDeleteBranch,
+  clone: executeCloneRepo,
+  pull: executePullRepo,
+};
+
+/** Pulls domain: action → handler. */
+const PULLS_ACTIONS: Readonly<Record<string, ToolHandler>> = {
+  list: executeListPulls,
+  get: executeGetPull,
+  create: executeCreatePull,
+  update: executeUpdatePull,
+  list_files: executeListPullFiles,
+  review: executeReviewPull,
+  merge: executeMergePull,
+};
+
+/** Issues domain: action → handler. */
+const ISSUES_ACTIONS: Readonly<Record<string, ToolHandler>> = {
+  list: executeListIssues,
+  get: executeGetIssue,
+  create: executeCreateIssue,
+  update: executeUpdateIssue,
+  list_comments: executeListComments,
+  add_comment: executeAddComment,
+};
+
+/** Actions/search domain: action → handler. */
+const ACTIONS_ACTIONS: Readonly<Record<string, ToolHandler>> = {
+  list_runs: executeListRuns,
+  cancel_run: executeCancelRun,
+  trigger_workflow: executeTriggerWorkflow,
+  search_code: executeSearchCode,
+  search_issues: executeSearchIssues,
+};
+
+/** Tool name → action dispatch map. */
+const TOOL_ACTION_MAPS: Readonly<
+  Record<string, Readonly<Record<string, ToolHandler>>>
+> = {
+  github_repos: REPOS_ACTIONS,
+  github_pulls: PULLS_ACTIONS,
+  github_issues: ISSUES_ACTIONS,
+  github_actions: ACTIONS_ACTIONS,
 };
 
 // ─── Path Resolution ─────────────────────────────────────────────────────────
 
-/** Tools whose `path` input refers to a local filesystem location. */
-const LOCAL_PATH_TOOLS = new Set(["github_clone_repo", "github_pull"]);
+/** Actions whose `path` input refers to a local filesystem location. */
+const LOCAL_PATH_ACTIONS = new Set(["clone", "pull"]);
 
-/** Resolve local path inputs to absolute workspace paths for clone/pull tools. */
+/** Resolve local path inputs to absolute workspace paths for clone/pull actions. */
 function resolveLocalPathInput(
-  toolName: string,
+  action: string,
   input: Record<string, unknown>,
   workspacePath: string,
 ): Record<string, unknown> {
-  if (!LOCAL_PATH_TOOLS.has(toolName)) return input;
+  if (!LOCAL_PATH_ACTIONS.has(action)) return input;
   const path = input.path;
   if (typeof path !== "string" || path.length === 0) return input;
   return { ...input, path: join(workspacePath, path) };
@@ -126,21 +147,26 @@ export function createGitHubToolExecutor(
     name: string,
     input: Record<string, unknown>,
   ): Promise<string | null> => {
-    if (!name.startsWith("github_")) {
-      return null;
-    }
+    const actionMap = TOOL_ACTION_MAPS[name];
+    if (!actionMap) return null;
 
     if (!ctx) {
       return "GitHub is not configured. Set up a GitHub token to use GitHub tools.";
     }
 
-    const handler = TOOL_HANDLERS[name];
+    const action = input.action;
+    if (typeof action !== "string" || action.length === 0) {
+      return `Error: ${name} requires an 'action' parameter (string).`;
+    }
+
+    const handler = actionMap[action];
     if (!handler) {
-      return null;
+      const valid = Object.keys(actionMap).join(", ");
+      return `Error: unknown action "${action}" for ${name}. Valid actions: ${valid}`;
     }
 
     const resolvedInput = ctx.workspacePath
-      ? resolveLocalPathInput(name, input, ctx.workspacePath)
+      ? resolveLocalPathInput(action, input, ctx.workspacePath)
       : input;
 
     return handler(ctx.client, resolvedInput);

--- a/src/integrations/github/tools_defs.ts
+++ b/src/integrations/github/tools_defs.ts
@@ -1,85 +1,335 @@
 /**
  * GitHub tool definitions and system prompt for the agent.
  *
- * Barrel that re-exports the 25 tool schemas across repos, pulls,
- * issues, actions, and search from their dedicated per-domain modules.
+ * Consolidated 4 domain-scoped tools (repos, pulls, issues, actions)
+ * with `action` parameter dispatch. Each tool covers one domain and
+ * documents which parameters each action uses.
  *
  * @module
  */
 
 import type { ToolDefinition } from "../../core/types/tool.ts";
 
-import {
-  buildCloneRepoDef,
-  buildCreateBranchDef,
-  buildDeleteBranchDef,
-  buildGetRepoDef,
-  buildListBranchesDef,
-  buildListCommitsDef,
-  buildListReposDef,
-  buildPullRepoDef,
-  buildReadFileDef,
-} from "./repos/mod.ts";
+// ── Repos ───────────────────────────────────────────────────────────
 
-import {
-  buildCreatePullDef,
-  buildGetPullDef,
-  buildListPullFilesDef,
-  buildListPullsDef,
-  buildMergePullDef,
-  buildReviewPullDef,
-  buildUpdatePullDef,
-} from "./pulls/mod.ts";
+function buildGitHubReposDef(): ToolDefinition {
+  return {
+    name: "github_repos",
+    description:
+      "Repository operations. Actions: list, get, read_file, list_commits, list_branches, create_branch, delete_branch, clone, pull.\n" +
+      "- list: list user repos. Params: page?, per_page?\n" +
+      "- get: get repo details. Params: repo (required)\n" +
+      "- read_file: read file contents (max 1MB). Params: repo (required), path (required), ref?\n" +
+      "- list_commits: list recent commits. Params: repo (required), sha?, per_page?\n" +
+      "- list_branches: list branches. Params: repo (required), per_page?\n" +
+      "- create_branch: create branch. Params: repo (required), branch (required), sha (required)\n" +
+      "- delete_branch: delete branch. Params: repo (required), branch (required)\n" +
+      "- clone: clone repo to local dir. Params: repo (required), path?, branch?, depth?\n" +
+      "- pull: pull latest changes. Params: repo (required), path (required), branch?",
+    parameters: {
+      action: {
+        type: "string",
+        description:
+          "The operation: list, get, read_file, list_commits, list_branches, create_branch, delete_branch, clone, pull",
+        required: true,
+      },
+      repo: {
+        type: "string",
+        description: 'Repository in "owner/name" format',
+        required: false,
+      },
+      path: {
+        type: "string",
+        description: "File path (read_file) or local directory (clone/pull)",
+        required: false,
+      },
+      ref: {
+        type: "string",
+        description: "Git ref — branch, tag, or SHA (read_file)",
+        required: false,
+      },
+      sha: {
+        type: "string",
+        description:
+          "Commit SHA for list_commits filtering or create_branch base",
+        required: false,
+      },
+      branch: {
+        type: "string",
+        description: "Branch name (create_branch, delete_branch, clone, pull)",
+        required: false,
+      },
+      depth: {
+        type: "number",
+        description: "Clone depth (clone)",
+        required: false,
+      },
+      page: {
+        type: "number",
+        description: "Page number for pagination (list)",
+        required: false,
+      },
+      per_page: {
+        type: "number",
+        description: "Results per page (list, list_commits, list_branches)",
+        required: false,
+      },
+    },
+  };
+}
 
-import {
-  buildAddCommentDef,
-  buildCreateIssueDef,
-  buildGetIssueDef,
-  buildListCommentsDef,
-  buildListIssuesDef,
-  buildUpdateIssueDef,
-} from "./issues/mod.ts";
+// ── Pulls ───────────────────────────────────────────────────────────
 
-import {
-  buildCancelRunDef,
-  buildListRunsDef,
-  buildSearchCodeDef,
-  buildSearchIssuesDef,
-  buildTriggerWorkflowDef,
-} from "./actions/mod.ts";
+function buildGitHubPullsDef(): ToolDefinition {
+  return {
+    name: "github_pulls",
+    description:
+      "Pull request operations. Actions: list, get, create, update, list_files, review, merge.\n" +
+      "- list: list PRs. Params: repo (required), state?, per_page?, sort?, direction?\n" +
+      "- get: get single PR. Params: repo (required), pr_number (required)\n" +
+      "- create: create PR. Params: repo (required), title (required), head (required), base (required), body?\n" +
+      "- update: update PR. Params: repo (required), pr_number (required), title?, body?, base?, state?\n" +
+      "- list_files: list changed files. Params: repo (required), pr_number (required), per_page?\n" +
+      "- review: submit review. Params: repo (required), pr_number (required), event (required: APPROVE|REQUEST_CHANGES|COMMENT), body (required)\n" +
+      "- merge: merge PR. Params: repo (required), pr_number (required), method?, commit_title?",
+    parameters: {
+      action: {
+        type: "string",
+        description:
+          "The operation: list, get, create, update, list_files, review, merge",
+        required: true,
+      },
+      repo: {
+        type: "string",
+        description: 'Repository in "owner/name" format',
+        required: false,
+      },
+      pr_number: {
+        type: "number",
+        description: "Pull request number",
+        required: false,
+      },
+      title: {
+        type: "string",
+        description: "PR title (create, update)",
+        required: false,
+      },
+      body: {
+        type: "string",
+        description: "PR body or review comment",
+        required: false,
+      },
+      head: {
+        type: "string",
+        description: "Source branch (create)",
+        required: false,
+      },
+      base: {
+        type: "string",
+        description: "Target branch (create, update)",
+        required: false,
+      },
+      state: {
+        type: "string",
+        description:
+          'Filter state: "open", "closed", "all" (list) or new state (update)',
+        required: false,
+      },
+      event: {
+        type: "string",
+        description:
+          "Review event: APPROVE, REQUEST_CHANGES, COMMENT (review)",
+        required: false,
+      },
+      method: {
+        type: "string",
+        description: 'Merge method: "merge", "squash", "rebase" (merge)',
+        required: false,
+      },
+      commit_title: {
+        type: "string",
+        description: "Custom merge commit title (merge)",
+        required: false,
+      },
+      sort: {
+        type: "string",
+        description:
+          'Sort by: "created", "updated", "popularity", "long-running" (list)',
+        required: false,
+      },
+      direction: {
+        type: "string",
+        description: 'Sort direction: "asc", "desc"',
+        required: false,
+      },
+      per_page: {
+        type: "number",
+        description: "Results per page",
+        required: false,
+      },
+    },
+  };
+}
 
-// ── Public API ──
+// ── Issues ──────────────────────────────────────────────────────────
 
-/** Get all 27 GitHub tool definitions. */
+function buildGitHubIssuesDef(): ToolDefinition {
+  return {
+    name: "github_issues",
+    description:
+      "Issue operations. Actions: list, get, create, update, list_comments, add_comment.\n" +
+      "- list: list issues. Params: repo (required), state?, labels?, per_page?, sort?, direction?\n" +
+      "- get: get single issue. Params: repo (required), number (required)\n" +
+      "- create: create issue. Params: repo (required), title (required), body?, labels?\n" +
+      "- update: update issue. Params: repo (required), number (required), title?, body?, state?, labels?, assignees?\n" +
+      "- list_comments: list comments. Params: repo (required), number (required), per_page?, direction?\n" +
+      "- add_comment: add comment. Params: repo (required), number (required), body (required)",
+    parameters: {
+      action: {
+        type: "string",
+        description:
+          "The operation: list, get, create, update, list_comments, add_comment",
+        required: true,
+      },
+      repo: {
+        type: "string",
+        description: 'Repository in "owner/name" format',
+        required: false,
+      },
+      number: {
+        type: "number",
+        description: "Issue or PR number",
+        required: false,
+      },
+      title: {
+        type: "string",
+        description: "Issue title (create, update)",
+        required: false,
+      },
+      body: {
+        type: "string",
+        description: "Issue body or comment text",
+        required: false,
+      },
+      state: {
+        type: "string",
+        description:
+          'Filter state: "open", "closed", "all" (list) or new state (update)',
+        required: false,
+      },
+      labels: {
+        type: "string",
+        description: "Comma-separated labels (list, create, update)",
+        required: false,
+      },
+      assignees: {
+        type: "string",
+        description: "Comma-separated assignees (update)",
+        required: false,
+      },
+      sort: {
+        type: "string",
+        description:
+          'Sort by: "created", "updated", "comments" (list)',
+        required: false,
+      },
+      direction: {
+        type: "string",
+        description: 'Sort direction: "asc", "desc"',
+        required: false,
+      },
+      per_page: {
+        type: "number",
+        description: "Results per page",
+        required: false,
+      },
+    },
+  };
+}
+
+// ── Actions & Search ────────────────────────────────────────────────
+
+function buildGitHubActionsDef(): ToolDefinition {
+  return {
+    name: "github_actions",
+    description:
+      "CI/CD and search operations. Actions: list_runs, cancel_run, trigger_workflow, search_code, search_issues.\n" +
+      "- list_runs: list workflow runs. Params: repo (required), workflow?, branch?, per_page?\n" +
+      "- cancel_run: cancel workflow run. Params: repo (required), run_id (required)\n" +
+      "- trigger_workflow: trigger workflow. Params: repo (required), workflow (required), ref (required), inputs?\n" +
+      "- search_code: search code. Params: query (required), per_page?\n" +
+      "- search_issues: search issues/PRs. Params: query (required), per_page?, sort?, order?",
+    parameters: {
+      action: {
+        type: "string",
+        description:
+          "The operation: list_runs, cancel_run, trigger_workflow, search_code, search_issues",
+        required: true,
+      },
+      repo: {
+        type: "string",
+        description: 'Repository in "owner/name" format',
+        required: false,
+      },
+      workflow: {
+        type: "string",
+        description: "Workflow filename or ID (list_runs, trigger_workflow)",
+        required: false,
+      },
+      branch: {
+        type: "string",
+        description: "Branch filter (list_runs)",
+        required: false,
+      },
+      ref: {
+        type: "string",
+        description: "Git ref for workflow dispatch (trigger_workflow)",
+        required: false,
+      },
+      run_id: {
+        type: "number",
+        description: "Workflow run ID (cancel_run)",
+        required: false,
+      },
+      inputs: {
+        type: "object",
+        description: "Workflow dispatch inputs (trigger_workflow)",
+        required: false,
+      },
+      query: {
+        type: "string",
+        description: "Search query (search_code, search_issues)",
+        required: false,
+      },
+      sort: {
+        type: "string",
+        description:
+          'Sort by: "comments", "reactions", "created", "updated" (search_issues)',
+        required: false,
+      },
+      order: {
+        type: "string",
+        description: 'Sort order: "asc", "desc" (search_issues)',
+        required: false,
+      },
+      per_page: {
+        type: "number",
+        description: "Results per page",
+        required: false,
+      },
+    },
+  };
+}
+
+// ── Public API ──────────────────────────────────────────────────────
+
+/** Get all 4 consolidated GitHub tool definitions. */
 export function getGitHubToolDefinitions(): readonly ToolDefinition[] {
   return [
-    buildListReposDef(),
-    buildGetRepoDef(),
-    buildReadFileDef(),
-    buildListCommitsDef(),
-    buildListBranchesDef(),
-    buildCreateBranchDef(),
-    buildDeleteBranchDef(),
-    buildCloneRepoDef(),
-    buildPullRepoDef(),
-    buildListPullsDef(),
-    buildGetPullDef(),
-    buildCreatePullDef(),
-    buildUpdatePullDef(),
-    buildListPullFilesDef(),
-    buildReviewPullDef(),
-    buildMergePullDef(),
-    buildListIssuesDef(),
-    buildGetIssueDef(),
-    buildCreateIssueDef(),
-    buildUpdateIssueDef(),
-    buildListCommentsDef(),
-    buildAddCommentDef(),
-    buildListRunsDef(),
-    buildCancelRunDef(),
-    buildTriggerWorkflowDef(),
-    buildSearchCodeDef(),
-    buildSearchIssuesDef(),
+    buildGitHubReposDef(),
+    buildGitHubPullsDef(),
+    buildGitHubIssuesDef(),
+    buildGitHubActionsDef(),
   ];
 }
 
@@ -89,4 +339,10 @@ export const GITHUB_TOOLS_SYSTEM_PROMPT = `## GitHub Access
 GitHub authentication is already configured. Do NOT use secret_save for GitHub — call the github_* tools directly.
 The \`repo\` parameter uses "owner/name" format (e.g. "octocat/Hello-World").
 Repository visibility determines classification: public→PUBLIC, private→CONFIDENTIAL, internal→INTERNAL.
-Accessing private repos escalates session taint. Never narrate intent — just call the tools directly.`;
+Accessing private repos escalates session taint. Never narrate intent — just call the tools directly.
+
+Available tools:
+- \`github_repos\`: action = list | get | read_file | list_commits | list_branches | create_branch | delete_branch | clone | pull
+- \`github_pulls\`: action = list | get | create | update | list_files | review | merge
+- \`github_issues\`: action = list | get | create | update | list_comments | add_comment
+- \`github_actions\`: action = list_runs | cancel_run | trigger_workflow | search_code | search_issues`;

--- a/src/integrations/google/tools.ts
+++ b/src/integrations/google/tools.ts
@@ -1,9 +1,9 @@
 /**
  * Google Workspace tool executor.
  *
- * Creates a chain-compatible executor for the 14 Google Workspace tools.
- * Tool definitions live in `tools_defs.ts`; per-domain execution logic
- * lives in `tools_exec_*.ts` modules.
+ * Creates a chain-compatible executor for the 5 consolidated Google
+ * Workspace tools. Each tool dispatches on the `action` parameter
+ * to the per-service executor module.
  *
  * @module
  */
@@ -42,28 +42,57 @@ export {
   GOOGLE_TOOLS_SYSTEM_PROMPT,
 } from "./tools_defs.ts";
 
-// ─── Dispatch table ─────────────────────────────────────────────────────────
+// ─── Action dispatch tables ─────────────────────────────────────────────────
 
-/** Map tool name to a per-domain executor function. */
-function buildDispatchTable(
+type ActionHandler = (input: Record<string, unknown>) => Promise<string>;
+
+function buildGmailDispatch(
   ctx: GoogleToolContext,
-): ReadonlyMap<string, (input: Record<string, unknown>) => Promise<string>> {
-  return new Map<string, (input: Record<string, unknown>) => Promise<string>>([
-    ["gmail_search", (input) => executeGmailSearch(ctx.gmail, input)],
-    ["gmail_read", (input) => executeGmailRead(ctx.gmail, input)],
-    ["gmail_send", (input) => executeGmailSend(ctx.gmail, input)],
-    ["gmail_label", (input) => executeGmailLabel(ctx.gmail, input)],
-    ["calendar_list", (input) => executeCalendarList(ctx.calendar, input)],
-    ["calendar_create", (input) => executeCalendarCreate(ctx.calendar, input)],
-    ["calendar_update", (input) => executeCalendarUpdate(ctx.calendar, input)],
-    ["tasks_list", (input) => executeTasksList(ctx.tasks, input)],
-    ["tasks_create", (input) => executeTasksCreate(ctx.tasks, input)],
-    ["tasks_complete", (input) => executeTasksComplete(ctx.tasks, input)],
-    ["drive_search", (input) => executeDriveSearch(ctx.drive, input)],
-    ["drive_read", (input) => executeDriveRead(ctx.drive, input)],
-    ["sheets_read", (input) => executeSheetsRead(ctx.sheets, input)],
-    ["sheets_write", (input) => executeSheetsWrite(ctx.sheets, input)],
-  ]);
+): Readonly<Record<string, ActionHandler>> {
+  return {
+    search: (input) => executeGmailSearch(ctx.gmail, input),
+    read: (input) => executeGmailRead(ctx.gmail, input),
+    send: (input) => executeGmailSend(ctx.gmail, input),
+    label: (input) => executeGmailLabel(ctx.gmail, input),
+  };
+}
+
+function buildCalendarDispatch(
+  ctx: GoogleToolContext,
+): Readonly<Record<string, ActionHandler>> {
+  return {
+    list: (input) => executeCalendarList(ctx.calendar, input),
+    create: (input) => executeCalendarCreate(ctx.calendar, input),
+    update: (input) => executeCalendarUpdate(ctx.calendar, input),
+  };
+}
+
+function buildTasksDispatch(
+  ctx: GoogleToolContext,
+): Readonly<Record<string, ActionHandler>> {
+  return {
+    list: (input) => executeTasksList(ctx.tasks, input),
+    create: (input) => executeTasksCreate(ctx.tasks, input),
+    complete: (input) => executeTasksComplete(ctx.tasks, input),
+  };
+}
+
+function buildDriveDispatch(
+  ctx: GoogleToolContext,
+): Readonly<Record<string, ActionHandler>> {
+  return {
+    search: (input) => executeDriveSearch(ctx.drive, input),
+    read: (input) => executeDriveRead(ctx.drive, input),
+  };
+}
+
+function buildSheetsDispatch(
+  ctx: GoogleToolContext,
+): Readonly<Record<string, ActionHandler>> {
+  return {
+    read: (input) => executeSheetsRead(ctx.sheets, input),
+    write: (input) => executeSheetsWrite(ctx.sheets, input),
+  };
 }
 
 // ─── Executor ───────────────────────────────────────────────────────────────
@@ -79,15 +108,35 @@ function buildDispatchTable(
 export function createGoogleToolExecutor(
   ctx: GoogleToolContext,
 ): (name: string, input: Record<string, unknown>) => Promise<string | null> {
-  const dispatch = buildDispatchTable(ctx);
+  const dispatchers: Readonly<
+    Record<string, Readonly<Record<string, ActionHandler>>>
+  > = {
+    google_gmail: buildGmailDispatch(ctx),
+    google_calendar: buildCalendarDispatch(ctx),
+    google_tasks: buildTasksDispatch(ctx),
+    google_drive: buildDriveDispatch(ctx),
+    google_sheets: buildSheetsDispatch(ctx),
+  };
 
   // deno-lint-ignore require-await
   return async (
     name: string,
     input: Record<string, unknown>,
   ): Promise<string | null> => {
-    const handler = dispatch.get(name);
-    if (!handler) return null;
+    const actionMap = dispatchers[name];
+    if (!actionMap) return null;
+
+    const action = input.action;
+    if (typeof action !== "string" || action.length === 0) {
+      return `Error: ${name} requires an 'action' parameter (string).`;
+    }
+
+    const handler = actionMap[action];
+    if (!handler) {
+      const valid = Object.keys(actionMap).join(", ");
+      return `Error: unknown action "${action}" for ${name}. Valid actions: ${valid}`;
+    }
+
     return handler(input);
   };
 }

--- a/src/integrations/google/tools_defs.ts
+++ b/src/integrations/google/tools_defs.ts
@@ -1,62 +1,299 @@
 /**
  * Google Workspace tool definitions and system prompt.
  *
- * Barrel that re-exports the 14 tool schemas across Gmail, Calendar,
- * Tasks, Drive, and Sheets from their dedicated per-service modules.
+ * Consolidated 5 service-scoped tools (gmail, calendar, tasks, drive, sheets)
+ * with `action` parameter dispatch.
  *
  * @module
  */
 
 import type { ToolDefinition } from "../../core/types/tool.ts";
 
-import {
-  buildGmailLabelDef,
-  buildGmailReadDef,
-  buildGmailSearchDef,
-  buildGmailSendDef,
-} from "./gmail/tools_defs_gmail.ts";
+// ── Gmail ───────────────────────────────────────────────────────────
 
-import {
-  buildCalendarCreateDef,
-  buildCalendarListDef,
-  buildCalendarUpdateDef,
-} from "./calendar/tools_defs_calendar.ts";
+function buildGoogleGmailDef(): ToolDefinition {
+  return {
+    name: "google_gmail",
+    description:
+      "Gmail operations. Actions: search, read, send, label.\n" +
+      "- search: find emails. Params: query (required), max_results?\n" +
+      "- read: read full email. Params: message_id (required)\n" +
+      "- send: send email. Params: to (required), subject (required), body (required), cc?, bcc?\n" +
+      "- label: modify labels. Params: message_id (required), add_labels?, remove_labels?",
+    parameters: {
+      action: {
+        type: "string",
+        description: "The operation: search, read, send, label",
+        required: true,
+      },
+      query: {
+        type: "string",
+        description:
+          "Gmail search query, same syntax as Gmail search box (search)",
+        required: false,
+      },
+      message_id: {
+        type: "string",
+        description: "Gmail message ID (read, label)",
+        required: false,
+      },
+      to: {
+        type: "string",
+        description: "Recipient email address (send)",
+        required: false,
+      },
+      subject: {
+        type: "string",
+        description: "Email subject line (send)",
+        required: false,
+      },
+      body: {
+        type: "string",
+        description: "Email body text (send)",
+        required: false,
+      },
+      cc: {
+        type: "string",
+        description: "CC recipients, comma-separated (send)",
+        required: false,
+      },
+      bcc: {
+        type: "string",
+        description: "BCC recipients, comma-separated (send)",
+        required: false,
+      },
+      add_labels: {
+        type: "string",
+        description:
+          "Comma-separated label IDs to add, e.g. 'STARRED,IMPORTANT' (label)",
+        required: false,
+      },
+      remove_labels: {
+        type: "string",
+        description:
+          "Comma-separated label IDs to remove, e.g. 'UNREAD,INBOX' (label)",
+        required: false,
+      },
+      max_results: {
+        type: "number",
+        description: "Maximum results to return (search, default: 10)",
+        required: false,
+      },
+    },
+  };
+}
 
-import {
-  buildTasksCompleteDef,
-  buildTasksCreateDef,
-  buildTasksListDef,
-} from "./tasks/tools_defs_tasks.ts";
+// ── Calendar ────────────────────────────────────────────────────────
 
-import {
-  buildDriveReadDef,
-  buildDriveSearchDef,
-} from "./drive/tools_defs_drive.ts";
+function buildGoogleCalendarDef(): ToolDefinition {
+  return {
+    name: "google_calendar",
+    description:
+      "Calendar operations. Actions: list, create, update.\n" +
+      "- list: list upcoming events. Params: time_min?, time_max?, max_results?, calendar_id?\n" +
+      "- create: create event. Params: summary (required), start (required), end (required), description?, location?, attendees?, calendar_id?\n" +
+      "- update: update event. Params: event_id (required), summary?, start?, end?, description?, location?, attendees?, calendar_id?",
+    parameters: {
+      action: {
+        type: "string",
+        description: "The operation: list, create, update",
+        required: true,
+      },
+      event_id: {
+        type: "string",
+        description: "Event ID to update (update)",
+        required: false,
+      },
+      summary: {
+        type: "string",
+        description: "Event title/summary (create, update)",
+        required: false,
+      },
+      start: {
+        type: "string",
+        description: "Start time ISO 8601 (list: time_min, create, update)",
+        required: false,
+      },
+      end: {
+        type: "string",
+        description: "End time ISO 8601 (list: time_max, create, update)",
+        required: false,
+      },
+      time_min: {
+        type: "string",
+        description: "Start of time range ISO 8601 (list, defaults to now)",
+        required: false,
+      },
+      time_max: {
+        type: "string",
+        description:
+          "End of time range ISO 8601 (list, defaults to 7 days from now)",
+        required: false,
+      },
+      description: {
+        type: "string",
+        description: "Event description/notes (create, update)",
+        required: false,
+      },
+      location: {
+        type: "string",
+        description: "Event location (create, update)",
+        required: false,
+      },
+      attendees: {
+        type: "string",
+        description: "Comma-separated email addresses (create, update)",
+        required: false,
+      },
+      calendar_id: {
+        type: "string",
+        description: "Calendar ID (default: 'primary')",
+        required: false,
+      },
+      max_results: {
+        type: "number",
+        description: "Maximum events to return (list, default: 10)",
+        required: false,
+      },
+    },
+  };
+}
 
-import {
-  buildSheetsReadDef,
-  buildSheetsWriteDef,
-} from "./sheets/tools_defs_sheets.ts";
+// ── Tasks ───────────────────────────────────────────────────────────
 
-// ── Public API ──
+function buildGoogleTasksDef(): ToolDefinition {
+  return {
+    name: "google_tasks",
+    description:
+      "Task operations. Actions: list, create, complete.\n" +
+      "- list: list tasks. Params: task_list_id?, show_completed?, max_results?\n" +
+      "- create: create task. Params: title (required), notes?, due?, task_list_id?\n" +
+      "- complete: complete task. Params: task_id (required), task_list_id?",
+    parameters: {
+      action: {
+        type: "string",
+        description: "The operation: list, create, complete",
+        required: true,
+      },
+      task_id: {
+        type: "string",
+        description: "Task ID to complete (complete)",
+        required: false,
+      },
+      title: {
+        type: "string",
+        description: "Task title (create)",
+        required: false,
+      },
+      notes: {
+        type: "string",
+        description: "Task notes/description (create)",
+        required: false,
+      },
+      due: {
+        type: "string",
+        description: "Due date ISO 8601 (create)",
+        required: false,
+      },
+      task_list_id: {
+        type: "string",
+        description: "Task list ID (default: '@default')",
+        required: false,
+      },
+      show_completed: {
+        type: "boolean",
+        description: "Include completed tasks (list, default: true)",
+        required: false,
+      },
+      max_results: {
+        type: "number",
+        description: "Maximum tasks to return (list, default: 20)",
+        required: false,
+      },
+    },
+  };
+}
 
-/** Get all 14 Google Workspace tool definitions. */
+// ── Drive ───────────────────────────────────────────────────────────
+
+function buildGoogleDriveDef(): ToolDefinition {
+  return {
+    name: "google_drive",
+    description:
+      "Drive operations. Actions: search, read.\n" +
+      "- search: search for files. Params: query (required), max_results?\n" +
+      "- read: read file content. Params: file_id (required)",
+    parameters: {
+      action: {
+        type: "string",
+        description: "The operation: search, read",
+        required: true,
+      },
+      query: {
+        type: "string",
+        description:
+          "Drive search query, e.g. \"name contains 'report'\" (search)",
+        required: false,
+      },
+      file_id: {
+        type: "string",
+        description: "Drive file ID from search results (read)",
+        required: false,
+      },
+      max_results: {
+        type: "number",
+        description: "Maximum files to return (search, default: 10)",
+        required: false,
+      },
+    },
+  };
+}
+
+// ── Sheets ──────────────────────────────────────────────────────────
+
+function buildGoogleSheetsDef(): ToolDefinition {
+  return {
+    name: "google_sheets",
+    description:
+      "Sheets operations. Actions: read, write.\n" +
+      "- read: read cell range. Params: spreadsheet_id (required), range (required)\n" +
+      "- write: write cell range. Params: spreadsheet_id (required), range (required), values (required)",
+    parameters: {
+      action: {
+        type: "string",
+        description: "The operation: read, write",
+        required: true,
+      },
+      spreadsheet_id: {
+        type: "string",
+        description: "Spreadsheet ID from URL or drive_search",
+        required: false,
+      },
+      range: {
+        type: "string",
+        description: "Cell range in A1 notation, e.g. 'Sheet1!A1:D10'",
+        required: false,
+      },
+      values: {
+        type: "string",
+        description:
+          'JSON-encoded 2D array of values, e.g. \'[["Name","Age"],["Alice","30"]]\' (write)',
+        required: false,
+      },
+    },
+  };
+}
+
+// ── Public API ──────────────────────────────────────────────────────
+
+/** Get all 5 consolidated Google Workspace tool definitions. */
 export function getGoogleToolDefinitions(): readonly ToolDefinition[] {
   return [
-    buildGmailSearchDef(),
-    buildGmailReadDef(),
-    buildGmailSendDef(),
-    buildGmailLabelDef(),
-    buildCalendarListDef(),
-    buildCalendarCreateDef(),
-    buildCalendarUpdateDef(),
-    buildTasksListDef(),
-    buildTasksCreateDef(),
-    buildTasksCompleteDef(),
-    buildDriveSearchDef(),
-    buildDriveReadDef(),
-    buildSheetsReadDef(),
-    buildSheetsWriteDef(),
+    buildGoogleGmailDef(),
+    buildGoogleCalendarDef(),
+    buildGoogleTasksDef(),
+    buildGoogleDriveDef(),
+    buildGoogleSheetsDef(),
   ];
 }
 
@@ -65,9 +302,11 @@ export const GOOGLE_TOOLS_SYSTEM_PROMPT = `## Google Workspace
 
 You have access to Google Workspace tools for Gmail, Calendar, Tasks, Drive, and Sheets.
 
-- Use gmail_search to find emails, then gmail_read for full content. Use gmail_send to compose and send.
-- Use calendar_list to see upcoming events. Use calendar_create and calendar_update to manage the schedule.
-- Use tasks_list, tasks_create, and tasks_complete for task management.
-- Use drive_search to find files, then drive_read for content. For spreadsheets, prefer sheets_read/sheets_write.
-- When the user asks about their schedule, emails, or documents, use these tools directly — never narrate intent.
-- All Google data is classified at least INTERNAL. Do not share Google data on PUBLIC channels.`;
+- \`google_gmail\`: action = search | read | send | label
+- \`google_calendar\`: action = list | create | update
+- \`google_tasks\`: action = list | create | complete
+- \`google_drive\`: action = search | read — for spreadsheets, prefer google_sheets
+- \`google_sheets\`: action = read | write
+
+When the user asks about their schedule, emails, or documents, use these tools directly — never narrate intent.
+All Google data is classified at least INTERNAL. Do not share Google data on PUBLIC channels.`;

--- a/tests/agent/plan_blocking_test.ts
+++ b/tests/agent/plan_blocking_test.ts
@@ -148,7 +148,7 @@ Deno.test("Blocking: write_file is blocked in plan mode", async () => {
   // LLM response 1: enter plan mode, then try to write
   const responses = [
     // First call: LLM enters plan mode
-    toolResponse({ name: "plan_enter", args: { goal: "Build feature" } }),
+    toolResponse({ name: "plan_manage", args: { action: "enter", goal: "Build feature" } }),
     // Second call: LLM tries to write a file (should be blocked)
     toolResponse({
       name: "write_file",
@@ -189,7 +189,7 @@ Deno.test("Blocking: read_file is allowed in plan mode", async () => {
 
   const responses = [
     // Enter plan mode then read a file
-    toolResponse({ name: "plan_enter", args: { goal: "Explore codebase" } }),
+    toolResponse({ name: "plan_manage", args: { action: "enter", goal: "Explore codebase" } }),
     // Read a file (should be allowed)
     toolResponse({ name: "read_file", args: { path: "/tmp/test.txt" } }),
     // Final response
@@ -241,9 +241,9 @@ Deno.test("Blocking: tools unblocked after plan_exit", async () => {
 
   const responses = [
     // Enter plan mode
-    toolResponse({ name: "plan_enter", args: { goal: "Build" } }),
+    toolResponse({ name: "plan_manage", args: { action: "enter", goal: "Build" } }),
     // Exit plan mode with plan
-    toolResponse({ name: "plan_exit", args: { plan: JSON.parse(planJson) } }),
+    toolResponse({ name: "plan_manage", args: { action: "exit", plan: JSON.parse(planJson) } }),
     // Now in awaiting_approval — write should be allowed
     toolResponse({
       name: "write_file",
@@ -279,7 +279,7 @@ Deno.test("Blocking: plan_enter itself is never blocked", async () => {
   const pm = createPlanManager({ plansDir: `${tmpDir}/plans` });
 
   const responses = [
-    toolResponse({ name: "plan_enter", args: { goal: "Build" } }),
+    toolResponse({ name: "plan_manage", args: { action: "enter", goal: "Build" } }),
     textResponse("In plan mode now."),
   ];
 
@@ -294,13 +294,13 @@ Deno.test("Blocking: plan_enter itself is never blocked", async () => {
     targetClassification: "INTERNAL",
   });
 
-  const enterResult = toolResults.find((r) => r.name === "plan_enter");
+  const enterResult = toolResults.find((r) => r.name === "plan_manage");
   assert(enterResult !== undefined);
   assertEquals(enterResult!.blocked, false);
   assertStringIncludes(enterResult!.result, "entered");
 });
 
-Deno.test("Blocking: cron_create blocked in plan mode", async () => {
+Deno.test("Blocking: cron create action blocked in plan mode", async () => {
   const tmpDir = Deno.makeTempDirSync();
   const pm = createPlanManager({ plansDir: `${tmpDir}/plans` });
 
@@ -309,8 +309,8 @@ Deno.test("Blocking: cron_create blocked in plan mode", async () => {
 
   const responses: readonly MockResponse[] = [
     toolResponse({
-      name: "cron_create",
-      args: { expression: "0 * * * *", task: "test" },
+      name: "cron",
+      args: { action: "create", expression: "0 * * * *", task: "test" },
     }),
     textResponse("Blocked, I see."),
   ];
@@ -351,11 +351,12 @@ Deno.test("Blocking: cron_create blocked in plan mode", async () => {
     tools: [
       ...getPlanToolDefinitions(),
       {
-        name: "cron_create",
-        description: "Create cron",
+        name: "cron",
+        description: "Cron management",
         parameters: {
-          expression: { type: "string", description: "Expr", required: true },
-          task: { type: "string", description: "Task", required: true },
+          action: { type: "string", description: "Action", required: true },
+          expression: { type: "string", description: "Expr", required: false },
+          task: { type: "string", description: "Task", required: false },
         },
       },
     ],
@@ -375,9 +376,9 @@ Deno.test("Blocking: cron_create blocked in plan mode", async () => {
     targetClassification: "INTERNAL",
   });
 
-  const cronResult = toolResults.find((r) => r.name === "cron_create");
+  const cronResult = toolResults.find((r) => r.name === "cron");
   assert(cronResult !== undefined);
-  assert(cronResult!.blocked, "cron_create should be blocked in plan mode");
+  assert(cronResult!.blocked, "cron create action should be blocked in plan mode");
 });
 
 // Helper to avoid unused variable lint

--- a/tests/agent/plan_mode_test.ts
+++ b/tests/agent/plan_mode_test.ts
@@ -153,8 +153,8 @@ Deno.test("PlanManager: isToolBlocked true for write_file in plan mode", () => {
   mgr.enter(TEST_SESSION, "Goal");
 
   assert(mgr.isToolBlocked(TEST_SESSION, "write_file"));
-  assert(mgr.isToolBlocked(TEST_SESSION, "cron_create"));
-  assert(mgr.isToolBlocked(TEST_SESSION, "cron_delete"));
+  assert(mgr.isToolBlocked(TEST_SESSION, "cron", { action: "create" }));
+  assert(mgr.isToolBlocked(TEST_SESSION, "cron", { action: "delete" }));
 });
 
 Deno.test("PlanManager: isToolBlocked false for read tools in plan mode", () => {
@@ -170,7 +170,7 @@ Deno.test("PlanManager: isToolBlocked false for read tools in plan mode", () => 
 Deno.test("PlanManager: isToolBlocked false in normal mode", () => {
   const mgr = createTestManager();
   assertEquals(mgr.isToolBlocked(TEST_SESSION, "write_file"), false);
-  assertEquals(mgr.isToolBlocked(TEST_SESSION, "cron_create"), false);
+  assertEquals(mgr.isToolBlocked(TEST_SESSION, "cron", { action: "create" }), false);
 });
 
 Deno.test("PlanManager: isToolBlocked false in awaiting_approval mode", async () => {

--- a/tests/agent/plan_tools_test.ts
+++ b/tests/agent/plan_tools_test.ts
@@ -46,11 +46,14 @@ const VALID_PLAN = {
   estimated_complexity: "small",
 };
 
-// --- plan_enter ---
+// --- plan_manage(action: "enter") ---
 
-Deno.test("plan_enter: returns status and blocked tools", async () => {
+Deno.test("plan_manage enter: returns status and blocked tools", async () => {
   const { exec } = createTestSetup();
-  const result = await exec("plan_enter", { goal: "Build auth" });
+  const result = await exec("plan_manage", {
+    action: "enter",
+    goal: "Build auth",
+  });
   assert(result !== null);
   const parsed = JSON.parse(result!);
   assertEquals(parsed.status, "entered");
@@ -58,81 +61,94 @@ Deno.test("plan_enter: returns status and blocked tools", async () => {
   assert(Array.isArray(parsed.blocked_tools));
 });
 
-Deno.test("plan_enter: with scope", async () => {
+Deno.test("plan_manage enter: with scope", async () => {
   const { exec, manager } = createTestSetup();
-  await exec("plan_enter", { goal: "Refactor", scope: "src/core/" });
+  await exec("plan_manage", {
+    action: "enter",
+    goal: "Refactor",
+    scope: "src/core/",
+  });
   assertEquals(manager.getState(SESSION).scope, "src/core/");
 });
 
-Deno.test("plan_enter: rejects missing goal", async () => {
+Deno.test("plan_manage enter: rejects missing goal", async () => {
   const { exec } = createTestSetup();
-  const result = await exec("plan_enter", {});
+  const result = await exec("plan_manage", { action: "enter" });
   assert(result !== null);
   assertStringIncludes(result!, "Error");
 });
 
-Deno.test("plan_enter: rejects when already in plan mode", async () => {
+Deno.test("plan_manage enter: rejects when already in plan mode", async () => {
   const { exec } = createTestSetup();
-  await exec("plan_enter", { goal: "First" });
-  const result = await exec("plan_enter", { goal: "Second" });
+  await exec("plan_manage", { action: "enter", goal: "First" });
+  const result = await exec("plan_manage", { action: "enter", goal: "Second" });
   assert(result !== null);
   assertStringIncludes(result!, "Already in plan mode");
 });
 
-// --- plan_exit ---
+// --- plan_manage(action: "exit") ---
 
-Deno.test("plan_exit: creates plan and returns markdown", async () => {
+Deno.test("plan_manage exit: creates plan and returns markdown", async () => {
   const { exec } = createTestSetup();
-  await exec("plan_enter", { goal: "Build auth" });
-  const result = await exec("plan_exit", { plan: VALID_PLAN });
+  await exec("plan_manage", { action: "enter", goal: "Build auth" });
+  const result = await exec("plan_manage", {
+    action: "exit",
+    plan: VALID_PLAN,
+  });
   assert(result !== null);
   assertStringIncludes(result!, "plan_presented");
   assertStringIncludes(result!, "Implementation Plan");
   assertStringIncludes(result!, "Add auth");
 });
 
-Deno.test("plan_exit: rejects missing plan object", async () => {
+Deno.test("plan_manage exit: rejects missing plan object", async () => {
   const { exec } = createTestSetup();
-  await exec("plan_enter", { goal: "Build auth" });
-  const result = await exec("plan_exit", {});
+  await exec("plan_manage", { action: "enter", goal: "Build auth" });
+  const result = await exec("plan_manage", { action: "exit" });
   assert(result !== null);
   assertStringIncludes(result!, "Error");
 });
 
-Deno.test("plan_exit: validates required plan fields", async () => {
+Deno.test("plan_manage exit: validates required plan fields", async () => {
   const { exec } = createTestSetup();
-  await exec("plan_enter", { goal: "Build auth" });
+  await exec("plan_manage", { action: "enter", goal: "Build auth" });
 
   // Missing summary
-  const result = await exec("plan_exit", {
+  const result = await exec("plan_manage", {
+    action: "exit",
     plan: { approach: "x", steps: [{ id: 1, description: "x" }] },
   });
   assert(result !== null);
   assertStringIncludes(result!, "summary");
 });
 
-Deno.test("plan_exit: validates steps are non-empty", async () => {
+Deno.test("plan_manage exit: validates steps are non-empty", async () => {
   const { exec } = createTestSetup();
-  await exec("plan_enter", { goal: "Build auth" });
-  const result = await exec("plan_exit", {
+  await exec("plan_manage", { action: "enter", goal: "Build auth" });
+  const result = await exec("plan_manage", {
+    action: "exit",
     plan: { summary: "x", approach: "y", steps: [] },
   });
   assert(result !== null);
   assertStringIncludes(result!, "steps");
 });
 
-Deno.test("plan_exit: rejects when not in plan mode", async () => {
+Deno.test("plan_manage exit: rejects when not in plan mode", async () => {
   const { exec } = createTestSetup();
-  const result = await exec("plan_exit", { plan: VALID_PLAN });
+  const result = await exec("plan_manage", {
+    action: "exit",
+    plan: VALID_PLAN,
+  });
   assert(result !== null);
   assertStringIncludes(result!, "Error");
   assertStringIncludes(result!, "Not in plan mode");
 });
 
-Deno.test("plan_exit: defaults missing optional fields", async () => {
+Deno.test("plan_manage exit: defaults missing optional fields", async () => {
   const { exec, manager } = createTestSetup();
-  await exec("plan_enter", { goal: "Build" });
-  await exec("plan_exit", {
+  await exec("plan_manage", { action: "enter", goal: "Build" });
+  await exec("plan_manage", {
+    action: "exit",
     plan: {
       summary: "Minimal plan",
       approach: "Direct",
@@ -154,7 +170,7 @@ Deno.test("plan_exit: defaults missing optional fields", async () => {
 
 Deno.test("plan_status: shows mode and goal", async () => {
   const { exec } = createTestSetup();
-  await exec("plan_enter", { goal: "Build auth" });
+  await exec("plan_manage", { action: "enter", goal: "Build auth" });
   const result = await exec("plan_status", {});
   assert(result !== null);
   const parsed = JSON.parse(result!);
@@ -162,14 +178,14 @@ Deno.test("plan_status: shows mode and goal", async () => {
   assertEquals(parsed.goal, "Build auth");
 });
 
-// --- plan_approve ---
+// --- plan_manage(action: "approve") ---
 
-Deno.test("plan_approve: transitions to normal with active plan", async () => {
+Deno.test("plan_manage approve: transitions to normal with active plan", async () => {
   const { exec, manager } = createTestSetup();
-  await exec("plan_enter", { goal: "Build" });
-  await exec("plan_exit", { plan: VALID_PLAN });
+  await exec("plan_manage", { action: "enter", goal: "Build" });
+  await exec("plan_manage", { action: "exit", plan: VALID_PLAN });
 
-  const result = await exec("plan_approve", {});
+  const result = await exec("plan_manage", { action: "approve" });
   assert(result !== null);
   const parsed = JSON.parse(result!);
   assertEquals(parsed.status, "approved");
@@ -179,20 +195,20 @@ Deno.test("plan_approve: transitions to normal with active plan", async () => {
   assert(manager.getState(SESSION).activePlan !== undefined);
 });
 
-Deno.test("plan_approve: with no pending plan returns error", async () => {
+Deno.test("plan_manage approve: with no pending plan returns error", async () => {
   const { exec } = createTestSetup();
-  const result = await exec("plan_approve", {});
+  const result = await exec("plan_manage", { action: "approve" });
   assert(result !== null);
   assertStringIncludes(result!, "No plan awaiting approval");
 });
 
-// --- plan_reject ---
+// --- plan_manage(action: "reject") ---
 
-Deno.test("plan_reject: transitions to normal", async () => {
+Deno.test("plan_manage reject: transitions to normal", async () => {
   const { exec, manager } = createTestSetup();
-  await exec("plan_enter", { goal: "Build" });
-  await exec("plan_exit", { plan: VALID_PLAN });
-  const result = await exec("plan_reject", {});
+  await exec("plan_manage", { action: "enter", goal: "Build" });
+  await exec("plan_manage", { action: "exit", plan: VALID_PLAN });
+  const result = await exec("plan_manage", { action: "reject" });
   assert(result !== null);
   const parsed = JSON.parse(result!);
   assertEquals(parsed.status, "rejected");
@@ -203,9 +219,9 @@ Deno.test("plan_reject: transitions to normal", async () => {
 
 Deno.test("plan_step_complete: marks step and advances", async () => {
   const { exec } = createTestSetup();
-  await exec("plan_enter", { goal: "Build" });
-  await exec("plan_exit", { plan: VALID_PLAN });
-  await exec("plan_approve", {});
+  await exec("plan_manage", { action: "enter", goal: "Build" });
+  await exec("plan_manage", { action: "exit", plan: VALID_PLAN });
+  await exec("plan_manage", { action: "approve" });
 
   const result = await exec("plan_step_complete", {
     step_id: 1,
@@ -219,24 +235,27 @@ Deno.test("plan_step_complete: marks step and advances", async () => {
 
 Deno.test("plan_step_complete: rejects missing args", async () => {
   const { exec } = createTestSetup();
-  await exec("plan_enter", { goal: "Build" });
-  await exec("plan_exit", { plan: VALID_PLAN });
-  await exec("plan_approve", {});
+  await exec("plan_manage", { action: "enter", goal: "Build" });
+  await exec("plan_manage", { action: "exit", plan: VALID_PLAN });
+  await exec("plan_manage", { action: "approve" });
 
-  const result = await exec("plan_step_complete", { step_id: "not a number" });
+  const result = await exec("plan_step_complete", {
+    step_id: "not a number",
+  });
   assert(result !== null);
   assertStringIncludes(result!, "Error");
 });
 
-// --- plan_complete ---
+// --- plan_manage(action: "complete") ---
 
-Deno.test("plan_complete: marks plan done", async () => {
+Deno.test("plan_manage complete: marks plan done", async () => {
   const { exec, manager } = createTestSetup();
-  await exec("plan_enter", { goal: "Build" });
-  await exec("plan_exit", { plan: VALID_PLAN });
-  await exec("plan_approve", {});
+  await exec("plan_manage", { action: "enter", goal: "Build" });
+  await exec("plan_manage", { action: "exit", plan: VALID_PLAN });
+  await exec("plan_manage", { action: "approve" });
 
-  const result = await exec("plan_complete", {
+  const result = await exec("plan_manage", {
+    action: "complete",
     summary: "Auth module complete",
   });
   assert(result !== null);
@@ -247,22 +266,23 @@ Deno.test("plan_complete: marks plan done", async () => {
   assertEquals(manager.getState(SESSION).activePlan, undefined);
 });
 
-Deno.test("plan_complete: rejects missing summary", async () => {
+Deno.test("plan_manage complete: rejects missing summary", async () => {
   const { exec } = createTestSetup();
-  const result = await exec("plan_complete", {});
+  const result = await exec("plan_manage", { action: "complete" });
   assert(result !== null);
   assertStringIncludes(result!, "Error");
 });
 
-// --- plan_modify ---
+// --- plan_manage(action: "modify") ---
 
-Deno.test("plan_modify: updates step", async () => {
+Deno.test("plan_manage modify: updates step", async () => {
   const { exec, manager } = createTestSetup();
-  await exec("plan_enter", { goal: "Build" });
-  await exec("plan_exit", { plan: VALID_PLAN });
-  await exec("plan_approve", {});
+  await exec("plan_manage", { action: "enter", goal: "Build" });
+  await exec("plan_manage", { action: "exit", plan: VALID_PLAN });
+  await exec("plan_manage", { action: "approve" });
 
-  const result = await exec("plan_modify", {
+  const result = await exec("plan_manage", {
+    action: "modify",
     step_id: 1,
     reason: "Better approach",
     new_description: "Create auth_v2 module",
@@ -277,11 +297,32 @@ Deno.test("plan_modify: updates step", async () => {
   assertEquals(step!.description, "Create auth_v2 module");
 });
 
-Deno.test("plan_modify: rejects missing required args", async () => {
+Deno.test("plan_manage modify: rejects missing required args", async () => {
   const { exec } = createTestSetup();
-  const result = await exec("plan_modify", { step_id: 1 });
+  const result = await exec("plan_manage", {
+    action: "modify",
+    step_id: 1,
+  });
   assert(result !== null);
   assertStringIncludes(result!, "Error");
+});
+
+// --- plan_manage: action validation ---
+
+Deno.test("plan_manage: rejects missing action", async () => {
+  const { exec } = createTestSetup();
+  const result = await exec("plan_manage", {});
+  assert(result !== null);
+  assertStringIncludes(result!, "Error");
+  assertStringIncludes(result!, "action");
+});
+
+Deno.test("plan_manage: rejects unknown action", async () => {
+  const { exec } = createTestSetup();
+  const result = await exec("plan_manage", { action: "frobnicate" });
+  assert(result !== null);
+  assertStringIncludes(result!, "Error");
+  assertStringIncludes(result!, "frobnicate");
 });
 
 // --- Non-plan tool fallthrough ---

--- a/tests/agent/response_cap_test.ts
+++ b/tests/agent/response_cap_test.ts
@@ -117,10 +117,10 @@ Deno.test("capToolResponse: truncation at line boundary", () => {
 
 Deno.test("capToolResponse: per-tool budget override takes precedence", () => {
   const cache = new ResponseCache();
-  const githubBudget = TOOL_RESPONSE_BUDGETS.get("github_list_comments")!;
+  const githubBudget = TOOL_RESPONSE_BUDGETS.get("github_issues")!;
   // Build text that exceeds the github budget but not the default
   const text = "x".repeat(githubBudget + 100);
-  const result = capToolResponse("github_list_comments", text, cache);
+  const result = capToolResponse("github_issues", text, cache);
   assertEquals(result.length < text.length, true);
   assertMatch(result, /truncated/);
 });

--- a/tests/exec/claude_test.ts
+++ b/tests/exec/claude_test.ts
@@ -420,29 +420,26 @@ Deno.test("ClaudeSessionManager: spawn fails gracefully for missing binary", asy
 
 // --- Tool definitions tests ---
 
-Deno.test("getClaudeToolDefinitions: returns all 5 tools", () => {
+Deno.test("getClaudeToolDefinitions: returns 2 consolidated tools", () => {
   const defs = getClaudeToolDefinitions();
-  assertEquals(defs.length, 5);
+  assertEquals(defs.length, 2);
 
   const names = defs.map((d) => d.name);
-  assert(names.includes("claude_start"));
-  assert(names.includes("claude_send"));
+  assert(names.includes("claude_session"));
   assert(names.includes("claude_output"));
-  assert(names.includes("claude_status"));
-  assert(names.includes("claude_stop"));
 });
 
-Deno.test("getClaudeToolDefinitions: claude_start has required prompt param", () => {
+Deno.test("getClaudeToolDefinitions: claude_session has required action param", () => {
   const defs = getClaudeToolDefinitions();
-  const startTool = defs.find((d) => d.name === "claude_start");
-  assertExists(startTool);
-  assertExists(startTool!.parameters.prompt);
-  assertEquals(startTool!.parameters.prompt.required, true);
+  const sessionTool = defs.find((d) => d.name === "claude_session");
+  assertExists(sessionTool);
+  assertExists(sessionTool!.parameters.action);
+  assertEquals(sessionTool!.parameters.action.required, true);
 });
 
 Deno.test("CLAUDE_SESSION_SYSTEM_PROMPT: is non-empty", () => {
   assert(CLAUDE_SESSION_SYSTEM_PROMPT.length > 0);
-  assertStringIncludes(CLAUDE_SESSION_SYSTEM_PROMPT, "claude_start");
+  assertStringIncludes(CLAUDE_SESSION_SYSTEM_PROMPT, "claude_session");
 });
 
 // --- Tool executor tests ---
@@ -457,25 +454,25 @@ Deno.test("createClaudeToolExecutor: returns null for unknown tools", async () =
   assertEquals(result, null);
 });
 
-Deno.test("createClaudeToolExecutor: claude_start validates prompt", async () => {
+Deno.test("createClaudeToolExecutor: claude_session start validates prompt", async () => {
   const manager = createClaudeSessionManager({
     workspacePath: "/tmp/test",
   });
   const executor = createClaudeToolExecutor(manager);
 
-  const result = await executor("claude_start", {});
+  const result = await executor("claude_session", { action: "start" });
   assertExists(result);
   assertStringIncludes(result!, "Error");
   assertStringIncludes(result!, "prompt");
 });
 
-Deno.test("createClaudeToolExecutor: claude_send validates session_id", async () => {
+Deno.test("createClaudeToolExecutor: claude_session send validates session_id", async () => {
   const manager = createClaudeSessionManager({
     workspacePath: "/tmp/test",
   });
   const executor = createClaudeToolExecutor(manager);
 
-  const result = await executor("claude_send", { input: "test" });
+  const result = await executor("claude_session", { action: "send", input: "test" });
   assertExists(result);
   assertStringIncludes(result!, "Error");
 });
@@ -491,29 +488,29 @@ Deno.test("createClaudeToolExecutor: claude_output validates session_id", async 
   assertStringIncludes(result!, "Error");
 });
 
-Deno.test("createClaudeToolExecutor: claude_status validates session_id", async () => {
+Deno.test("createClaudeToolExecutor: claude_session status validates session_id", async () => {
   const manager = createClaudeSessionManager({
     workspacePath: "/tmp/test",
   });
   const executor = createClaudeToolExecutor(manager);
 
-  const result = await executor("claude_status", {});
+  const result = await executor("claude_session", { action: "status" });
   assertExists(result);
   assertStringIncludes(result!, "Error");
 });
 
-Deno.test("createClaudeToolExecutor: claude_stop validates session_id", async () => {
+Deno.test("createClaudeToolExecutor: claude_session stop validates session_id", async () => {
   const manager = createClaudeSessionManager({
     workspacePath: "/tmp/test",
   });
   const executor = createClaudeToolExecutor(manager);
 
-  const result = await executor("claude_stop", {});
+  const result = await executor("claude_session", { action: "stop" });
   assertExists(result);
   assertStringIncludes(result!, "Error");
 });
 
-Deno.test("createClaudeToolExecutor: claude_start success returns JSON with session_id", async () => {
+Deno.test("createClaudeToolExecutor: claude_session start success returns JSON with session_id", async () => {
   const tmpDir = await Deno.makeTempDir();
   const mockBin = await createMockClaude(tmpDir);
   const manager = createClaudeSessionManager({
@@ -523,7 +520,7 @@ Deno.test("createClaudeToolExecutor: claude_start success returns JSON with sess
   const executor = createClaudeToolExecutor(manager);
 
   try {
-    const result = await executor("claude_start", { prompt: "Hello!" });
+    const result = await executor("claude_session", { action: "start", prompt: "Hello!" });
     assertExists(result);
     assert(!result!.startsWith("Error"));
     const parsed = JSON.parse(result!);
@@ -537,7 +534,7 @@ Deno.test("createClaudeToolExecutor: claude_start success returns JSON with sess
   }
 });
 
-Deno.test("createClaudeToolExecutor: claude_status returns JSON for valid session", async () => {
+Deno.test("createClaudeToolExecutor: claude_session status returns JSON for valid session", async () => {
   const tmpDir = await Deno.makeTempDir();
   const mockBin = await createMockClaude(tmpDir);
   const manager = createClaudeSessionManager({
@@ -547,11 +544,12 @@ Deno.test("createClaudeToolExecutor: claude_status returns JSON for valid sessio
   const executor = createClaudeToolExecutor(manager);
 
   try {
-    const startResult = await executor("claude_start", { prompt: "Hello" });
+    const startResult = await executor("claude_session", { action: "start", prompt: "Hello" });
     assertExists(startResult);
     const started = JSON.parse(startResult!);
 
-    const statusResult = await executor("claude_status", {
+    const statusResult = await executor("claude_session", {
+      action: "status",
       session_id: started.session_id,
     });
     assertExists(statusResult);
@@ -567,7 +565,7 @@ Deno.test("createClaudeToolExecutor: claude_status returns JSON for valid sessio
   }
 });
 
-Deno.test("createClaudeToolExecutor: claude_stop returns success message", async () => {
+Deno.test("createClaudeToolExecutor: claude_session stop returns success message", async () => {
   const tmpDir = await Deno.makeTempDir();
   const mockBin = await createHangingMockClaude(tmpDir);
   const manager = createClaudeSessionManager({
@@ -577,13 +575,15 @@ Deno.test("createClaudeToolExecutor: claude_stop returns success message", async
   const executor = createClaudeToolExecutor(manager);
 
   try {
-    const startResult = await executor("claude_start", {
+    const startResult = await executor("claude_session", {
+      action: "start",
       prompt: "Long task",
     });
     assertExists(startResult);
     const started = JSON.parse(startResult!);
 
-    const stopResult = await executor("claude_stop", {
+    const stopResult = await executor("claude_session", {
+      action: "stop",
       session_id: started.session_id,
     });
     assertExists(stopResult);
@@ -597,10 +597,7 @@ Deno.test("createClaudeToolExecutor: claude_stop returns success message", async
 
 Deno.test("HARDCODED_TOOL_FLOORS: claude tools have INTERNAL floor", () => {
   const claudeTools = [
-    "claude_start",
-    "claude_send",
-    "claude_stop",
-    "claude_status",
+    "claude_session",
     "claude_output",
   ];
   for (const tool of claudeTools) {

--- a/tests/gateway/role_filter_test.ts
+++ b/tests/gateway/role_filter_test.ts
@@ -89,8 +89,8 @@ Deno.test("filterToolsForRole: non-owner never receives secret_save", () => {
   assertEquals(result[0].name, "todo_write");
 });
 
-Deno.test("filterToolsForRole: non-owner never receives cron_create", () => {
-  const tools = [stubTool("cron_create"), stubTool("web_search")];
+Deno.test("filterToolsForRole: non-owner never receives cron", () => {
+  const tools = [stubTool("cron"), stubTool("web_search")];
   const result = filterToolsForRole(tools, false);
   assertEquals(result.length, 1);
   assertEquals(result[0].name, "web_search");
@@ -110,8 +110,8 @@ Deno.test("filterToolsForRole: non-owner never receives subagent", () => {
   assertEquals(result[0].name, "summarize");
 });
 
-Deno.test("filterToolsForRole: non-owner never receives claude_start", () => {
-  const tools = [stubTool("claude_start"), stubTool("explore")];
+Deno.test("filterToolsForRole: non-owner never receives claude_session", () => {
+  const tools = [stubTool("claude_session"), stubTool("explore")];
   const result = filterToolsForRole(tools, false);
   assertEquals(result.length, 1);
   assertEquals(result[0].name, "explore");
@@ -194,16 +194,13 @@ Deno.test("filterToolsForRole: all owner-only tools are in the OWNER_ONLY_TOOLS 
     "secret_save",
     "secret_save_credential",
     "secret_delete",
-    "cron_create",
-    "cron_delete",
+    "cron",
     "subagent",
     "agents_list",
-    "claude_start",
-    "claude_send",
+    "claude_session",
     "sessions_send",
     "sessions_spawn",
-    "plan_enter",
-    "plan_exit",
+    "plan_manage",
     "tidepool_render_component",
     "tidepool_render_html",
   ];

--- a/tests/integrations/github/tools_test.ts
+++ b/tests/integrations/github/tools_test.ts
@@ -1,7 +1,7 @@
 /**
  * GitHub tools tests.
  *
- * Tests all 27 tool definitions, parameter validation,
+ * Tests all 4 consolidated tool definitions, parameter validation,
  * response formatting, null fallthrough, and graceful error handling.
  */
 import { assertEquals } from "@std/assert";
@@ -17,9 +17,9 @@ import type { Result } from "../../../src/core/types/classification.ts";
 
 // ─── Tool Definitions ────────────────────────────────────────────────────────
 
-Deno.test("getGitHubToolDefinitions: returns 27 tool definitions", () => {
+Deno.test("getGitHubToolDefinitions: returns 4 consolidated tool definitions", () => {
   const defs = getGitHubToolDefinitions();
-  assertEquals(defs.length, 27);
+  assertEquals(defs.length, 4);
 });
 
 Deno.test("getGitHubToolDefinitions: all tools have github_ prefix", () => {
@@ -45,31 +45,15 @@ Deno.test("getGitHubToolDefinitions: all tools have descriptions", () => {
   }
 });
 
-Deno.test("getGitHubToolDefinitions: all tool names follow verb-first pattern", () => {
+Deno.test("getGitHubToolDefinitions: all tools use domain-noun naming pattern", () => {
   const defs = getGitHubToolDefinitions();
-  const verbs = [
-    "list",
-    "get",
-    "read",
-    "create",
-    "update",
-    "delete",
-    "review",
-    "merge",
-    "trigger",
-    "cancel",
-    "add",
-    "search",
-    "clone",
-    "pull",
-  ];
+  const domains = ["repos", "pulls", "issues", "actions"];
   for (const def of defs) {
     const afterPrefix = def.name.replace("github_", "");
-    const firstWord = afterPrefix.split("_")[0];
     assertEquals(
-      verbs.includes(firstWord),
+      domains.includes(afterPrefix),
       true,
-      `${def.name} does not start with a known verb (got "${firstWord}")`,
+      `${def.name} does not match a known domain (got "${afterPrefix}")`,
     );
   }
 });
@@ -78,35 +62,27 @@ Deno.test("getGitHubToolDefinitions: expected tool names present", () => {
   const defs = getGitHubToolDefinitions();
   const names = new Set(defs.map((d) => d.name));
   const expected = [
-    "github_list_repos",
-    "github_get_repo",
-    "github_read_file",
-    "github_list_commits",
-    "github_list_branches",
-    "github_create_branch",
-    "github_delete_branch",
-    "github_list_pulls",
-    "github_get_pull",
-    "github_create_pull",
-    "github_update_pull",
-    "github_list_pull_files",
-    "github_review_pull",
-    "github_merge_pull",
-    "github_list_issues",
-    "github_get_issue",
-    "github_create_issue",
-    "github_update_issue",
-    "github_list_comments",
-    "github_add_comment",
-    "github_list_runs",
-    "github_cancel_run",
-    "github_trigger_workflow",
-    "github_search_code",
-    "github_search_issues",
-    "github_clone_repo",
+    "github_repos",
+    "github_pulls",
+    "github_issues",
+    "github_actions",
   ];
   for (const name of expected) {
     assertEquals(names.has(name), true, `Missing tool: ${name}`);
+  }
+});
+
+Deno.test("getGitHubToolDefinitions: all tools have required action parameter", () => {
+  const defs = getGitHubToolDefinitions();
+  for (const def of defs) {
+    const actionParam = def.parameters.action;
+    assertEquals(
+      actionParam !== undefined,
+      true,
+      `${def.name} missing action parameter`,
+    );
+    assertEquals(actionParam.required, true, `${def.name} action not required`);
+    assertEquals(actionParam.type, "string", `${def.name} action not string`);
   }
 });
 
@@ -133,7 +109,7 @@ Deno.test("createGitHubToolExecutor: returns null for non-github tools", async (
 Deno.test("createGitHubToolExecutor: returns null for unknown github_ tool", async () => {
   const ctx = createMockContext();
   const executor = createGitHubToolExecutor(ctx);
-  const result = await executor("github_unknown_tool", {});
+  const result = await executor("github_unknown_tool", { action: "list" });
   assertEquals(result, null);
 });
 
@@ -141,41 +117,66 @@ Deno.test("createGitHubToolExecutor: returns null for unknown github_ tool", asy
 
 Deno.test("createGitHubToolExecutor: returns error when not configured", async () => {
   const executor = createGitHubToolExecutor(undefined);
-  const result = await executor("github_list_repos", {});
+  const result = await executor("github_repos", { action: "list" });
   assertEquals(typeof result, "string");
   assertEquals(result!.includes("not configured"), true);
 });
 
-// ─── Parameter Validation ────────────────────────────────────────────────────
+// ─── Action Validation ──────────────────────────────────────────────────────
 
-Deno.test("executor: github_read_file requires repo param", async () => {
+Deno.test("executor: returns error when action is missing", async () => {
   const ctx = createMockContext();
   const executor = createGitHubToolExecutor(ctx);
-  const result = await executor("github_read_file", { path: "README.md" });
+  const result = await executor("github_repos", {});
+  assertEquals(result!.includes("action"), true);
+});
+
+Deno.test("executor: returns error for unknown action", async () => {
+  const ctx = createMockContext();
+  const executor = createGitHubToolExecutor(ctx);
+  const result = await executor("github_repos", { action: "nonexistent" });
+  assertEquals(result!.includes("unknown action"), true);
+  assertEquals(result!.includes("nonexistent"), true);
+});
+
+// ─── Parameter Validation ────────────────────────────────────────────────────
+
+Deno.test("executor: github_repos read_file requires repo param", async () => {
+  const ctx = createMockContext();
+  const executor = createGitHubToolExecutor(ctx);
+  const result = await executor("github_repos", {
+    action: "read_file",
+    path: "README.md",
+  });
   assertEquals(result!.includes("Error"), true);
 });
 
-Deno.test("executor: github_read_file requires path param", async () => {
+Deno.test("executor: github_repos read_file requires path param", async () => {
   const ctx = createMockContext();
   const executor = createGitHubToolExecutor(ctx);
-  const result = await executor("github_read_file", { repo: "o/r" });
+  const result = await executor("github_repos", {
+    action: "read_file",
+    repo: "o/r",
+  });
   assertEquals(result!.includes("Error"), true);
 });
 
 Deno.test("executor: rejects invalid repo format (no slash)", async () => {
   const ctx = createMockContext();
   const executor = createGitHubToolExecutor(ctx);
-  const result = await executor("github_read_file", {
+  const result = await executor("github_repos", {
+    action: "read_file",
     repo: "invalid",
     path: "f",
   });
   assertEquals(result!.includes("owner/name"), true);
 });
 
-Deno.test("executor: github_create_pull requires title", async () => {
+Deno.test("executor: github_pulls create requires title", async () => {
   const ctx = createMockContext();
   const executor = createGitHubToolExecutor(ctx);
-  const result = await executor("github_create_pull", {
+  const result = await executor("github_pulls", {
+    action: "create",
     repo: "o/r",
     head: "feature",
     base: "main",
@@ -184,18 +185,21 @@ Deno.test("executor: github_create_pull requires title", async () => {
   assertEquals(result!.includes("title"), true);
 });
 
-Deno.test("executor: github_search_code requires query", async () => {
+Deno.test("executor: github_actions search_code requires query", async () => {
   const ctx = createMockContext();
   const executor = createGitHubToolExecutor(ctx);
-  const result = await executor("github_search_code", {});
+  const result = await executor("github_actions", {
+    action: "search_code",
+  });
   assertEquals(result!.includes("Error"), true);
   assertEquals(result!.includes("query"), true);
 });
 
-Deno.test("executor: github_add_comment requires number", async () => {
+Deno.test("executor: github_issues add_comment requires number", async () => {
   const ctx = createMockContext();
   const executor = createGitHubToolExecutor(ctx);
-  const result = await executor("github_add_comment", {
+  const result = await executor("github_issues", {
+    action: "add_comment",
     repo: "o/r",
     body: "hi",
   });
@@ -203,32 +207,40 @@ Deno.test("executor: github_add_comment requires number", async () => {
   assertEquals(result!.includes("number"), true);
 });
 
-Deno.test("executor: github_get_issue requires number", async () => {
+Deno.test("executor: github_issues get requires number", async () => {
   const ctx = createMockContext();
   const executor = createGitHubToolExecutor(ctx);
-  const result = await executor("github_get_issue", { repo: "o/r" });
+  const result = await executor("github_issues", {
+    action: "get",
+    repo: "o/r",
+  });
   assertEquals(result!.includes("Error"), true);
   assertEquals(result!.includes("number"), true);
 });
 
-Deno.test("executor: github_get_pull requires pr_number", async () => {
+Deno.test("executor: github_pulls get requires pr_number", async () => {
   const ctx = createMockContext();
   const executor = createGitHubToolExecutor(ctx);
-  const result = await executor("github_get_pull", { repo: "o/r" });
+  const result = await executor("github_pulls", {
+    action: "get",
+    repo: "o/r",
+  });
   assertEquals(result!.includes("Error"), true);
   assertEquals(result!.includes("pr_number"), true);
 });
 
-Deno.test("executor: github_create_branch requires branch and sha", async () => {
+Deno.test("executor: github_repos create_branch requires branch and sha", async () => {
   const ctx = createMockContext();
   const executor = createGitHubToolExecutor(ctx);
-  const result1 = await executor("github_create_branch", {
+  const result1 = await executor("github_repos", {
+    action: "create_branch",
     repo: "o/r",
     sha: "abc",
   });
   assertEquals(result1!.includes("Error"), true);
   assertEquals(result1!.includes("branch"), true);
-  const result2 = await executor("github_create_branch", {
+  const result2 = await executor("github_repos", {
+    action: "create_branch",
     repo: "o/r",
     branch: "feat",
   });
@@ -236,25 +248,31 @@ Deno.test("executor: github_create_branch requires branch and sha", async () => 
   assertEquals(result2!.includes("sha"), true);
 });
 
-Deno.test("executor: github_delete_branch requires branch", async () => {
+Deno.test("executor: github_repos delete_branch requires branch", async () => {
   const ctx = createMockContext();
   const executor = createGitHubToolExecutor(ctx);
-  const result = await executor("github_delete_branch", { repo: "o/r" });
+  const result = await executor("github_repos", {
+    action: "delete_branch",
+    repo: "o/r",
+  });
   assertEquals(result!.includes("Error"), true);
   assertEquals(result!.includes("branch"), true);
 });
 
-Deno.test("executor: github_cancel_run requires run_id", async () => {
+Deno.test("executor: github_actions cancel_run requires run_id", async () => {
   const ctx = createMockContext();
   const executor = createGitHubToolExecutor(ctx);
-  const result = await executor("github_cancel_run", { repo: "o/r" });
+  const result = await executor("github_actions", {
+    action: "cancel_run",
+    repo: "o/r",
+  });
   assertEquals(result!.includes("Error"), true);
   assertEquals(result!.includes("run_id"), true);
 });
 
 // ─── Response Formatting ─────────────────────────────────────────────────────
 
-Deno.test("executor: github_list_repos returns JSON with _classification", async () => {
+Deno.test("executor: github_repos list returns JSON with _classification", async () => {
   const ctx = createMockContext({
     listRepos: () =>
       Promise.resolve({
@@ -271,14 +289,14 @@ Deno.test("executor: github_list_repos returns JSON with _classification", async
       }),
   });
   const executor = createGitHubToolExecutor(ctx);
-  const result = await executor("github_list_repos", {});
+  const result = await executor("github_repos", { action: "list" });
 
   const parsed = JSON.parse(result!);
   assertEquals(parsed.repos.length, 1);
   assertEquals(parsed.repos[0]._classification, "PUBLIC");
 });
 
-Deno.test("executor: github_search_code returns JSON with results", async () => {
+Deno.test("executor: github_actions search_code returns JSON with results", async () => {
   const ctx = createMockContext({
     searchCode: () =>
       Promise.resolve({
@@ -293,14 +311,17 @@ Deno.test("executor: github_search_code returns JSON with results", async () => 
       }),
   });
   const executor = createGitHubToolExecutor(ctx);
-  const result = await executor("github_search_code", { query: "import foo" });
+  const result = await executor("github_actions", {
+    action: "search_code",
+    query: "import foo",
+  });
 
   const parsed = JSON.parse(result!);
   assertEquals(parsed.results.length, 1);
   assertEquals(parsed.results[0]._classification, "CONFIDENTIAL");
 });
 
-Deno.test("executor: github_create_issue returns created issue JSON", async () => {
+Deno.test("executor: github_issues create returns created issue JSON", async () => {
   const ctx = createMockContext({
     createIssue: () =>
       Promise.resolve({
@@ -319,7 +340,8 @@ Deno.test("executor: github_create_issue returns created issue JSON", async () =
       }),
   });
   const executor = createGitHubToolExecutor(ctx);
-  const result = await executor("github_create_issue", {
+  const result = await executor("github_issues", {
+    action: "create",
     repo: "o/r",
     title: "New issue",
   });
@@ -329,7 +351,7 @@ Deno.test("executor: github_create_issue returns created issue JSON", async () =
   assertEquals(parsed._classification, "PUBLIC");
 });
 
-Deno.test("executor: github_get_repo returns repo detail JSON", async () => {
+Deno.test("executor: github_repos get returns repo detail JSON", async () => {
   const ctx = createMockContext({
     getRepo: () =>
       Promise.resolve({
@@ -352,7 +374,10 @@ Deno.test("executor: github_get_repo returns repo detail JSON", async () => {
       }),
   });
   const executor = createGitHubToolExecutor(ctx);
-  const result = await executor("github_get_repo", { repo: "o/r" });
+  const result = await executor("github_repos", {
+    action: "get",
+    repo: "o/r",
+  });
 
   const parsed = JSON.parse(result!);
   assertEquals(parsed.language, "TypeScript");
@@ -360,7 +385,7 @@ Deno.test("executor: github_get_repo returns repo detail JSON", async () => {
   assertEquals(parsed._classification, "PUBLIC");
 });
 
-Deno.test("executor: github_list_comments returns comments JSON", async () => {
+Deno.test("executor: github_issues list_comments returns comments JSON", async () => {
   const ctx = createMockContext({
     listComments: () =>
       Promise.resolve({
@@ -376,7 +401,8 @@ Deno.test("executor: github_list_comments returns comments JSON", async () => {
       }),
   });
   const executor = createGitHubToolExecutor(ctx);
-  const result = await executor("github_list_comments", {
+  const result = await executor("github_issues", {
+    action: "list_comments",
     repo: "o/r",
     number: 1,
   });
@@ -397,7 +423,7 @@ Deno.test("executor: formats API error correctly", async () => {
       }),
   });
   const executor = createGitHubToolExecutor(ctx);
-  const result = await executor("github_list_repos", {});
+  const result = await executor("github_repos", { action: "list" });
   assertEquals(result!.includes("401"), true);
   assertEquals(result!.includes("Bad credentials"), true);
 });
@@ -416,7 +442,7 @@ Deno.test("executor: formats rate limit error", async () => {
       }),
   });
   const executor = createGitHubToolExecutor(ctx);
-  const result = await executor("github_list_repos", {});
+  const result = await executor("github_repos", { action: "list" });
   assertEquals(result!.includes("rate limit exceeded"), true);
 });
 
@@ -492,6 +518,8 @@ function createMockContext(
       defaultMethod as unknown as GitHubClient["searchIssues"],
     cloneRepo: overrides?.cloneRepo as GitHubClient["cloneRepo"] ??
       defaultMethod as unknown as GitHubClient["cloneRepo"],
+    pullRepo: overrides?.pullRepo as GitHubClient["pullRepo"] ??
+      defaultMethod as unknown as GitHubClient["pullRepo"],
   };
 
   return {

--- a/tests/integrations/google/classification_test.ts
+++ b/tests/integrations/google/classification_test.ts
@@ -238,11 +238,14 @@ Deno.test("classification: INTERNAL data cannot flow to PUBLIC", () => {
 
 // ─── Test 4: Gmail tool returns data (executor produces output) ─────────────
 
-Deno.test("classification: gmail_search returns data at session taint level", async () => {
+Deno.test("classification: google_gmail search returns data at session taint level", async () => {
   const ctx = createContextWithTaint("CONFIDENTIAL");
   const executor = createGoogleToolExecutor(ctx);
 
-  const result = await executor("gmail_search", { query: "Q4 report" });
+  const result = await executor("google_gmail", {
+    action: "search",
+    query: "Q4 report",
+  });
   assertEquals(result !== null, true);
 
   // Data was returned — in a real system, the orchestrator would check
@@ -255,22 +258,25 @@ Deno.test("classification: gmail_search returns data at session taint level", as
 
 // ─── Test 5: Drive file read returns content ────────────────────────────────
 
-Deno.test("classification: drive_read returns file content", async () => {
+Deno.test("classification: google_drive read returns file content", async () => {
   const ctx = createContextWithTaint("INTERNAL");
   const executor = createGoogleToolExecutor(ctx);
 
-  const result = await executor("drive_read", { file_id: "file1" });
+  const result = await executor("google_drive", {
+    action: "read",
+    file_id: "file1",
+  });
   assertEquals(result !== null, true);
   assertEquals(result!.includes("Confidential roadmap"), true);
 });
 
 // ─── Test 6: Calendar with attendees returns data ───────────────────────────
 
-Deno.test("classification: calendar_list returns events with attendees", async () => {
+Deno.test("classification: google_calendar list returns events with attendees", async () => {
   const ctx = createContextWithTaint("INTERNAL");
   const executor = createGoogleToolExecutor(ctx);
 
-  const result = await executor("calendar_list", {});
+  const result = await executor("google_calendar", { action: "list" });
   assertEquals(result !== null, true);
 
   const parsed = JSON.parse(result!);
@@ -306,18 +312,22 @@ Deno.test("classification: executor surfaces API errors as strings", async () =>
   };
   const executor = createGoogleToolExecutor(ctx);
 
-  const result = await executor("gmail_search", { query: "test" });
+  const result = await executor("google_gmail", {
+    action: "search",
+    query: "test",
+  });
   assertEquals(result!.includes("Error"), true);
   assertEquals(result!.includes("Insufficient permission"), true);
 });
 
 // ─── Test 8: Sheets write validates JSON ────────────────────────────────────
 
-Deno.test("classification: sheets_write rejects non-JSON values safely", async () => {
+Deno.test("classification: google_sheets write rejects non-JSON values safely", async () => {
   const ctx = createContextWithTaint("INTERNAL");
   const executor = createGoogleToolExecutor(ctx);
 
-  const result = await executor("sheets_write", {
+  const result = await executor("google_sheets", {
+    action: "write",
     spreadsheet_id: "ss1",
     range: "A1",
     values: "this is not json",

--- a/tests/integrations/google/integration_test.ts
+++ b/tests/integrations/google/integration_test.ts
@@ -337,7 +337,7 @@ Deno.test("integration: expired token triggers refresh using stored client creds
   }
 });
 
-Deno.test("integration: executor routes gmail_search end-to-end", async () => {
+Deno.test("integration: executor routes google_gmail search end-to-end", async () => {
   const { server, baseUrl } = createMockGoogleServer();
   const mockFetch = createMockFetch(baseUrl);
 
@@ -357,7 +357,10 @@ Deno.test("integration: executor routes gmail_search end-to-end", async () => {
       sourceSessionId: "integration-session" as SessionId,
     });
 
-    const result = await executor("gmail_search", { query: "test" });
+    const result = await executor("google_gmail", {
+      action: "search",
+      query: "test",
+    });
     assertEquals(result !== null, true);
 
     // Should contain email data from mock
@@ -383,7 +386,10 @@ Deno.test("integration: executor returns clear error when not connected", async 
     sourceSessionId: "no-auth-session" as SessionId,
   });
 
-  const result = await executor("gmail_search", { query: "test" });
+  const result = await executor("google_gmail", {
+    action: "search",
+    query: "test",
+  });
   assertEquals(result !== null, true);
   assertStringIncludes(result!, "triggerfish connect google");
 });

--- a/tests/integrations/google/tools_test.ts
+++ b/tests/integrations/google/tools_test.ts
@@ -1,7 +1,9 @@
 /**
  * Google Workspace tool definitions and executor tests.
  *
- * Tests tool definition shapes, executor routing, and parameter validation.
+ * Tests tool definition shapes, executor routing, and parameter validation
+ * for the 5 consolidated tools (google_gmail, google_calendar, google_tasks,
+ * google_drive, google_sheets) with action-based dispatch.
  *
  * @module
  */
@@ -24,16 +26,16 @@ import type { SessionId } from "../../../src/core/types/session.ts";
 
 // ─── Tool Definitions ───────────────────────────────────────────────────────
 
-Deno.test("getGoogleToolDefinitions: returns 14 tools", () => {
+Deno.test("getGoogleToolDefinitions: returns 5 consolidated tools", () => {
   const defs = getGoogleToolDefinitions();
-  assertEquals(defs.length, 14);
+  assertEquals(defs.length, 5);
 });
 
 Deno.test("getGoogleToolDefinitions: all tools have unique names", () => {
   const defs = getGoogleToolDefinitions();
   const names = defs.map((d) => d.name);
   const unique = new Set(names);
-  assertEquals(unique.size, 14);
+  assertEquals(unique.size, 5);
 });
 
 Deno.test("getGoogleToolDefinitions: contains all expected tool names", () => {
@@ -41,20 +43,11 @@ Deno.test("getGoogleToolDefinitions: contains all expected tool names", () => {
   const names = new Set(defs.map((d) => d.name));
 
   const expected = [
-    "gmail_search",
-    "gmail_read",
-    "gmail_send",
-    "gmail_label",
-    "calendar_list",
-    "calendar_create",
-    "calendar_update",
-    "tasks_list",
-    "tasks_create",
-    "tasks_complete",
-    "drive_search",
-    "drive_read",
-    "sheets_read",
-    "sheets_write",
+    "google_gmail",
+    "google_calendar",
+    "google_tasks",
+    "google_drive",
+    "google_sheets",
   ];
 
   for (const name of expected) {
@@ -62,27 +55,33 @@ Deno.test("getGoogleToolDefinitions: contains all expected tool names", () => {
   }
 });
 
-Deno.test("getGoogleToolDefinitions: gmail_search has required query param", () => {
+Deno.test("getGoogleToolDefinitions: google_gmail has required action param", () => {
   const defs = getGoogleToolDefinitions();
-  const tool = defs.find((d) => d.name === "gmail_search")!;
-  assertEquals(tool.parameters.query.required, true);
+  const tool = defs.find((d) => d.name === "google_gmail")!;
+  assertEquals(tool.parameters.action.required, true);
+  assertEquals(tool.parameters.action.type, "string");
+});
+
+Deno.test("getGoogleToolDefinitions: google_gmail has query param for search", () => {
+  const defs = getGoogleToolDefinitions();
+  const tool = defs.find((d) => d.name === "google_gmail")!;
   assertEquals(tool.parameters.query.type, "string");
 });
 
-Deno.test("getGoogleToolDefinitions: gmail_send has required to, subject, body", () => {
+Deno.test("getGoogleToolDefinitions: google_gmail has send params (to, subject, body)", () => {
   const defs = getGoogleToolDefinitions();
-  const tool = defs.find((d) => d.name === "gmail_send")!;
-  assertEquals(tool.parameters.to.required, true);
-  assertEquals(tool.parameters.subject.required, true);
-  assertEquals(tool.parameters.body.required, true);
+  const tool = defs.find((d) => d.name === "google_gmail")!;
+  assertEquals(tool.parameters.to.type, "string");
+  assertEquals(tool.parameters.subject.type, "string");
+  assertEquals(tool.parameters.body.type, "string");
 });
 
-Deno.test("getGoogleToolDefinitions: sheets_write has required values param", () => {
+Deno.test("getGoogleToolDefinitions: google_sheets has values param for write", () => {
   const defs = getGoogleToolDefinitions();
-  const tool = defs.find((d) => d.name === "sheets_write")!;
-  assertEquals(tool.parameters.spreadsheet_id.required, true);
-  assertEquals(tool.parameters.range.required, true);
-  assertEquals(tool.parameters.values.required, true);
+  const tool = defs.find((d) => d.name === "google_sheets")!;
+  assertEquals(tool.parameters.spreadsheet_id.type, "string");
+  assertEquals(tool.parameters.range.type, "string");
+  assertEquals(tool.parameters.values.type, "string");
 });
 
 Deno.test("GOOGLE_TOOLS_SYSTEM_PROMPT: is a non-empty string", () => {
@@ -200,26 +199,33 @@ Deno.test("executor: returns null for unknown tool", async () => {
   assertEquals(result, null);
 });
 
-Deno.test("executor: routes gmail_search correctly", async () => {
+Deno.test("executor: routes google_gmail action:search correctly", async () => {
   const executor = createGoogleToolExecutor(createMockContext());
-  const result = await executor("gmail_search", { query: "test" });
+  const result = await executor("google_gmail", {
+    action: "search",
+    query: "test",
+  });
   assertEquals(result !== null, true);
   // Empty results from mock
   assertEquals(result!.includes("No emails found"), true);
 });
 
-Deno.test("executor: routes gmail_read correctly", async () => {
+Deno.test("executor: routes google_gmail action:read correctly", async () => {
   const executor = createGoogleToolExecutor(createMockContext());
-  const result = await executor("gmail_read", { message_id: "msg1" });
+  const result = await executor("google_gmail", {
+    action: "read",
+    message_id: "msg1",
+  });
   assertEquals(result !== null, true);
   const parsed = JSON.parse(result!);
   assertEquals(parsed.id, "msg1");
   assertEquals(parsed.subject, "Test");
 });
 
-Deno.test("executor: routes gmail_send correctly", async () => {
+Deno.test("executor: routes google_gmail action:send correctly", async () => {
   const executor = createGoogleToolExecutor(createMockContext());
-  const result = await executor("gmail_send", {
+  const result = await executor("google_gmail", {
+    action: "send",
     to: "test@example.com",
     subject: "Hi",
     body: "Hello",
@@ -228,9 +234,10 @@ Deno.test("executor: routes gmail_send correctly", async () => {
   assertEquals(parsed.sent, true);
 });
 
-Deno.test("executor: routes calendar_create correctly", async () => {
+Deno.test("executor: routes google_calendar action:create correctly", async () => {
   const executor = createGoogleToolExecutor(createMockContext());
-  const result = await executor("calendar_create", {
+  const result = await executor("google_calendar", {
+    action: "create",
     summary: "Meeting",
     start: "2025-01-15T10:00:00Z",
     end: "2025-01-15T11:00:00Z",
@@ -240,22 +247,29 @@ Deno.test("executor: routes calendar_create correctly", async () => {
   assertEquals(parsed.id, "evt1");
 });
 
-Deno.test("executor: routes tasks_create correctly", async () => {
+Deno.test("executor: routes google_tasks action:create correctly", async () => {
   const executor = createGoogleToolExecutor(createMockContext());
-  const result = await executor("tasks_create", { title: "Buy milk" });
+  const result = await executor("google_tasks", {
+    action: "create",
+    title: "Buy milk",
+  });
   const parsed = JSON.parse(result!);
   assertEquals(parsed.created, true);
 });
 
-Deno.test("executor: routes drive_read correctly", async () => {
+Deno.test("executor: routes google_drive action:read correctly", async () => {
   const executor = createGoogleToolExecutor(createMockContext());
-  const result = await executor("drive_read", { file_id: "file1" });
+  const result = await executor("google_drive", {
+    action: "read",
+    file_id: "file1",
+  });
   assertEquals(result, "File content here");
 });
 
-Deno.test("executor: routes sheets_read correctly", async () => {
+Deno.test("executor: routes google_sheets action:read correctly", async () => {
   const executor = createGoogleToolExecutor(createMockContext());
-  const result = await executor("sheets_read", {
+  const result = await executor("google_sheets", {
+    action: "read",
     spreadsheet_id: "ss1",
     range: "Sheet1!A1:B2",
   });
@@ -264,9 +278,10 @@ Deno.test("executor: routes sheets_read correctly", async () => {
   assertEquals(parsed.values.length, 2);
 });
 
-Deno.test("executor: routes sheets_write correctly", async () => {
+Deno.test("executor: routes google_sheets action:write correctly", async () => {
   const executor = createGoogleToolExecutor(createMockContext());
-  const result = await executor("sheets_write", {
+  const result = await executor("google_sheets", {
+    action: "write",
     spreadsheet_id: "ss1",
     range: "Sheet1!A1",
     values: '[["x","y"]]',
@@ -275,35 +290,57 @@ Deno.test("executor: routes sheets_write correctly", async () => {
   assertEquals(parsed.written, true);
 });
 
+// ─── Action Validation ──────────────────────────────────────────────────────
+
+Deno.test("executor: rejects missing action parameter", async () => {
+  const executor = createGoogleToolExecutor(createMockContext());
+  const result = await executor("google_gmail", { query: "test" });
+  assertEquals(result!.includes("Error"), true);
+  assertEquals(result!.includes("action"), true);
+});
+
+Deno.test("executor: rejects unknown action", async () => {
+  const executor = createGoogleToolExecutor(createMockContext());
+  const result = await executor("google_gmail", { action: "delete" });
+  assertEquals(result!.includes("Error"), true);
+  assertEquals(result!.includes("unknown action"), true);
+});
+
 // ─── Parameter Validation ───────────────────────────────────────────────────
 
-Deno.test("executor: gmail_search rejects empty query", async () => {
+Deno.test("executor: google_gmail search rejects empty query", async () => {
   const executor = createGoogleToolExecutor(createMockContext());
-  const result = await executor("gmail_search", { query: "" });
+  const result = await executor("google_gmail", {
+    action: "search",
+    query: "",
+  });
   assertEquals(result!.includes("Error"), true);
 });
 
-Deno.test("executor: gmail_send rejects missing to", async () => {
+Deno.test("executor: google_gmail send rejects missing to", async () => {
   const executor = createGoogleToolExecutor(createMockContext());
-  const result = await executor("gmail_send", {
+  const result = await executor("google_gmail", {
+    action: "send",
     subject: "Hi",
     body: "Hello",
   });
   assertEquals(result!.includes("Error"), true);
 });
 
-Deno.test("executor: calendar_create rejects missing summary", async () => {
+Deno.test("executor: google_calendar create rejects missing summary", async () => {
   const executor = createGoogleToolExecutor(createMockContext());
-  const result = await executor("calendar_create", {
+  const result = await executor("google_calendar", {
+    action: "create",
     start: "2025-01-15T10:00:00Z",
     end: "2025-01-15T11:00:00Z",
   });
   assertEquals(result!.includes("Error"), true);
 });
 
-Deno.test("executor: sheets_write rejects invalid JSON values", async () => {
+Deno.test("executor: google_sheets write rejects invalid JSON values", async () => {
   const executor = createGoogleToolExecutor(createMockContext());
-  const result = await executor("sheets_write", {
+  const result = await executor("google_sheets", {
+    action: "write",
     spreadsheet_id: "ss1",
     range: "A1",
     values: "not json",


### PR DESCRIPTION
## Summary

- Consolidates 6 bloated tool groups into action-dispatched tools, reducing the tool count sent per LLM call from ~109 to ~64
- GitHub: 27 → 4 (`github_repos`, `github_pulls`, `github_issues`, `github_actions`)
- Google: 14 → 5 (`google_gmail`, `google_calendar`, `google_tasks`, `google_drive`, `google_sheets`)
- Plan: 8 → 3 (`plan_manage`, `plan_step_complete`, `plan_status`)
- Claude subprocess: 5 → 2 (`claude_session`, `claude_output`)
- Cron: 4 → 1 (`cron`)
- Sessions: 7 → 5 (merged `session_status` into `sessions_list`, `message` into `sessions_send`)

## Test plan

- [x] `deno task check` — type check passes
- [x] `deno task lint` — 0 errors (812 files)
- [x] `deno task test tests/agent/` — 281 passed
- [x] `deno task test tests/exec/` — 96 passed
- [x] `deno task test tests/gateway/` — 197 passed
- [x] `deno task test tests/e2e/` — 38 passed
- [x] `deno task test tests/integrations/` — 269 passed
- [ ] Build and run, verify Fireworks request logs show reduced tool count
- [ ] Smoke test consolidated tools end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)