### PR TITLE
feat: show site footer on all doc pages

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -89,6 +89,11 @@
   font-size: 28px;
 }
 
+/* Show site footer on all pages, not just home */
+.VPFooter {
+  display: flex !important;
+}
+
 /* Trust center table refinements — keep badge cells compact */
 .vp-doc table td:has(.status-badge) {
   white-space: nowrap;


### PR DESCRIPTION
## Summary
- CSS override to display the VitePress footer on doc pages, not just the home page
- Makes privacy policy, terms, and other footer links accessible from every page

## Test plan
- [ ] Navigate to any doc page and confirm footer is visible at the bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)