### PR TITLE
fix: friendly message when triggerfish is already running on Windows

### DIFF
--- a/src/gateway/startup/bootstrap.ts
+++ b/src/gateway/startup/bootstrap.ts
@@ -87,11 +87,30 @@ export async function initializeStartupLogger(): Promise<
 > {
   const isWindowsService = Deno.build.os === "windows" &&
     !Deno.stdout.isTerminal();
-  const fileWriter = isWindowsService
-    ? undefined
-    : await createFileWriter({ logDir: resolveLogDir() });
-  initLogger({ level: "INFO", fileWriter, console: true });
-  return fileWriter;
+  try {
+    const fileWriter = isWindowsService
+      ? undefined
+      : await createFileWriter({ logDir: resolveLogDir() });
+    initLogger({ level: "INFO", fileWriter, console: true });
+    return fileWriter;
+  } catch (err: unknown) {
+    if (isLogFileBusyError(err)) {
+      // console.error is intentional — the logger itself failed to initialize
+      console.error(
+        "Triggerfish is already running. Stop the existing instance first, " +
+          "or use 'triggerfish status' to check.",
+      );
+      Deno.exit(1);
+    }
+    throw err;
+  }
+}
+
+/** Detect EBUSY / lock errors on the log file (Windows exclusive lock). */
+function isLogFileBusyError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const withCode = err as Error & { code?: string };
+  return withCode.code === "EBUSY" || err.message.includes("os error 32");
 }
 
 /** Load config from disk with secret resolution, exit on failure. */


### PR DESCRIPTION
## Summary

- On Windows, the log file gets an exclusive lock. When a second instance tries to start, `Deno.open` fails with `EBUSY` (os error 32) and dumps an ugly stack trace
- Catch this specific error during logger init in `bootstrap.ts` and print a clear message: `Triggerfish is already running. Stop the existing instance first, or use 'triggerfish status' to check.`

## Test plan

- [x] `deno task check` — zero type errors
- [x] `deno task lint` — zero lint errors
- [ ] Manual (Windows): start daemon, run `triggerfish run` again, verify friendly message

🤖 Generated with [Claude Code](https://claude.com/claude-code)