### PR TITLE
fix: graceful shutdown of callback server so browser receives success page

### DIFF
--- a/src/dive/cloud_server.ts
+++ b/src/dive/cloud_server.ts
@@ -23,8 +23,8 @@ export interface CallbackServer {
   readonly port: number;
   /** Resolves with the license key when callback is received. */
   readonly keyPromise: Promise<string>;
-  /** Close the server. */
-  readonly close: () => void;
+  /** Gracefully shut down the server (waits for in-flight responses). */
+  readonly close: () => Promise<void>;
 }
 
 // ─── Callback Server ──────────────────────────────────────────────────────────
@@ -51,8 +51,11 @@ export function startCallbackServer(
     rejectKey = reject;
   });
 
+  // Do NOT pass `signal` to Deno.serve — aborting the signal forcefully kills
+  // the server before in-flight responses (like the success HTML) are sent to
+  // the browser. Instead, use server.shutdown() for graceful close.
   const server = Deno.serve(
-    { port: 0, hostname: "127.0.0.1", signal, onListen: () => {} },
+    { port: 0, hostname: "127.0.0.1", onListen: () => {} },
     (req) => {
       const url = new URL(req.url);
       if (url.pathname === "/callback") {
@@ -92,7 +95,7 @@ export function startCallbackServer(
     port: addr.port,
     keyPromise,
     close: () => server.shutdown(),
-  };
+  } satisfies CallbackServer;
 }
 
 // ─── Gateway URL Resolution ──────────────────────────────────────────────────

--- a/src/dive/selective/selective_llm.ts
+++ b/src/dive/selective/selective_llm.ts
@@ -366,7 +366,7 @@ async function promptTriggerfishKeyViaCheckout(): Promise<{
     return await promptTriggerfishKeyDirect();
   } finally {
     ac.abort();
-    server.close();
+    await server.close();
   }
 }
 
@@ -415,7 +415,7 @@ async function promptTriggerfishKeyViaMagicLink(): Promise<{
     return await promptTriggerfishKeyDirect();
   } finally {
     ac.abort();
-    server.close();
+    await server.close();
   }
 }
 

--- a/src/dive/wizard/wizard_llm.ts
+++ b/src/dive/wizard/wizard_llm.ts
@@ -220,7 +220,7 @@ async function collectTriggerfishKeyViaCheckout(): Promise<{
     return await collectTriggerfishKeyDirect();
   } finally {
     ac.abort();
-    server.close();
+    await server.close();
   }
 }
 
@@ -269,7 +269,7 @@ async function collectTriggerfishKeyViaMagicLink(): Promise<{
     return await collectTriggerfishKeyDirect();
   } finally {
     ac.abort();
-    server.close();
+    await server.close();
   }
 }
 

--- a/tests/dive/cloud_server_test.ts
+++ b/tests/dive/cloud_server_test.ts
@@ -20,7 +20,7 @@ Deno.test("Cloud: callback server receives key from query param", async () => {
     assertEquals(key, "tf_test_callback_key");
   } finally {
     ac.abort();
-    server.close();
+    await server.close();
   }
 });
 
@@ -34,7 +34,7 @@ Deno.test("Cloud: callback server returns 404 for non-callback paths", async () 
     await resp.text();
   } finally {
     ac.abort();
-    server.close();
+    await server.close();
   }
 });
 
@@ -50,11 +50,11 @@ Deno.test("Cloud: callback server returns 404 when key param is missing", async 
     await resp.text();
   } finally {
     ac.abort();
-    server.close();
+    await server.close();
   }
 });
 
-Deno.test("Cloud: callback server listens on random port", () => {
+Deno.test("Cloud: callback server listens on random port", async () => {
   const ac = new AbortController();
   const server = startCallbackServer(ac.signal);
 
@@ -62,6 +62,6 @@ Deno.test("Cloud: callback server listens on random port", () => {
     assertEquals(server.port > 0, true);
   } finally {
     ac.abort();
-    server.close();
+    await server.close();
   }
 });


### PR DESCRIPTION
## Summary
- Removed the abort signal from `Deno.serve()` in the callback server — aborting forcefully killed the server before the "Triggerfish setup complete!" HTML response could be sent to the browser
- The abort signal now only rejects the `keyPromise` (for cancellation), while server lifecycle uses graceful `shutdown()` that waits for in-flight responses
- Updated all callers (`wizard_llm.ts`, `selective_llm.ts`) to `await server.close()` for proper graceful shutdown

## Test plan
- [x] `deno task lint` — 917 files, zero errors
- [x] `deno task test tests/dive/` — 104 tests pass
- [ ] Manual: run `triggerfish dive`, complete checkout flow, verify browser shows "setup complete" page instead of "Unable to connect"

🤖 Generated with [Claude Code](https://claude.com/claude-code)