### PR TITLE
fix: force text-only fallback and block outbound HTTP write-down

### DIFF
--- a/src/agent/dispatch/mod.ts
+++ b/src/agent/dispatch/mod.ts
@@ -36,10 +36,9 @@ export {
 } from "./access_control.ts";
 
 export type { SecurityContext } from "./security_context.ts";
-export {
-  assembleSecurityContext,
-  renderPolicyBlockExplanation,
-} from "./security_context.ts";
+export { assembleSecurityContext } from "./security_context.ts";
+
+export { renderPolicyBlockExplanation } from "./policy_block_explanation.ts";
 
 export {
   buildRecoveryNudge,

--- a/src/agent/dispatch/policy_block_explanation.ts
+++ b/src/agent/dispatch/policy_block_explanation.ts
@@ -1,0 +1,76 @@
+/**
+ * User-facing error messages for policy violations.
+ *
+ * Renders detailed explanations for blocked tool calls so the agent
+ * can inform the user why a specific action was denied and what they
+ * can do to resolve it.
+ *
+ * @module
+ */
+
+import type { ClassificationLevel } from "../../core/types/classification.ts";
+import type { SecurityContext } from "./security_context.ts";
+
+/** Render tool-floor enforcement error. */
+function renderToolFloorError(
+  ctx: SecurityContext,
+  sessionTaint: ClassificationLevel,
+): string {
+  return `Error: "${ctx.toolName}" requires a minimum session taint of ${ctx.toolFloor}. ` +
+    `Your current session taint is ${sessionTaint}. ` +
+    `Access higher-classified data first to escalate your session taint, ` +
+    `or use a tool that doesn't require ${ctx.toolFloor} clearance.`;
+}
+
+/** Render resource write-down error. */
+function renderWriteDownError(
+  ctx: SecurityContext,
+  sessionTaint: ClassificationLevel,
+): string {
+  if (ctx.isOutboundRequest && ctx.operationType === "read") {
+    return `Error: Outbound request blocked — your session taint is ${sessionTaint}, ` +
+      `but the target domain${
+        ctx.resourceParam ? ` "${ctx.resourceParam}"` : ""
+      } is classified ${ctx.resourceClassification}. ` +
+      `Outbound HTTP requests from a ${sessionTaint}-tainted session to ${ctx.resourceClassification}-level domains ` +
+      `risk exfiltrating classified data via the request itself. ` +
+      `Use /clear to reset your session context and taint before fetching from ${ctx.resourceClassification}-classified domains.`;
+  }
+  return `Error: Write-down blocked — your session taint is ${sessionTaint}, ` +
+    `but the target resource${
+      ctx.resourceParam ? ` "${ctx.resourceParam}"` : ""
+    } is classified ${ctx.resourceClassification}. ` +
+    `A ${sessionTaint}-tainted session cannot write to ${ctx.resourceClassification}-level destinations. ` +
+    `Use /clear to reset your session context and taint before writing to ${ctx.resourceClassification}-classified resources.`;
+}
+
+/** Render resource read-ceiling error. */
+function renderReadCeilingError(ctx: SecurityContext): string {
+  return `Error: Access denied — the resource${
+    ctx.resourceParam ? ` "${ctx.resourceParam}"` : ""
+  } is classified ${ctx.resourceClassification}, ` +
+    `which exceeds your session ceiling of ${ctx.nonOwnerCeiling}. ` +
+    `You do not have permission to access ${ctx.resourceClassification}-classified resources.`;
+}
+
+/** Build a detailed error message for a blocked tool call. */
+export function renderPolicyBlockExplanation(
+  ruleId: string | null,
+  ctx: SecurityContext,
+  sessionTaint: ClassificationLevel,
+): string {
+  switch (ruleId) {
+    case "tool-floor-enforcement":
+      return renderToolFloorError(ctx, sessionTaint);
+    case "resource-write-down":
+      return renderWriteDownError(ctx, sessionTaint);
+    case "resource-read-ceiling":
+      return renderReadCeilingError(ctx);
+    case "no-write-down":
+      return `Error: Write-down blocked — your session taint is ${sessionTaint}, ` +
+        `which exceeds the target classification. ` +
+        `Use /clear to reset your session context and taint before outputting to lower-classified channels.`;
+    default:
+      return `Tool call blocked by policy: ${ruleId ?? "denied"}`;
+  }
+}

--- a/src/agent/dispatch/security_context.ts
+++ b/src/agent/dispatch/security_context.ts
@@ -54,6 +54,8 @@ export interface SecurityContext {
   readonly isTrigger: boolean;
   readonly nonOwnerCeiling: ClassificationLevel | null;
   readonly resourceParam: string | null;
+  /** True for URL-based tools that make outbound network requests. */
+  readonly isOutboundRequest: boolean;
 }
 
 /** Resource classification result shape. */
@@ -124,16 +126,19 @@ function classifyFilesystemResource(
 function classifyUrlResource(
   call: ParsedToolCall,
   config: SecurityContextConfig,
-): ResourceClassResult {
+): ResourceClassResult & { isOutbound: boolean } {
   const urlParam = (call.args.url) as string | undefined ?? null;
-  if (!config.domainClassifier || !urlParam) return NO_RESOURCE_CLASSIFICATION;
-  return classifyResourceByToolSets(
+  if (!config.domainClassifier || !urlParam) {
+    return { ...NO_RESOURCE_CLASSIFICATION, isOutbound: false };
+  }
+  const result = classifyResourceByToolSets(
     call.name,
     urlParam,
     config.domainClassifier,
     URL_READ_TOOLS,
     URL_WRITE_TOOLS,
   );
+  return { ...result, isOutbound: result.classification !== null };
 }
 
 // ─── Identity context ────────────────────────────────────────────────────────
@@ -177,22 +182,31 @@ function classifyShellCommandResource(
   };
 }
 
+/** Extended resource classification result including outbound request flag. */
+type ExtendedResourceClassResult = ResourceClassResult & {
+  isOutbound: boolean;
+};
+
 /** Resolve resource classification from filesystem, shell command, or URL tools. */
 function resolveResourceClassification(
   call: ParsedToolCall,
   config: SecurityContextConfig,
-): ResourceClassResult {
+): ExtendedResourceClassResult {
   const fsResult = classifyFilesystemResource(call, config);
-  if (fsResult.classification !== null) return fsResult;
+  if (fsResult.classification !== null) {
+    return { ...fsResult, isOutbound: false };
+  }
   const shellResult = classifyShellCommandResource(call, config);
-  if (shellResult.classification !== null) return shellResult;
+  if (shellResult.classification !== null) {
+    return { ...shellResult, isOutbound: false };
+  }
   return classifyUrlResource(call, config);
 }
 
 /** Populate hook input with resource and identity fields. */
 function populateHookInputFields(
   hookInput: Record<string, unknown>,
-  resource: ResourceClassResult,
+  resource: ExtendedResourceClassResult,
   identity: {
     isOwner: boolean;
     isTrigger: boolean;
@@ -202,6 +216,9 @@ function populateHookInputFields(
   if (resource.classification !== null) {
     hookInput.resource_classification = resource.classification;
     hookInput.operation_type = resource.operation;
+  }
+  if (resource.isOutbound) {
+    hookInput.is_outbound_request = true;
   }
   hookInput.is_owner = identity.isOwner;
   hookInput.is_trigger = identity.isTrigger;
@@ -232,64 +249,9 @@ export function assembleSecurityContext(
       resourceClassification: resource.classification,
       operationType: resource.operation,
       resourceParam: resource.param,
+      isOutboundRequest: resource.isOutbound,
       ...identity,
     },
   };
 }
 
-// ─── Policy block explanation ────────────────────────────────────────────────
-
-/** Render tool-floor enforcement error. */
-function renderToolFloorError(
-  ctx: SecurityContext,
-  sessionTaint: ClassificationLevel,
-): string {
-  return `Error: "${ctx.toolName}" requires a minimum session taint of ${ctx.toolFloor}. ` +
-    `Your current session taint is ${sessionTaint}. ` +
-    `Access higher-classified data first to escalate your session taint, ` +
-    `or use a tool that doesn't require ${ctx.toolFloor} clearance.`;
-}
-
-/** Render resource write-down error. */
-function renderWriteDownError(
-  ctx: SecurityContext,
-  sessionTaint: ClassificationLevel,
-): string {
-  return `Error: Write-down blocked — your session taint is ${sessionTaint}, ` +
-    `but the target resource${
-      ctx.resourceParam ? ` "${ctx.resourceParam}"` : ""
-    } is classified ${ctx.resourceClassification}. ` +
-    `A ${sessionTaint}-tainted session cannot write to ${ctx.resourceClassification}-level destinations. ` +
-    `Use /clear to reset your session context and taint before writing to ${ctx.resourceClassification}-classified resources.`;
-}
-
-/** Render resource read-ceiling error. */
-function renderReadCeilingError(ctx: SecurityContext): string {
-  return `Error: Access denied — the resource${
-    ctx.resourceParam ? ` "${ctx.resourceParam}"` : ""
-  } is classified ${ctx.resourceClassification}, ` +
-    `which exceeds your session ceiling of ${ctx.nonOwnerCeiling}. ` +
-    `You do not have permission to access ${ctx.resourceClassification}-classified resources.`;
-}
-
-/** Build a detailed error message for a blocked tool call. */
-export function renderPolicyBlockExplanation(
-  ruleId: string | null,
-  ctx: SecurityContext,
-  sessionTaint: ClassificationLevel,
-): string {
-  switch (ruleId) {
-    case "tool-floor-enforcement":
-      return renderToolFloorError(ctx, sessionTaint);
-    case "resource-write-down":
-      return renderWriteDownError(ctx, sessionTaint);
-    case "resource-read-ceiling":
-      return renderReadCeilingError(ctx);
-    case "no-write-down":
-      return `Error: Write-down blocked — your session taint is ${sessionTaint}, ` +
-        `which exceeds the target classification. ` +
-        `Use /clear to reset your session context and taint before outputting to lower-classified channels.`;
-    default:
-      return `Tool call blocked by policy: ${ruleId ?? "denied"}`;
-  }
-}

--- a/src/agent/dispatch/security_pipeline.ts
+++ b/src/agent/dispatch/security_pipeline.ts
@@ -18,10 +18,8 @@ import type {
   ParsedToolCall,
   ToolExecutor,
 } from "../orchestrator/orchestrator_types.ts";
-import {
-  assembleSecurityContext,
-  renderPolicyBlockExplanation,
-} from "./security_context.ts";
+import { assembleSecurityContext } from "./security_context.ts";
+import { renderPolicyBlockExplanation } from "./policy_block_explanation.ts";
 import type { SecurityContext } from "./security_context.ts";
 import { escalateToolPrefixTaint } from "./access_control.ts";
 import { createLogger } from "../../core/logger/mod.ts";

--- a/src/agent/loop/agent_loop.ts
+++ b/src/agent/loop/agent_loop.ts
@@ -55,7 +55,9 @@ async function executeIteration(
   ctx: AgentLoopContext,
   iteration: number,
 ): Promise<
-  { done: true; result: Result<ProcessMessageResult, string> } | { done: false }
+  | { done: true; result: Result<ProcessMessageResult, string> }
+  | { done: false }
+  | { done: true; forceTextOnly: true }
 > {
   const llmResult = await callLlmAndRecordUsage(ctx, iteration);
   if (!llmResult.ok) return { done: true, result: llmResult.result };
@@ -65,6 +67,9 @@ async function executeIteration(
     iteration,
   });
   if (outcome.action === "continue") return { done: false };
+  if (outcome.action === "force_text_only") {
+    return { done: true, forceTextOnly: true };
+  }
   return { done: true, result: outcome.result };
 }
 
@@ -130,7 +135,16 @@ export async function runAgentLoop(
       return { ok: false, error: "Operation cancelled by user" };
     }
     const step = await executeIteration(ctx, i);
-    if (step.done) return step.result;
+    if (!step.done) continue;
+    if ("forceTextOnly" in step) {
+      log.info("Nudges exhausted after tool calls — forcing text-only response", {
+        operation: "runAgentLoop",
+        iteration: i,
+        toolCallsMade: ctx.toolCallHistory.calls.size,
+      });
+      return forceTextOnlyResponse(ctx);
+    }
+    return step.result;
   }
   return forceTextOnlyResponse(ctx);
 }

