### PR TITLE
refactor: hygiene audit #383 — remove dead aliases, fix barrel boundaries

### DIFF
--- a/src/exec/command.ts
+++ b/src/exec/command.ts
@@ -136,6 +136,3 @@ export async function invokeShellCommand(
     };
   }
 }
-
-/** @deprecated Use invokeShellCommand instead */
-export const runShellCommand = invokeShellCommand;

--- a/src/gateway/healing/healing_orchestrator.ts
+++ b/src/gateway/healing/healing_orchestrator.ts
@@ -11,10 +11,10 @@ import type { SelfHealingConfig } from "../../core/types/healing.ts";
 import type { SessionId } from "../../core/types/session.ts";
 import type {
   RichWorkflowEvent,
+  WorkflowRunRegistry,
   WorkflowVersion,
-} from "../../workflow/healing/types.ts";
-import type { WorkflowRunRegistry } from "../../workflow/registry_types.ts";
-import type { WorkflowVersionStore } from "../../workflow/healing/version_store.ts";
+  WorkflowVersionStore,
+} from "../../workflow/mod.ts";
 import { createHealingEventBridge } from "./event_bridge.ts";
 import {
   spawnHealingLead,

--- a/src/scheduler/service_trigger.ts
+++ b/src/scheduler/service_trigger.ts
@@ -221,6 +221,3 @@ export async function invokeTriggerCallback(
     });
   }
 }
-
-/** @deprecated Use invokeTriggerCallback instead */
-export const runTriggerCallback = invokeTriggerCallback;

--- a/src/scheduler/service_webhooks.ts
+++ b/src/scheduler/service_webhooks.ts
@@ -164,9 +164,3 @@ export async function dispatchWebhookSession(
     );
   }
 }
-
-/** @deprecated Use verifyWebhookRequest instead */
-export const validateWebhookRequest = verifyWebhookRequest;
-
-/** @deprecated Use dispatchWebhookSession instead */
-export const executeWebhookSession = dispatchWebhookSession;

--- a/src/tools/workflow_healing/tool_handlers.ts
+++ b/src/tools/workflow_healing/tool_handlers.ts
@@ -4,8 +4,10 @@
  */
 
 import type { ClassificationLevel } from "../../core/types/classification.ts";
-import type { WorkflowVersionStore } from "../../workflow/healing/version_store.ts";
-import type { WorkflowRunRegistry } from "../../workflow/registry_types.ts";
+import type {
+  WorkflowRunRegistry,
+  WorkflowVersionStore,
+} from "../../workflow/mod.ts";
 import { createLogger } from "../../core/logger/logger.ts";
 
 const log = createLogger("workflow-healing-tools");


### PR DESCRIPTION
## Summary

Addresses [#383](https://github.com/greghavens/triggerfish/issues/383) hygiene audit findings with two categories of surgical cleanups:

### Dead alias removal

Removed four `@deprecated` aliases that had zero remaining call sites in the codebase:

- `runShellCommand` → `src/exec/command.ts`
- `runTriggerCallback` → `src/scheduler/service_trigger.ts`
- `validateWebhookRequest` → `src/scheduler/service_webhooks.ts`
- `executeWebhookSession` → `src/scheduler/service_webhooks.ts`

### Cross-module barrel boundary fixes

Two files violated the dependency-layers rule by importing directly from `workflow/` internals instead of through `workflow/mod.ts`:

- `src/gateway/healing/healing_orchestrator.ts` — consolidated 3 direct imports into 1 barrel import
- `src/tools/workflow_healing/tool_handlers.ts` — consolidated 2 direct imports into 1 barrel import

## Scope

This PR deliberately stays narrowly scoped to the two highest-signal categories from the audit. Larger structural findings (oversized files, broader test coverage gaps) are out of scope for this incremental cleanup.

## Test plan

- [x] `deno task check` passes
- [x] `deno task lint` shows no new errors (5 pre-existing unrelated errors remain on master, untouched)
- [ ] CI review checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)