### PR TITLE
fix: query both A and AAAA DNS records in SSRF denylist check

### DIFF
--- a/src/core/security/ssrf.ts
+++ b/src/core/security/ssrf.ts
@@ -113,30 +113,40 @@ export function isPrivateIp(ip: string): boolean {
   return false;
 }
 
-/** Resolve a hostname to ALL its A record IP addresses. */
+/** Resolve a hostname to ALL its A and AAAA record IP addresses. */
 async function resolveDnsHostname(
   hostname: string,
 ): Promise<Result<readonly string[], string>> {
-  let addresses: string[];
-  try {
-    addresses = await Deno.resolveDns(
-      hostname,
-      "A",
-    ) as unknown as string[];
-  } catch (err) {
+  const [v4Result, v6Result] = await Promise.allSettled([
+    Deno.resolveDns(hostname, "A"),
+    Deno.resolveDns(hostname, "AAAA"),
+  ]);
+
+  const v4Ips = v4Result.status === "fulfilled"
+    ? (v4Result.value as unknown as string[])
+    : [];
+  const v6Ips = v6Result.status === "fulfilled"
+    ? (v6Result.value as unknown as string[])
+    : [];
+
+  const addresses = [...v4Ips.map(String), ...v6Ips.map(String)];
+
+  if (addresses.length === 0) {
+    const firstErr = v4Result.status === "rejected"
+      ? v4Result.reason
+      : v6Result.status === "rejected"
+      ? v6Result.reason
+      : null;
+    const detail = firstErr instanceof Error
+      ? firstErr.message
+      : String(firstErr);
     return {
       ok: false,
-      error: `DNS resolution failed for ${hostname}: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
+      error: `DNS resolution failed for ${hostname}: ${detail}`,
     };
   }
 
-  if (!Array.isArray(addresses) || addresses.length === 0) {
-    return { ok: false, error: `No DNS records found for ${hostname}` };
-  }
-
-  return { ok: true, value: addresses.map(String) };
+  return { ok: true, value: addresses };
 }
 
 /**
@@ -146,7 +156,7 @@ async function resolveDnsHostname(
  * on success (for logging). Exported for unit testing without DNS mocking.
  *
  * @param hostname - The original hostname (used in error messages)
- * @param ips - All DNS A records returned for the hostname
+ * @param ips - All DNS A and AAAA records returned for the hostname
  * @returns Ok with the first IP, or Err if any IP is private
  */
 export function checkIpListForSsrf(
@@ -172,7 +182,7 @@ export function checkIpListForSsrf(
 /**
  * Resolve a hostname via DNS and check ALL resolved IPs against the SSRF denylist.
  *
- * Blocks if ANY of the returned A records is a private/reserved IP address.
+ * Blocks if ANY of the returned A or AAAA records is a private/reserved IP address.
  * This prevents DNS rebinding attacks where a domain returns a mix of
  * public and private IPs.
  *

--- a/tests/tools/web/ssrf_test.ts
+++ b/tests/tools/web/ssrf_test.ts
@@ -12,6 +12,7 @@ import { assertEquals } from "@std/assert";
 import {
   checkIpListForSsrf,
   isPrivateIp,
+  resolveAndCheck,
 } from "../../../src/tools/web/ssrf.ts";
 import { safeFetch } from "../../../src/tools/web/safe_fetch.ts";
 
@@ -191,4 +192,97 @@ Deno.test("isPrivateIp regression: IPv6 loopback ::1 still blocked", () => {
 Deno.test("isPrivateIp regression: public IPs still allowed", () => {
   assertEquals(isPrivateIp("8.8.8.8"), false);
   assertEquals(isPrivateIp("1.1.1.1"), false);
+});
+
+// ─── resolveAndCheck: IPv6 AAAA record handling ──────────────────────────────
+
+function stubResolveDns(
+  aRecords: string[] | Error,
+  aaaaRecords: string[] | Error,
+): Deno.Disposable {
+  const original = Deno.resolveDns;
+  (Deno as Record<string, unknown>).resolveDns = (
+    _hostname: string,
+    recordType: string,
+  ) => {
+    if (recordType === "A") {
+      return aRecords instanceof Error
+        ? Promise.reject(aRecords)
+        : Promise.resolve(aRecords);
+    }
+    if (recordType === "AAAA") {
+      return aaaaRecords instanceof Error
+        ? Promise.reject(aaaaRecords)
+        : Promise.resolve(aaaaRecords);
+    }
+    return Promise.reject(new Error(`Unexpected record type: ${recordType}`));
+  };
+  return {
+    [Symbol.dispose]() {
+      (Deno as Record<string, unknown>).resolveDns = original;
+    },
+  };
+}
+
+Deno.test("resolveAndCheck: blocks private IPv6 loopback from AAAA record", async () => {
+  using _stub = stubResolveDns(["1.2.3.4"], ["::1"]);
+  const result = await resolveAndCheck("evil.example.com");
+  assertEquals(result.ok, false);
+  if (!result.ok) {
+    assertEquals(result.error.includes("::1"), true);
+  }
+});
+
+Deno.test("resolveAndCheck: blocks private IPv6 unique-local (fd) from AAAA record", async () => {
+  using _stub = stubResolveDns(["1.2.3.4"], ["fd12::1"]);
+  const result = await resolveAndCheck("evil.example.com");
+  assertEquals(result.ok, false);
+  if (!result.ok) {
+    assertEquals(result.error.includes("fd12::1"), true);
+  }
+});
+
+Deno.test("resolveAndCheck: blocks private IPv6 link-local from AAAA record", async () => {
+  using _stub = stubResolveDns(["1.2.3.4"], ["fe80::1"]);
+  const result = await resolveAndCheck("evil.example.com");
+  assertEquals(result.ok, false);
+  if (!result.ok) {
+    assertEquals(result.error.includes("fe80::1"), true);
+  }
+});
+
+Deno.test("resolveAndCheck: allows public IPv6 from AAAA record", async () => {
+  using _stub = stubResolveDns(["93.184.216.34"], ["2607:f8b0:4004:800::200e"]);
+  const result = await resolveAndCheck("example.com");
+  assertEquals(result.ok, true);
+});
+
+Deno.test("resolveAndCheck: works with AAAA-only host (no A records)", async () => {
+  using _stub = stubResolveDns(new Error("no A records"), ["2607:f8b0:4004:800::200e"]);
+  const result = await resolveAndCheck("ipv6only.example.com");
+  assertEquals(result.ok, true);
+});
+
+Deno.test("resolveAndCheck: works with A-only host (no AAAA records)", async () => {
+  using _stub = stubResolveDns(["93.184.216.34"], new Error("no AAAA records"));
+  const result = await resolveAndCheck("ipv4only.example.com");
+  assertEquals(result.ok, true);
+});
+
+Deno.test("resolveAndCheck: fails when both A and AAAA queries fail", async () => {
+  using _stub = stubResolveDns(new Error("NXDOMAIN"), new Error("NXDOMAIN"));
+  const result = await resolveAndCheck("nonexistent.example.com");
+  assertEquals(result.ok, false);
+  if (!result.ok) {
+    assertEquals(result.error.includes("DNS resolution failed"), true);
+  }
+});
+
+Deno.test("resolveAndCheck: blocks AAAA-only host with private IPv6", async () => {
+  using _stub = stubResolveDns(new Error("no A records"), ["::1"]);
+  const result = await resolveAndCheck("sneaky.example.com");
+  assertEquals(result.ok, false);
+  if (!result.ok) {
+    assertEquals(result.error.includes("::1"), true);
+  }
 });


### PR DESCRIPTION
Fixes #228

`resolveDnsHostname` now queries both A (IPv4) and AAAA (IPv6) DNS records using `Promise.allSettled`, then checks all resolved IPs against the SSRF denylist. Previously only A records were queried, allowing a dual-stack host with a private IPv6 address to bypass SSRF protection.

Generated with [Claude Code](https://claude.ai/code)