--- a/src/agent/loop/loop_iteration.ts
+++ b/src/agent/loop/loop_iteration.ts
@@ -21,7 +21,6 @@ import {
   type ResponseQuality,
 } from "../dispatch/response_handling.ts";
 import type {
-  HistoryEntry,
   ParsedToolCall,
   ToolDefinition,
 } from "../orchestrator/orchestrator_types.ts";
@@ -32,6 +31,7 @@ import type {
   IterationOutcome,
 } from "./loop_types.ts";
 import {
+  injectSoftLimitWarning,
   recordToolCallsAndDetectLoop,
   traceLog,
 } from "./loop_types.ts";
@@ -50,30 +50,6 @@ interface IterationData {
   };
   readonly tools: readonly ToolDefinition[];
   readonly iteration: number;
-}
-
-// ─── Soft-limit helpers ──────────────────────────────────────────────────────
-
-/** Compute the soft limit iteration from max iterations (80% of max). */
-function computeSoftLimit(maxIter: number): number {
-  return Math.floor(maxIter * 0.8);
-}
-
-/** Inject soft limit warning into history when approaching max iterations. */
-function injectSoftLimitWarning(
-  history: HistoryEntry[],
-  iterations: number,
-  maxIter: number,
-): void {
-  if (iterations !== computeSoftLimit(maxIter)) return;
-  history.push({
-    role: "user",
-    content:
-      `[SYSTEM] You have used many tool calls (${iterations}/${maxIter}). ` +
-      `You have ${maxIter - iterations} remaining iterations. ` +
-      "Please provide your best answer now based on the information gathered so far. " +
-      "If you cannot find what you're looking for, say so rather than continuing to search.",
-  });
 }
 
 // ─── Tool call parsing ──────────────────────────────────────────────────────
