### PR TITLE
fix: disable filesystem sandbox when deno runtime unavailable

### DIFF
--- a/src/exec/mod.ts
+++ b/src/exec/mod.ts
@@ -59,7 +59,7 @@ export {
   getClaudeToolDefinitions,
 } from "./claude.ts";
 
-export { createFilesystemSandbox } from "./sandbox/mod.ts";
+export { createFilesystemSandbox, probeDenoRuntime } from "./sandbox/mod.ts";
 export type {
   FilesystemSandbox,
   FilesystemSandboxOptions,

--- a/src/exec/sandbox/client.ts
+++ b/src/exec/sandbox/client.ts
@@ -40,6 +40,29 @@ interface PendingRequest {
 }
 
 /**
+ * Probe whether the Deno runtime is available as a subprocess.
+ *
+ * Returns false when running as a `deno compile`d binary on a machine
+ * without Deno installed — the sandbox requires spawning a child
+ * `deno run` process which is impossible without the runtime.
+ */
+export function probeDenoRuntime(): boolean {
+  try {
+    const result = new Deno.Command("deno", {
+      args: ["--version"],
+      stdout: "null",
+      stderr: "null",
+    }).outputSync();
+    return result.success;
+  } catch {
+    log.warn("Deno runtime not found, filesystem sandbox disabled", {
+      operation: "probeDenoRuntime",
+    });
+    return false;
+  }
+}
+
+/**
  * Extract the worker script to a real temp file for subprocess execution.
  *
  * Needed because `deno compile` embeds sources in a virtual FS that child

--- a/src/exec/sandbox/mod.ts
+++ b/src/exec/sandbox/mod.ts
@@ -9,6 +9,6 @@
  * @module
  */
 
-export { createFilesystemSandbox } from "./client.ts";
+export { createFilesystemSandbox, probeDenoRuntime } from "./client.ts";
 export type { FilesystemSandbox, FilesystemSandboxOptions } from "./client.ts";
 export type { SandboxOp, SandboxRequest, SandboxResponse } from "./protocol.ts";

--- a/src/gateway/startup/tools/scheduler_tool_assembly.ts
+++ b/src/gateway/startup/tools/scheduler_tool_assembly.ts
@@ -16,7 +16,10 @@ import type { createProviderRegistry } from "../../../agent/llm.ts";
 import type { resolveVisionProvider } from "../../../agent/providers/config.ts";
 import type { createWorkspace } from "../../../exec/workspace.ts";
 import { createExecTools } from "../../../exec/tools.ts";
-import { createFilesystemSandbox } from "../../../exec/sandbox/mod.ts";
+import {
+  createFilesystemSandbox,
+  probeDenoRuntime,
+} from "../../../exec/sandbox/mod.ts";
 import { createPathClassifier } from "../../../core/security/path_classification.ts";
 import {
   createHealthcheckToolExecutor,
@@ -204,10 +207,12 @@ export function assembleSchedulerToolExecutor(opts: {
     restrictedPath: workspace.restrictedPath,
   };
   const getTaint = opts.getSessionTaint ?? (() => session.taint);
-  const filesystemSandbox = createFilesystemSandbox({
-    resolveWorkspacePath: () =>
-      resolveWorkspacePathForTaint(getTaint(), workspacePaths),
-  });
+  const filesystemSandbox = probeDenoRuntime()
+    ? createFilesystemSandbox({
+      resolveWorkspacePath: () =>
+        resolveWorkspacePathForTaint(getTaint(), workspacePaths),
+    })
+    : undefined;
 
   return createToolExecutor({
     execTools: createExecTools(workspace, {

--- a/src/gateway/startup/tools/tool_infra.ts
+++ b/src/gateway/startup/tools/tool_infra.ts
@@ -52,7 +52,10 @@ import {
   initializeMemorySystem,
 } from "../infra/workspace_init.ts";
 import { initializeBrowserExecutor } from "../services/browser_init.ts";
-import { createFilesystemSandbox } from "../../../exec/sandbox/mod.ts";
+import {
+  createFilesystemSandbox,
+  probeDenoRuntime,
+} from "../../../exec/sandbox/mod.ts";
 import type { MainSessionState, WorkspacePaths } from "./tool_executor.ts";
 import {
   assembleMainToolExecutor,
@@ -289,9 +292,9 @@ export async function initializeBaseToolDeps(
   const execTools = createExecTools(workspace, {
     cwdOverride: resolveTaintCwd,
   });
-  const filesystemSandbox = createFilesystemSandbox({
-    resolveWorkspacePath: resolveTaintCwd,
-  });
+  const filesystemSandbox = probeDenoRuntime()
+    ? createFilesystemSandbox({ resolveWorkspacePath: resolveTaintCwd })
+    : undefined;
   const todoManager = createTodoManager({
     storage: coreInfra.storage,
     agentId: "main-session",


### PR DESCRIPTION
## Summary
- Add `probeDenoRuntime()` that checks if `deno` is on PATH at startup
- When unavailable (compiled binary on machines without Deno), skip sandbox creation
- Filesystem tools fall back to direct Deno APIs (existing fallback paths already in executor)
- Fixes `Failed to spawn 'deno': entity not found` on all compiled binary deployments

## Root cause
`createFilesystemSandbox` spawns a child `deno run` process for OS-level permission isolation. Compiled binaries (`deno compile`) don't bundle the Deno runtime, so this fails on machines without Deno installed.

## Test plan
- [x] `deno task check` passes
- [x] `deno task test tests/exec/` — 96 passed
- [x] `deno task test tests/gateway/` — 197 passed
- [x] Sandbox is optional (`filesystemSandbox?: FilesystemSandbox`) — all executor fallback paths already tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)