### PR TITLE
fix: enforce SSRF protection on Vault HTTP client

### DIFF
--- a/src/core/secrets/vault/auth/approle.ts
+++ b/src/core/secrets/vault/auth/approle.ts
@@ -10,6 +10,7 @@
 import type { Result } from "../../../types/classification.ts";
 import type { VaultAuthResponse } from "../vault_types.ts";
 import { createLogger } from "../../../logger/logger.ts";
+import { safeFetch, type SsrfChecker } from "../../../security/safe_fetch.ts";
 
 const log = createLogger("vault:approle");
 
@@ -36,6 +37,7 @@ export function createAppRoleAuth(
   options: AppRoleAuthOptions,
   vaultAddress: string,
   namespace?: string,
+  ssrfChecker?: SsrfChecker,
 ): {
   authenticate: () => Promise<Result<VaultAuthResponse, string>>;
   currentToken: () => string;
@@ -68,41 +70,39 @@ export function createAppRoleAuth(
       : vaultAddress;
     const url = `${base}/v1/auth/${mountPath}/login`;
 
-    try {
-      const response = await fetch(url, {
-        method: "POST",
-        headers: buildHeaders(),
-        body: JSON.stringify({
-          role_id: options.roleId,
-          secret_id: options.secretId,
-        }),
-      });
+    const fetchResult = await safeFetch(url, {
+      method: "POST",
+      headers: buildHeaders(),
+      body: JSON.stringify({
+        role_id: options.roleId,
+        secret_id: options.secretId,
+      }),
+    }, ssrfChecker);
 
-      if (!response.ok) {
-        const body = await response.json().catch(() => ({}));
-        const errors = (body as { errors?: string[] }).errors ?? [];
-        const errorMsg = `AppRole login failed (${response.status}): ${
-          errors.join(", ") || "unknown error"
-        }`;
-        log.warn("AppRole login HTTP error", {
-          operation: "login",
-          status: response.status,
-          errors,
-        });
-        return { ok: false, error: errorMsg };
-      }
-
-      const body = await response.json();
-      const auth = body.auth as VaultAuthResponse;
-      token = auth.client_token;
-      return { ok: true, value: auth };
-    } catch (err: unknown) {
-      log.warn("AppRole login request failed", { operation: "login", err });
-      return {
-        ok: false,
-        error: `AppRole login request failed: ${err instanceof Error ? err.message : String(err)}`,
-      };
+    if (!fetchResult.ok) {
+      log.warn("AppRole login request failed", { operation: "login", err: fetchResult.error });
+      return { ok: false, error: `AppRole login request failed: ${fetchResult.error}` };
     }
+
+    const response = fetchResult.value;
+    if (!response.ok) {
+      const body = await response.json().catch(() => ({}));
+      const errors = (body as { errors?: string[] }).errors ?? [];
+      const errorMsg = `AppRole login failed (${response.status}): ${
+        errors.join(", ") || "unknown error"
+      }`;
+      log.warn("AppRole login HTTP error", {
+        operation: "login",
+        status: response.status,
+        errors,
+      });
+      return { ok: false, error: errorMsg };
+    }
+
+    const body = await response.json();
+    const auth = body.auth as VaultAuthResponse;
+    token = auth.client_token;
+    return { ok: true, value: auth };
   }
 
   async function renewToken(): Promise<Result<VaultAuthResponse, string>> {
@@ -111,35 +111,33 @@ export function createAppRoleAuth(
       : vaultAddress;
     const url = `${base}/v1/auth/token/renew-self`;
 
-    try {
-      const response = await fetch(url, {
-        method: "POST",
-        headers: buildHeaders(),
-        body: JSON.stringify({}),
+    const fetchResult = await safeFetch(url, {
+      method: "POST",
+      headers: buildHeaders(),
+      body: JSON.stringify({}),
+    }, ssrfChecker);
+
+    if (!fetchResult.ok) {
+      log.warn("Token renewal request failed", { operation: "renewToken", err: fetchResult.error });
+      return { ok: false, error: `Token renewal request failed: ${fetchResult.error}` };
+    }
+
+    const response = fetchResult.value;
+    if (!response.ok) {
+      log.warn("Token renewal HTTP error", {
+        operation: "renewToken",
+        status: response.status,
       });
-
-      if (!response.ok) {
-        log.warn("Token renewal HTTP error", {
-          operation: "renewToken",
-          status: response.status,
-        });
-        return {
-          ok: false,
-          error: `Token renewal failed with status ${response.status}`,
-        };
-      }
-
-      const body = await response.json();
-      const auth = body.auth as VaultAuthResponse;
-      token = auth.client_token;
-      return { ok: true, value: auth };
-    } catch (err: unknown) {
-      log.warn("Token renewal request failed", { operation: "renewToken", err });
       return {
         ok: false,
-        error: `Token renewal request failed: ${err instanceof Error ? err.message : String(err)}`,
+        error: `Token renewal failed with status ${response.status}`,
       };
     }
+
+    const body = await response.json();
+    const auth = body.auth as VaultAuthResponse;
+    token = auth.client_token;
+    return { ok: true, value: auth };
   }
 
   function scheduleRenewal(

--- a/src/core/secrets/vault/auth/kubernetes.ts
+++ b/src/core/secrets/vault/auth/kubernetes.ts
@@ -10,6 +10,7 @@
 import type { Result } from "../../../types/classification.ts";
 import type { VaultAuthResponse } from "../vault_types.ts";
 import { createLogger } from "../../../logger/logger.ts";
+import { safeFetch, type SsrfChecker } from "../../../security/safe_fetch.ts";
 
 const log = createLogger("vault:kubernetes");
 
@@ -37,6 +38,7 @@ export function createKubernetesAuth(
   options: KubernetesAuthOptions,
   vaultAddress: string,
   namespace?: string,
+  ssrfChecker?: SsrfChecker,
 ): {
   authenticate: () => Promise<Result<VaultAuthResponse, string>>;
   currentToken: () => string;
@@ -74,43 +76,41 @@ export function createKubernetesAuth(
       headers["X-Vault-Namespace"] = namespace;
     }
 
-    try {
-      const response = await fetch(url, {
-        method: "POST",
-        headers,
-        body: JSON.stringify({
-          role: options.role,
-          jwt: jwtResult.value,
-        }),
+    const fetchResult = await safeFetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        role: options.role,
+        jwt: jwtResult.value,
+      }),
+    }, ssrfChecker);
+
+    if (!fetchResult.ok) {
+      log.warn("Kubernetes auth login request failed", { operation: "authenticate", err: fetchResult.error });
+      return { ok: false, error: `Kubernetes auth login request failed: ${fetchResult.error}` };
+    }
+
+    const response = fetchResult.value;
+    if (!response.ok) {
+      const body = await response.json().catch(() => ({}));
+      const errors = (body as { errors?: string[] }).errors ?? [];
+      log.warn("Kubernetes auth login HTTP error", {
+        operation: "authenticate",
+        status: response.status,
+        errors,
       });
-
-      if (!response.ok) {
-        const body = await response.json().catch(() => ({}));
-        const errors = (body as { errors?: string[] }).errors ?? [];
-        log.warn("Kubernetes auth login HTTP error", {
-          operation: "authenticate",
-          status: response.status,
-          errors,
-        });
-        return {
-          ok: false,
-          error: `Kubernetes auth login failed (${response.status}): ${
-            errors.join(", ") || "unknown error"
-          }`,
-        };
-      }
-
-      const body = await response.json();
-      const auth = body.auth as VaultAuthResponse;
-      token = auth.client_token;
-      return { ok: true, value: auth };
-    } catch (err: unknown) {
-      log.warn("Kubernetes auth login request failed", { operation: "authenticate", err });
       return {
         ok: false,
-        error: `Kubernetes auth login request failed: ${err instanceof Error ? err.message : String(err)}`,
+        error: `Kubernetes auth login failed (${response.status}): ${
+          errors.join(", ") || "unknown error"
+        }`,
       };
     }
+
+    const body = await response.json();
+    const auth = body.auth as VaultAuthResponse;
+    token = auth.client_token;
+    return { ok: true, value: auth };
   }
 
   return {

--- a/src/core/secrets/vault/auth/mod.ts
+++ b/src/core/secrets/vault/auth/mod.ts
@@ -8,6 +8,7 @@
  */
 
 import type { Result } from "../../../types/classification.ts";
+import type { SsrfChecker } from "../../../security/safe_fetch.ts";
 import type { VaultAuthMethod, VaultAuthResponse } from "../vault_types.ts";
 import { createAppRoleAuth } from "./approle.ts";
 import { createKubernetesAuth } from "./kubernetes.ts";
@@ -39,6 +40,7 @@ export function createVaultAuth(
   authConfig: VaultAuthMethod,
   vaultAddress: string,
   namespace?: string,
+  ssrfChecker?: SsrfChecker,
 ): VaultAuth {
   switch (authConfig.method) {
     case "token":
@@ -53,6 +55,7 @@ export function createVaultAuth(
         },
         vaultAddress,
         namespace,
+        ssrfChecker,
       );
       return {
         authenticate: auth.authenticate,
@@ -71,6 +74,7 @@ export function createVaultAuth(
         },
         vaultAddress,
         namespace,
+        ssrfChecker,
       );
       return {
         authenticate: auth.authenticate,

--- a/src/core/secrets/vault/vault_client.ts
+++ b/src/core/secrets/vault/vault_client.ts
@@ -2,13 +2,14 @@
  * Minimal HTTP client for HashiCorp Vault REST API.
  *
  * Targets KV v2 secret engine. No external SDK dependency —
- * uses Deno's built-in `fetch()` for all HTTP communication.
+ * uses `safeFetch()` with SSRF prevention for all HTTP communication.
  *
  * @module
  */
 
 import type { Result } from "../../types/classification.ts";
 import { createLogger } from "../../logger/logger.ts";
+import { safeFetch } from "../../security/safe_fetch.ts";
 import type {
   KvReadResponse,
   KvWriteResponse,
@@ -93,7 +94,7 @@ export function createVaultClient(
   options: VaultClientOptions,
   getToken: TokenAccessor,
 ): VaultClient {
-  const { address, namespace, requestTimeoutMs } = options;
+  const { address, namespace, requestTimeoutMs, ssrfChecker } = options;
 
   async function vaultFetch(
     apiPath: string,
@@ -107,15 +108,25 @@ export function createVaultClient(
     );
 
     try {
-      const response = await fetch(url, {
-        ...fetchOptions,
-        headers: {
-          ...buildHeaders(getToken(), namespace),
-          ...fetchOptions.headers,
+      const result = await safeFetch(
+        url,
+        {
+          ...fetchOptions,
+          headers: {
+            ...buildHeaders(getToken(), namespace),
+            ...fetchOptions.headers,
+          },
+          signal: controller.signal,
         },
-        signal: controller.signal,
-      });
-      return { ok: true, value: response };
+        ssrfChecker,
+      );
+      if (!result.ok) {
+        return {
+          ok: false,
+          error: `Vault request to ${apiPath} failed: ${result.error}`,
+        };
+      }
+      return { ok: true, value: result.value };
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
       return {
@@ -219,11 +230,15 @@ export function createVaultClient(
     );
 
     try {
-      const response = await fetch(url, {
-        method: "GET",
-        signal: controller.signal,
-      });
-      const body = await response.json();
+      const result = await safeFetch(
+        url,
+        { method: "GET", signal: controller.signal },
+        ssrfChecker,
+      );
+      if (!result.ok) {
+        return { ok: false, error: `Vault health check failed: ${result.error}` };
+      }
+      const body = await result.value.json();
       return { ok: true, value: body as VaultHealth };
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);

--- a/src/core/secrets/vault/vault_types.ts
+++ b/src/core/secrets/vault/vault_types.ts
@@ -7,6 +7,8 @@
  * @module
  */
 
+import type { SsrfChecker } from "../../security/safe_fetch.ts";
+
 /** Vault KV v2 read response data. */
 export interface KvReadResponse {
   readonly data: Readonly<Record<string, string>>;
@@ -74,6 +76,8 @@ export interface VaultClientOptions {
   readonly namespace?: string;
   /** Request timeout in milliseconds. Default: 10_000. */
   readonly requestTimeoutMs: number;
+  /** Override SSRF checker for testing. Default: resolveAndCheck. */
+  readonly ssrfChecker?: SsrfChecker;
 }
 
 /** Union type for authentication methods. */

--- a/tests/core/secrets/vault/auth/approle_test.ts
+++ b/tests/core/secrets/vault/auth/approle_test.ts
@@ -1,0 +1,87 @@
+/**
+ * AppRole authentication SSRF protection tests.
+ *
+ * @module
+ */
+
+import { assertEquals } from "@std/assert";
+import { createAppRoleAuth } from "../../../../../src/core/secrets/vault/auth/approle.ts";
+import type { SsrfChecker } from "../../../../../src/core/security/safe_fetch.ts";
+
+const allowAllSsrf: SsrfChecker = (hostname: string) =>
+  Promise.resolve({ ok: true, value: hostname });
+
+const blockAllSsrf: SsrfChecker = (hostname: string) =>
+  Promise.resolve({
+    ok: false,
+    error: `SSRF blocked: ${hostname} resolves to private IP`,
+  });
+
+function withMockFetch(
+  handler: (url: string, init?: RequestInit) => Response,
+  fn: () => Promise<void>,
+): Promise<void> {
+  const original = globalThis.fetch;
+  globalThis.fetch = (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string"
+      ? input
+      : input instanceof URL
+      ? input.toString()
+      : input.url;
+    return Promise.resolve(handler(url, init));
+  };
+  return fn().finally(() => {
+    globalThis.fetch = original;
+  });
+}
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+Deno.test("AppRoleAuth: SSRF blocks login to private IP", async () => {
+  const auth = createAppRoleAuth(
+    { roleId: "role-1", secretId: "secret-1" },
+    "http://10.0.0.1:8200",
+    undefined,
+    blockAllSsrf,
+  );
+
+  const result = await auth.authenticate();
+  assertEquals(result.ok, false);
+  if (!result.ok) {
+    assertEquals(result.error.includes("SSRF blocked"), true);
+  }
+});
+
+Deno.test("AppRoleAuth: login succeeds with permissive SSRF checker", () =>
+  withMockFetch(
+    () =>
+      jsonResponse({
+        auth: {
+          client_token: "s.abc123",
+          accessor: "acc-1",
+          policies: ["default"],
+          token_policies: ["default"],
+          lease_duration: 3600,
+          renewable: true,
+        },
+      }),
+    async () => {
+      const auth = createAppRoleAuth(
+        { roleId: "role-1", secretId: "secret-1" },
+        "http://127.0.0.1:8200",
+        undefined,
+        allowAllSsrf,
+      );
+
+      const result = await auth.authenticate();
+      assertEquals(result.ok, true);
+      if (result.ok) {
+        assertEquals(result.value.client_token, "s.abc123");
+      }
+    },
+  ));

--- a/tests/core/secrets/vault/auth/kubernetes_test.ts
+++ b/tests/core/secrets/vault/auth/kubernetes_test.ts
@@ -1,0 +1,37 @@
+/**
+ * Kubernetes authentication SSRF protection tests.
+ *
+ * @module
+ */
+
+import { assertEquals } from "@std/assert";
+import { createKubernetesAuth } from "../../../../../src/core/secrets/vault/auth/kubernetes.ts";
+import type { SsrfChecker } from "../../../../../src/core/security/safe_fetch.ts";
+
+const blockAllSsrf: SsrfChecker = (hostname: string) =>
+  Promise.resolve({
+    ok: false,
+    error: `SSRF blocked: ${hostname} resolves to private IP`,
+  });
+
+Deno.test("KubernetesAuth: SSRF blocks authenticate to private IP", async () => {
+  const tmpFile = await Deno.makeTempFile();
+  await Deno.writeTextFile(tmpFile, "mock-jwt-token");
+
+  try {
+    const auth = createKubernetesAuth(
+      { role: "my-role", jwtPath: tmpFile },
+      "http://10.0.0.1:8200",
+      undefined,
+      blockAllSsrf,
+    );
+
+    const result = await auth.authenticate();
+    assertEquals(result.ok, false);
+    if (!result.ok) {
+      assertEquals(result.error.includes("SSRF blocked"), true);
+    }
+  } finally {
+    await Deno.remove(tmpFile);
+  }
+});

--- a/tests/core/secrets/vault/vault_client_test.ts
+++ b/tests/core/secrets/vault/vault_client_test.ts
@@ -6,6 +6,18 @@
 
 import { assertEquals } from "@std/assert";
 import { createVaultClient } from "../../../../src/core/secrets/vault/vault_client.ts";
+import type { SsrfChecker } from "../../../../src/core/security/safe_fetch.ts";
+
+/** Permissive SSRF checker that allows all hostnames (for tests using 127.0.0.1). */
+const allowAllSsrf: SsrfChecker = (hostname: string) =>
+  Promise.resolve({ ok: true, value: hostname });
+
+/** SSRF checker that blocks all hostnames. */
+const blockAllSsrf: SsrfChecker = (hostname: string) =>
+  Promise.resolve({
+    ok: false,
+    error: `SSRF blocked: ${hostname} resolves to private IP`,
+  });
 
 function withMockFetch(
   handler: (url: string, init?: RequestInit) => Response,
@@ -48,7 +60,7 @@ Deno.test("VaultClient: kvRead returns secret data", () =>
       }),
     async () => {
       const client = createVaultClient(
-        { address: "http://127.0.0.1:8200", requestTimeoutMs: 5000 },
+        { address: "http://127.0.0.1:8200", requestTimeoutMs: 5000, ssrfChecker: allowAllSsrf },
         () => "test-token",
       );
 
@@ -66,7 +78,7 @@ Deno.test("VaultClient: kvRead returns error for 404", () =>
     () => jsonResponse({ errors: ["no secret found"] }, 404),
     async () => {
       const client = createVaultClient(
-        { address: "http://127.0.0.1:8200", requestTimeoutMs: 5000 },
+        { address: "http://127.0.0.1:8200", requestTimeoutMs: 5000, ssrfChecker: allowAllSsrf },
         () => "test-token",
       );
 
@@ -83,7 +95,7 @@ Deno.test("VaultClient: kvPut writes secret data", () =>
       }),
     async () => {
       const client = createVaultClient(
-        { address: "http://127.0.0.1:8200", requestTimeoutMs: 5000 },
+        { address: "http://127.0.0.1:8200", requestTimeoutMs: 5000, ssrfChecker: allowAllSsrf },
         () => "test-token",
       );
 
@@ -100,7 +112,7 @@ Deno.test("VaultClient: kvDelete deletes a secret", () =>
     () => new Response(null, { status: 204 }),
     async () => {
       const client = createVaultClient(
-        { address: "http://127.0.0.1:8200", requestTimeoutMs: 5000 },
+        { address: "http://127.0.0.1:8200", requestTimeoutMs: 5000, ssrfChecker: allowAllSsrf },
         () => "test-token",
       );
 
@@ -114,7 +126,7 @@ Deno.test("VaultClient: kvList returns secret keys", () =>
     () => jsonResponse({ data: { keys: ["secret-a", "secret-b"] } }),
     async () => {
       const client = createVaultClient(
-        { address: "http://127.0.0.1:8200", requestTimeoutMs: 5000 },
+        { address: "http://127.0.0.1:8200", requestTimeoutMs: 5000, ssrfChecker: allowAllSsrf },
         () => "test-token",
       );
 
@@ -131,7 +143,7 @@ Deno.test("VaultClient: kvList returns empty array for 404", () =>
     () => jsonResponse({ errors: [] }, 404),
     async () => {
       const client = createVaultClient(
-        { address: "http://127.0.0.1:8200", requestTimeoutMs: 5000 },
+        { address: "http://127.0.0.1:8200", requestTimeoutMs: 5000, ssrfChecker: allowAllSsrf },
         () => "test-token",
       );
 
@@ -153,7 +165,7 @@ Deno.test("VaultClient: healthCheck returns server status", () =>
       }),
     async () => {
       const client = createVaultClient(
-        { address: "http://127.0.0.1:8200", requestTimeoutMs: 5000 },
+        { address: "http://127.0.0.1:8200", requestTimeoutMs: 5000, ssrfChecker: allowAllSsrf },
         () => "test-token",
       );
 
@@ -189,7 +201,7 @@ Deno.test("VaultClient: tokenLookupSelf returns token info", () =>
       }),
     async () => {
       const client = createVaultClient(
-        { address: "http://127.0.0.1:8200", requestTimeoutMs: 5000 },
+        { address: "http://127.0.0.1:8200", requestTimeoutMs: 5000, ssrfChecker: allowAllSsrf },
         () => "test-token",
       );
 
@@ -215,6 +227,7 @@ Deno.test("VaultClient: sends namespace header when configured", () =>
           address: "http://127.0.0.1:8200",
           namespace: "my-ns",
           requestTimeoutMs: 5000,
+          ssrfChecker: allowAllSsrf,
         },
         () => "test-token",
       );
@@ -228,7 +241,7 @@ Deno.test("VaultClient: handles Vault error responses", () =>
     () => jsonResponse({ errors: ["permission denied"] }, 403),
     async () => {
       const client = createVaultClient(
-        { address: "http://127.0.0.1:8200", requestTimeoutMs: 5000 },
+        { address: "http://127.0.0.1:8200", requestTimeoutMs: 5000, ssrfChecker: allowAllSsrf },
         () => "bad-token",
       );
 
@@ -239,3 +252,52 @@ Deno.test("VaultClient: handles Vault error responses", () =>
       }
     },
   ));
+
+// --- SSRF protection tests ---
+
+Deno.test("VaultClient: SSRF blocks vaultFetch to private IP", async () => {
+  const client = createVaultClient(
+    { address: "http://10.0.0.1:8200", requestTimeoutMs: 5000, ssrfChecker: blockAllSsrf },
+    () => "test-token",
+  );
+
+  const result = await client.kvRead("secret", "myapp");
+  assertEquals(result.ok, false);
+  if (!result.ok) {
+    assertEquals(result.error.includes("SSRF blocked"), true);
+  }
+});
+
+Deno.test("VaultClient: SSRF blocks healthCheck to private IP", async () => {
+  const client = createVaultClient(
+    { address: "http://192.168.1.1:8200", requestTimeoutMs: 5000, ssrfChecker: blockAllSsrf },
+    () => "test-token",
+  );
+
+  const result = await client.healthCheck();
+  assertEquals(result.ok, false);
+  if (!result.ok) {
+    assertEquals(result.error.includes("SSRF blocked"), true);
+  }
+});
+
+Deno.test("VaultClient: SSRF checker is invoked with correct hostname", async () => {
+  const checkedHostnames: string[] = [];
+  const trackingSsrf: SsrfChecker = (hostname: string) => {
+    checkedHostnames.push(hostname);
+    return Promise.resolve({ ok: true, value: hostname });
+  };
+
+  await withMockFetch(
+    () => jsonResponse({ data: { data: {}, metadata: { version: 1, created_time: "", deletion_time: "", destroyed: false } } }),
+    async () => {
+      const client = createVaultClient(
+        { address: "http://vault.example.com:8200", requestTimeoutMs: 5000, ssrfChecker: trackingSsrf },
+        () => "test-token",
+      );
+
+      await client.kvRead("secret", "test");
+      assertEquals(checkedHostnames, ["vault.example.com"]);
+    },
+  );
+});


### PR DESCRIPTION
Closes #231

Replaces all 5 raw `fetch()` calls in the Vault client and auth modules with `safeFetch()` from `core/security/safe_fetch.ts`, enforcing DNS resolution + IP denylist checks before any outbound HTTP to user-configured Vault addresses.

Generated with [Claude Code](https://claude.ai/code)