@@ -162,6 +138,12 @@ async function handleNoToolCallsIteration(
   if (needsRecovery && iter.iteration < maxIter) {
     const nudgeResult = attemptRecoveryNudge(ctx, iter.completion, quality);
     if (nudgeResult) return nudgeResult;
+    // Nudges exhausted. If tool calls were made this turn, the model has
+    // gathered information but is stuck in tool-calling mode. Strip tools
+    // and force a text-only summary instead of returning FALLBACK_RESPONSE.
+    if (ctx.toolCallHistory.calls.size > 0) {
+      return { action: "force_text_only" };
+    }
   }
 
   const result = await handleFinalResponse(

--- a/src/agent/loop/loop_types.ts
+++ b/src/agent/loop/loop_types.ts
@@ -173,7 +173,8 @@ export interface AgentLoopContext {
 /** Result of a single agent loop iteration. */
 export type IterationOutcome =
   | { action: "continue" }
-  | { action: "return"; result: Result<ProcessMessageResult, string> };
+  | { action: "return"; result: Result<ProcessMessageResult, string> }
+  | { action: "force_text_only" };
 
 /** Successful LLM iteration result. */
 export interface LlmIterationResult {
@@ -200,3 +201,27 @@ export const CANCELLED_RESULT: LlmCallOutcome = {
   ok: false,
   result: { ok: false, error: "Operation cancelled by user" },
 };
+
+// ─── Soft-limit helpers ──────────────────────────────────────────────────────
+
+/** Compute the soft limit iteration from max iterations (80% of max). */
+export function computeSoftLimit(maxIter: number): number {
+  return Math.floor(maxIter * 0.8);
+}
+
+/** Inject soft limit warning into history when approaching max iterations. */
+export function injectSoftLimitWarning(
+  history: HistoryEntry[],
+  iterations: number,
+  maxIter: number,
+): void {
+  if (iterations !== computeSoftLimit(maxIter)) return;
+  history.push({
+    role: "user",
+    content:
+      `[SYSTEM] You have used many tool calls (${iterations}/${maxIter}). ` +
+      `You have ${maxIter - iterations} remaining iterations. ` +
+      "Please provide your best answer now based on the information gathered so far. " +
+      "If you cannot find what you're looking for, say so rather than continuing to search.",
+  });
+}

--- a/src/agent/loop/mod.ts
+++ b/src/agent/loop/mod.ts
@@ -27,6 +27,8 @@ export type {
 export {
   buildLlmMessages,
   CANCELLED_RESULT,
+  computeSoftLimit,
+  injectSoftLimitWarning,
   logFirstIterationDetails,
   resolveActiveToolList,
   traceLog,

--- a/src/core/policy/hooks/hook_violations.ts
+++ b/src/core/policy/hooks/hook_violations.ts
@@ -35,10 +35,15 @@ export function detectToolFloorViolation(
 }
 
 /**
- * Check if session taint exceeds a resource's classification level on a write.
+ * Check if session taint exceeds a resource's classification level.
  *
- * Only triggers for write operations — reading a lower-classified resource
- * into a higher-tainted session is a safe read-up, not a write-down.
+ * Triggers for:
+ * - Write operations (writing tainted data to a lower-classified resource).
+ * - Outbound network requests (the HTTP request itself carries session
+ *   context — URL, headers, timing — to the remote server, making even
+ *   "read" fetches a data-exfiltration vector from higher-tainted sessions).
+ *
+ * Local filesystem reads are safe read-ups and do not trigger this check.
  */
 export function detectResourceWriteDownViolation(
   input: Record<string, unknown>,
@@ -46,9 +51,10 @@ export function detectResourceWriteDownViolation(
 ): boolean {
   const rc = input.resource_classification as ClassificationLevel | undefined;
   const opType = input.operation_type as string | undefined;
+  const isOutbound = input.is_outbound_request === true;
   return rc !== undefined &&
     rc in CLASSIFICATION_ORDER &&
-    opType === "write" &&
+    (opType === "write" || isOutbound) &&
     !canFlowTo(sessionTaint, rc);
 }
 

--- a/tests/e2e/resource_classification_test.ts
+++ b/tests/e2e/resource_classification_test.ts
@@ -1371,3 +1371,117 @@ Deno.test("integration-write-down: gmail_send from PUBLIC session is NOT blocked
     "gmail_send from PUBLIC session must NOT be blocked",
   );
 });
+
+// --- Test: Outbound HTTP write-down — RESTRICTED session to PUBLIC domain ---
+
+Deno.test("resource-classification: web_fetch to unclassified domain blocked from RESTRICTED session", async () => {
+  const hookRunner = makeHookRunner();
+
+  // Unclassified domains default to PUBLIC
+  const domainClassifier = createMockDomainClassifier({});
+
+  const registry = createProviderRegistry();
+  registry.register(createToolCallingProvider("web_fetch", {
+    url: "https://docs.example.dev/mcp-servers",
+  }));
+  registry.setDefault("mock-tool-caller");
+
+  const sessionTaint: ClassificationLevel = "RESTRICTED";
+  const toolResults: Array<{ name: string; blocked: boolean }> = [];
+
+  const orchestrator = createOrchestrator({
+    hookRunner,
+    providerRegistry: registry,
+    tools: TOOL_DEFS,
+    // deno-lint-ignore require-await
+    toolExecutor: async (_name, _input) => "ok",
+    domainClassifier,
+    getSessionTaint: () => sessionTaint,
+    escalateTaint: () => {},
+    isOwnerSession: () => true,
+    onEvent: (event) => {
+      if (event.type === "tool_result") {
+        toolResults.push({ name: event.name, blocked: event.blocked });
+      }
+    },
+  });
+
+  let session = createSession({
+    userId: "u" as UserId,
+    channelId: "c" as ChannelId,
+  });
+  session = updateTaint(session, "RESTRICTED", "classified access");
+
+  const result = await orchestrator.executeAgentTurn({
+    session,
+    message: "Fetch the docs page",
+    targetClassification: "RESTRICTED",
+  });
+
+  assertEquals(result.ok, true);
+  assertEquals(toolResults.length, 1);
+  assertEquals(
+    toolResults[0].blocked,
+    true,
+    "web_fetch to PUBLIC domain from RESTRICTED session must be blocked (outbound write-down)",
+  );
+});
+
+// --- Test: Hook-level outbound request flag blocks read fetch ---
+
+Deno.test("resource-classification: hook blocks outbound read to lower-classified domain", async () => {
+  const hookRunner = makeHookRunner();
+
+  const session = createSession({
+    userId: "u" as UserId,
+    channelId: "c" as ChannelId,
+  });
+  const updatedSession = updateTaint(session, "RESTRICTED", "setup");
+
+  // Simulate web_fetch (read operation) to a PUBLIC domain with is_outbound_request
+  const result = await hookRunner.evaluateHook("PRE_TOOL_CALL", {
+    session: updatedSession,
+    input: {
+      tool_call: {
+        name: "web_fetch",
+        args: { url: "https://docs.example.dev/page" },
+      },
+      resource_classification: "PUBLIC" as ClassificationLevel,
+      operation_type: "read",
+      is_outbound_request: true,
+      is_owner: true,
+    },
+  });
+
+  assertEquals(result.allowed, false);
+  assertEquals(result.ruleId, "resource-write-down");
+});
+
+// --- Test: Outbound read to same-or-higher classified domain is allowed ---
+
+Deno.test("resource-classification: outbound read to same-classified domain is allowed", async () => {
+  const hookRunner = makeHookRunner();
+
+  const session = createSession({
+    userId: "u" as UserId,
+    channelId: "c" as ChannelId,
+  });
+  const updatedSession = updateTaint(session, "CONFIDENTIAL", "setup");
+
+  // web_fetch to a CONFIDENTIAL domain — same level, should be allowed
+  const result = await hookRunner.evaluateHook("PRE_TOOL_CALL", {
+    session: updatedSession,
+    input: {
+      tool_call: {
+        name: "web_fetch",
+        args: { url: "https://intranet.corp/report" },
+      },
+      resource_classification: "CONFIDENTIAL" as ClassificationLevel,
+      operation_type: "read",
+      is_outbound_request: true,
+      is_owner: true,
+    },
+  });
+
+  assertEquals(result.allowed, true);
+});


### PR DESCRIPTION
## Summary

Two critical reliability and security bugs fixed:

### Bug 1: Agent returns generic "did not produce usable response" after successful tool calls

**Symptoms**: Consistent issue across tested, good models. After multiple successful tool calls (e.g., read_skill, search_files, web_search × 4, read_file, list_directory), the agent returns:

> "The language model did not produce a usable response after multiple attempts. This is typically caused by output token limits or provider issues."

On the **very next user message**, the agent produces a perfect response with the exact same context.

**Root cause**: After successful tool calls, the model returns empty/junk text on the next iteration because it's stuck in tool-calling mode. Two recovery nudges fire (still with tools available), but the model can't break out. After nudges are exhausted, `handleFinalResponse` substitutes `FALLBACK_RESPONSE` — discarding all the work the model did.

**Fix**: When recovery nudges are exhausted AND tool calls were made in this turn (`ctx.toolCallHistory.calls.size > 0`), return a new `force_text_only` action. The main loop handles this by calling `forceTextOnlyResponse()` — which strips all tools from the LLM call and injects a system message forcing the model to summarize its findings. This is the same mechanism already used at the iteration hard limit (25), now also triggered when the model has gathered data but can't switch from tool-calling to text-response mode.

**Key insight**: The model works perfectly on the next turn because the user's new message jolts it out of tool mode. The force-text-only call achieves the same effect programmatically.

### Bug 2: RESTRICTED session can `web_fetch` unclassified (PUBLIC) domains — write-down violation

**Symptoms**: A session with RESTRICTED taint (visible in the UI badge) successfully calls `web_fetch https://docs.triggerfish.dev/mcp-servers`. Since `docs.triggerfish.dev` is not in the domain classification map, it defaults to PUBLIC. A RESTRICTED → PUBLIC data flow is the textbook write-down violation that Triggerfish's #1 selling point is designed to prevent.

**Root cause**: `detectResourceWriteDownViolation()` in `hook_violations.ts` only triggered for `opType === "write"`. The `web_fetch` and `browser_navigate` tools are classified as `"read"` operations (they fetch content). But outbound HTTP requests carry session context — URLs, headers, timing information — to the remote server. The request itself is a data-exfiltration vector from a higher-tainted session to a lower-classified domain.

**Fix**: Added `is_outbound_request` flag for all URL-based tool calls. `detectResourceWriteDownViolation` now triggers on `opType === "write" || isOutbound`, catching both:
- Explicit writes (e.g., `browser_type` posting to a form)
- Outbound network requests (e.g., `web_fetch` from RESTRICTED → PUBLIC)

Local filesystem reads remain unaffected — reading a PUBLIC file into a RESTRICTED session is a safe read-up with no outbound data flow.

**Error message**: Outbound request blocks now show a specific message explaining why the fetch was denied, distinct from the existing write-down message.

## Files changed

| File | Change |
|------|--------|
| `src/agent/loop/loop_types.ts` | Added `force_text_only` to `IterationOutcome` union; moved soft-limit helpers here from `loop_iteration.ts` |
| `src/agent/loop/loop_iteration.ts` | Return `force_text_only` when nudges exhausted after tool calls; removed soft-limit helpers (moved to `loop_types.ts`) |
| `src/agent/loop/agent_loop.ts` | Handle `force_text_only` outcome by calling `forceTextOnlyResponse()` with structured logging |
| `src/agent/loop/mod.ts` | Export new `computeSoftLimit` and `injectSoftLimitWarning` |
| `src/core/policy/hooks/hook_violations.ts` | `detectResourceWriteDownViolation` now also triggers on `is_outbound_request` |
| `src/agent/dispatch/security_context.ts` | Set `is_outbound_request: true` on URL tool hook inputs; added `isOutboundRequest` to `SecurityContext` |
| `src/agent/dispatch/policy_block_explanation.ts` | **New file** — extracted policy block error rendering from `security_context.ts` (file was over 300-line hygiene limit) |
| `src/agent/dispatch/security_pipeline.ts` | Updated import path for `renderPolicyBlockExplanation` |
| `src/agent/dispatch/mod.ts` | Updated barrel exports for new file split |
| `tests/e2e/resource_classification_test.ts` | 3 new tests: RESTRICTED→PUBLIC web_fetch blocked, hook-level outbound read blocked, same-level outbound read allowed |

## Test plan

- [x] `deno task lint` — 0 errors (1134 files)
- [x] `deno task check` — type check passes
- [x] `deno task test tests/agent/` — 395 passed
- [x] `deno task test tests/e2e/` — 47 passed (includes 3 new outbound write-down tests)
- [x] `deno task test tests/core/policy/ tests/core/security/` — 203 passed
- [x] `deno task test tests/tools/web/ tests/tools/browser/` — 140 passed
- [x] All changed files under 300-line hygiene limit
- [x] No new vague export names
- [x] All files have JSDoc `@module` comments
- [x] All exports registered in barrel `mod.ts` files
- [ ] Manual test: RESTRICTED session → `web_fetch` to unclassified domain → should see outbound request blocked error
- [ ] Manual test: send multi-tool-call prompt → agent should produce text summary instead of "did not produce" fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)